### PR TITLE
fix(release): publish the Gradle plugin alongside the library

### DIFF
--- a/admob-cmp/docs/PUBLISHING.md
+++ b/admob-cmp/docs/PUBLISHING.md
@@ -27,27 +27,30 @@ export ORG_GRADLE_PROJECT_mavenCentralUsername=...   # Central Portal token user
 export ORG_GRADLE_PROJECT_mavenCentralPassword=...   # token password
 export ORG_GRADLE_PROJECT_signingInMemoryKey=...     # ASCII-armored GPG key
 export ORG_GRADLE_PROJECT_signingInMemoryKeyPassword=...
-./scripts/publish-maven-central.sh   # = ./gradlew publishToMavenCentral
+./scripts/publish-maven-central.sh   # library + Gradle plugin
 ```
 
-This uploads the main library modules into a Central Portal staging deployment and
-does **not** auto-release it. Inspect the deployment and signatures in
-Central Portal, then publish it manually.
+The script asserts that the library and plugin `VERSION_NAME`s match, then runs both
+publications. Neither auto-releases. Inspect the deployments and signatures in Central
+Portal, then publish them manually.
 
-### Publishing the Gradle plugin
+### Two deployments, both required
 
-The Gradle plugin is a **separate included build** (`admob-cmp-gradle-plugin`) and is *not*
-covered by the root `publishToMavenCentral`. Both commands are required, and the plugin's
-`VERSION_NAME` in `admob-cmp-gradle-plugin/gradle.properties` must be bumped in lockstep
-with the root `gradle.properties`:
+The Gradle plugin is a **separate included build** (`admob-cmp-gradle-plugin`), so it is
+*not* covered by the root `publishToMavenCentral`. The script runs both:
 
 ```bash
 ./gradlew publishToMavenCentral
-```
-
-```bash
 ./gradlew -p admob-cmp-gradle-plugin publishToMavenCentral
 ```
+
+Because these are two separate Gradle builds, they produce **two staging deployments** in
+Central Portal. Release both. Publishing the library alone ships a release whose README,
+SETUP.md, and cinterop `userSetupHint` all instruct consumers to apply a plugin that does
+not exist on Maven Central.
+
+The plugin's `VERSION_NAME` in `admob-cmp-gradle-plugin/gradle.properties` must be bumped in
+lockstep with the root `gradle.properties`; the script refuses to publish a mismatched pair.
 
 ## API stability workflow
 
@@ -88,4 +91,4 @@ Repeat before each release:
 5. Local publication plus `-PadmobCmpConsumePublished=true` compiles Android and iOS.
 6. `./gradlew publishToMavenCentral --dry-run` and `./gradlew -p admob-cmp-gradle-plugin publishToMavenCentral --dry-run` schedule all modules.
 7. Confirm the `dev.avinya` namespace is verified in Central Portal.
-8. Run both publication commands (`publishToMavenCentral` for library and plugin), inspect the staging deployment, then release manually.
+8. Run `./scripts/publish-maven-central.sh`, inspect **both** staging deployments (library and plugin), then release each manually.

--- a/admob-cmp/scripts/publish-maven-central.sh
+++ b/admob-cmp/scripts/publish-maven-central.sh
@@ -17,7 +17,24 @@ if [ ! -x "$GRADLE_CMD" ]; then
 fi
 
 cd "$REPO_ROOT"
-# Upload every module into one Central Portal staging deployment. Deliberately
-# do not auto-release: inspect the deployment in Central Portal, then publish it
-# manually once all artifacts and signatures are confirmed.
+
+# The plugin is an included build with its own VERSION_NAME. Consumers are told to
+# pair the two by the same version number, so refuse to publish a mismatched pair
+# rather than discover it after the coordinates are immutable.
+LIB_VERSION="$(sed -n 's/^VERSION_NAME=//p' gradle.properties)"
+PLUGIN_VERSION="$(sed -n 's/^VERSION_NAME=//p' admob-cmp-gradle-plugin/gradle.properties)"
+if [ "$LIB_VERSION" != "$PLUGIN_VERSION" ]; then
+  echo "Version mismatch: library is $LIB_VERSION but plugin is $PLUGIN_VERSION." >&2
+  echo "Bump both gradle.properties files in lockstep before publishing." >&2
+  exit 1
+fi
+echo "Publishing admob-cmp $LIB_VERSION (library + Gradle plugin)"
+
+# Deliberately do not auto-release: inspect each deployment in Central Portal, then
+# publish it manually once all artifacts and signatures are confirmed.
+#
+# These are two separate Gradle builds, so they produce TWO staging deployments in
+# Central Portal. Both must be released — a library without its plugin ships docs
+# and a userSetupHint pointing at an artifact that does not exist.
 $GRADLE_CMD publishToMavenCentral
+$GRADLE_CMD -p admob-cmp-gradle-plugin publishToMavenCentral


### PR DESCRIPTION
publish-maven-central.sh ran only the root publishToMavenCentral, which does not reach the admob-cmp-gradle-plugin included build. Since publish.yml calls this script, a release would have shipped admob-cmp:1.1.0 whose README, SETUP.md and cinterop userSetupHint all tell consumers to apply a plugin that was never uploaded to Maven Central.

Also guards against the version drift that made this visible: the script now refuses to publish when the library and plugin VERSION_NAMEs disagree, rather than letting a mismatched pair reach immutable coordinates.

PUBLISHING.md now records that these are two separate Gradle builds and therefore two staging deployments, both of which must be released.