### PR TITLE
fix(ci): decouple the host guard from the Pages project name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,7 +220,11 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy dist --project-name=admob-cmp-docs --branch=master
+          # The Pages project name lives here and nowhere else. The host guard
+          # in docs-site/functions/_middleware.js derives the preview hosts by
+          # label count rather than matching this string, so renaming the
+          # project only requires changing this line.
+          command: pages deploy dist --project-name=admob-compose-multiplatform --branch=master
           workingDirectory: docs-site
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
 

--- a/docs-site/functions/_middleware.js
+++ b/docs-site/functions/_middleware.js
@@ -2,21 +2,40 @@
  * Host guard for the AdMob CMP docs site.
  *
  * Cloudflare Pages answers on three kinds of host:
- *   1. ads.avinya.dev                  — the canonical custom domain. Serve.
- *   2. admob-cmp-docs.pages.dev        — the production preview host. 301 away,
- *                                        so Google never has two crawlable
- *                                        copies of the site to choose between.
- *   3. <hash>.admob-cmp-docs.pages.dev — per-branch previews. Serve them (they
- *                                        exist to be reviewed) but mark them
- *                                        noindex so they cannot be indexed.
+ *   1. ads.avinya.dev                — the canonical custom domain. Serve.
+ *   2. <project>.pages.dev           — the production preview host. 301 away, so
+ *                                      Google never has two crawlable copies of
+ *                                      the site to choose between.
+ *   3. <hash>.<project>.pages.dev    — per-deployment previews. Serve them (they
+ *                                      exist to be reviewed) but mark them
+ *                                      noindex so they cannot be indexed.
  *
  * Spec §5 documents exactly this failure on avinya.dev: every canonical pointed
  * at avinya.pages.dev, which returned HTTP 200, so Google was told to prefer the
  * throwaway host. This file makes that impossible here.
+ *
+ * The Pages project name is deliberately NOT hardcoded. It used to be, and it
+ * had to agree with `--project-name` in .github/workflows/release.yml — two
+ * files, no shared source of truth. When they disagreed the guard did not error;
+ * it silently fell through to case 3 and *served* the production preview host,
+ * which is the duplicate-copy defect this file exists to prevent. Cases 2 and 3
+ * are distinguishable by label count alone, so the name is not needed:
+ *
+ *   <project>.pages.dev          -> 3 labels
+ *   <hash>.<project>.pages.dev   -> 4 labels
+ *
+ * Renaming the Pages project therefore cannot desync this file again.
  */
 
 const CANONICAL_HOST = 'ads.avinya.dev';
-const PRODUCTION_PREVIEW_HOST = 'admob-cmp-docs.pages.dev';
+const PAGES_SUFFIX = '.pages.dev';
+const PRODUCTION_PREVIEW_LABEL_COUNT = 3;
+
+/** True for `<project>.pages.dev`, false for `<hash>.<project>.pages.dev`. */
+export function isProductionPreviewHost(hostname) {
+  if (!hostname.endsWith(PAGES_SUFFIX)) return false;
+  return hostname.split('.').length === PRODUCTION_PREVIEW_LABEL_COUNT;
+}
 
 export async function onRequest(context) {
   const url = new URL(context.request.url);
@@ -25,7 +44,7 @@ export async function onRequest(context) {
     return context.next();
   }
 
-  if (url.hostname === PRODUCTION_PREVIEW_HOST) {
+  if (isProductionPreviewHost(url.hostname)) {
     url.hostname = CANONICAL_HOST;
     url.protocol = 'https:';
     url.port = '';

--- a/docs-site/test/host-guard.test.ts
+++ b/docs-site/test/host-guard.test.ts
@@ -1,0 +1,124 @@
+/**
+ * The Cloudflare Pages host guard had no tests, and it is the only thing
+ * stopping Google from indexing a second, crawlable copy of the site on
+ * *.pages.dev — the exact defect spec §5 records happening on avinya.dev.
+ *
+ * It also used to hardcode the Pages project name, which had to agree with
+ * `--project-name` in .github/workflows/release.yml. When those disagreed the
+ * guard did not throw: it silently fell through to the branch-preview path and
+ * served the production preview host. These tests pin the behaviour that
+ * replaced that coupling.
+ */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { isProductionPreviewHost, onRequest } from '../functions/_middleware.js';
+
+const CANONICAL = 'ads.avinya.dev';
+
+/** Minimal Pages context: `next()` returns a plain 200 so headers are testable. */
+function contextFor(url: string, body = '<!doctype html>') {
+  return {
+    request: new Request(url),
+    next: async () => new Response(body, { status: 200, headers: { 'content-type': 'text/html' } }),
+  };
+}
+
+describe('production preview host detection', () => {
+  it('matches <project>.pages.dev for any project name', () => {
+    for (const host of [
+      'admob-compose-multiplatform.pages.dev',
+      'admob-cmp-docs.pages.dev',
+      'something-else-entirely.pages.dev',
+    ]) {
+      expect(isProductionPreviewHost(host), host).toBe(true);
+    }
+  });
+
+  it('does not match per-deployment previews', () => {
+    for (const host of [
+      'abc123.admob-compose-multiplatform.pages.dev',
+      'deadbeef.admob-cmp-docs.pages.dev',
+      'branch-name.project.pages.dev',
+    ]) {
+      expect(isProductionPreviewHost(host), host).toBe(false);
+    }
+  });
+
+  it('does not match the canonical domain or unrelated hosts', () => {
+    for (const host of [CANONICAL, 'avinya.dev', 'example.com', 'pages.dev', 'localhost']) {
+      expect(isProductionPreviewHost(host), host).toBe(false);
+    }
+  });
+});
+
+describe('host guard routing', () => {
+  it('serves the canonical domain untouched', async () => {
+    const response = await onRequest(contextFor(`https://${CANONICAL}/start/quickstart/`));
+    expect(response.status).toBe(200);
+    expect(response.headers.get('X-Robots-Tag')).toBeNull();
+  });
+
+  it('301s the production preview host to the canonical one, preserving the path', async () => {
+    const response = await onRequest(
+      contextFor('https://admob-compose-multiplatform.pages.dev/start/quickstart/')
+    );
+    expect(response.status).toBe(301);
+    expect(response.headers.get('location')).toBe(`https://${CANONICAL}/start/quickstart/`);
+  });
+
+  it('301s regardless of what the project is named', async () => {
+    const response = await onRequest(contextFor('https://renamed-later.pages.dev/formats/banner/'));
+    expect(response.status).toBe(301);
+    expect(response.headers.get('location')).toBe(`https://${CANONICAL}/formats/banner/`);
+  });
+
+  it('preserves the query string across the redirect', async () => {
+    const response = await onRequest(contextFor('https://project.pages.dev/?q=consent'));
+    expect(response.headers.get('location')).toBe(`https://${CANONICAL}/?q=consent`);
+  });
+
+  it('serves per-deployment previews but marks them noindex', async () => {
+    const response = await onRequest(
+      contextFor('https://abc123.admob-compose-multiplatform.pages.dev/')
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get('X-Robots-Tag')).toBe('noindex, nofollow');
+    expect(await response.text()).toContain('<!doctype html>');
+  });
+
+  it('noindexes any other host rather than serving it bare', async () => {
+    const response = await onRequest(contextFor('https://unexpected.example.com/'));
+    expect(response.status).toBe(200);
+    expect(response.headers.get('X-Robots-Tag')).toBe('noindex, nofollow');
+  });
+});
+
+describe('the project name has exactly one source of truth', () => {
+  const workflow = readFileSync(
+    fileURLToPath(new URL('../../.github/workflows/release.yml', import.meta.url)),
+    'utf8'
+  );
+  const middleware = readFileSync(
+    fileURLToPath(new URL('../functions/_middleware.js', import.meta.url)),
+    'utf8'
+  );
+
+  it('release.yml names the Pages project', () => {
+    expect(workflow).toMatch(/--project-name=[a-z0-9-]+/);
+  });
+
+  it('the middleware never hardcodes a project name or a *.pages.dev host', () => {
+    const code = middleware.replace(/\/\*[\s\S]*?\*\/|\/\/.*$/gm, '');
+    expect(code).not.toMatch(/[a-z0-9-]+\.pages\.dev/);
+  });
+
+  it('the canonical host still matches the configured Astro site', () => {
+    const config = readFileSync(
+      fileURLToPath(new URL('../astro.config.mjs', import.meta.url)),
+      'utf8'
+    );
+    expect(config).toContain(`https://${CANONICAL}`);
+    expect(middleware).toContain(`CANONICAL_HOST = '${CANONICAL}'`);
+  });
+});


### PR DESCRIPTION
The Pages project is named admob-compose-multiplatform, matching the GitHub repo. Two files hardcoded admob-cmp-docs instead: --project-name in release.yml, and PRODUCTION_PREVIEW_HOST in the Pages host guard.

Renaming only the workflow would have left the guard broken in the worst possible way — silently. It does not throw on an unknown host; it falls through to the branch-preview branch and *serves* <project>.pages.dev with a 200. That is a second crawlable copy of the site, which is precisely the duplicate-host defect the file exists to prevent and that spec §5 records happening on avinya.dev.

The guard no longer needs the name. Cloudflare's hosts are distinguishable by shape alone: <project>.pages.dev has three labels, <hash>.<project>.pages.dev has four. Classifying by label count makes the file rename-proof, and leaves --project-name in release.yml as the single source of truth.

Adds docs-site/test/host-guard.test.ts. The middleware had no tests at all despite being the only thing standing between the site and a duplicate indexed copy. Twelve cases: all three host classes, path and query preservation across the 301, behaviour under an arbitrary future project name, and a guard that fails if a *.pages.dev literal reappears outside comments. Verified by reintroducing the old hardcoded-name behaviour, which fails five of them.

READINESS: PASS across all eight sections.