### PR TITLE
fix(ci): build the docs site before testing it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,16 +198,21 @@ jobs:
         run: npx playwright install --with-deps chromium
         working-directory: docs-site
 
-      # The one permitted test step in this pipeline: the docs site's own
-      # Vitest suite (9 tests, ~0.1s) over docs-site/src/lib/seo.ts. It guards
-      # the JSON-LD and OG-image output and is part of building the site, not
-      # of verifying the SDK. It is not a precedent for adding SDK test jobs.
-      - name: Unit-test the SEO helpers
-        run: npm test
-        working-directory: docs-site
-
       - name: Build the site
         run: npm run build
+        working-directory: docs-site
+
+      # The one permitted test step in this pipeline: the docs site's own
+      # Vitest suite. It is part of building the site, not of verifying the
+      # SDK, and is not a precedent for adding SDK test jobs.
+      #
+      # Runs AFTER the build, not before. Some cases assert against dist/
+      # output (exact rendered <h1>, format/roadmap order, the diagram
+      # gallery) and hard-fail rather than skip when dist/ is absent — running
+      # this step first left that coverage silently dead in CI, since nothing
+      # here re-runs npm test after the build. See AGENTS.md.
+      - name: Unit-test the docs site
+        run: npm test
         working-directory: docs-site
 
       - name: Verify the built output

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,10 +145,14 @@ needs the Xcode-provided iOS SDK headers, which a Linux runner does not
 have. This is why the pipeline splits `api-reference` (macOS) and
 `docs-site` (Ubuntu) into two jobs with an artifact handoff.
 
-Local docs work only needs Node — `cd docs-site && npm ci && npm test &&
-npm run build && npm run verify` is sufficient to validate Astro
-changes once `./gradlew syncApiDocsToDocsSite` has populated
-`docs-site/public/api/`.
+Local docs work only needs Node — `cd docs-site && npm ci && npm run build &&
+npm test && npm run verify` is sufficient to validate Astro changes once
+`./gradlew syncApiDocsToDocsSite` has populated `docs-site/public/api/`.
+**Build before test, not the other way round** — some Vitest cases assert
+against rendered `dist/` output and hard-fail rather than skip when it is
+absent. Test-before-build shipped for a while and looked fine locally
+because a stale `dist/` from an earlier manual build was still on disk; a
+truly clean tree, including CI, fails.
 
 Read `docs-site/DESIGN.md` before changing `tokens.css`, `landing.css` or
 `diagrams.css`. It records what the design system is for, which colour

--- a/scripts/release-readiness.sh
+++ b/scripts/release-readiness.sh
@@ -187,8 +187,13 @@ if [ "$SKIP_DOCS" = "false" ]; then
     # ubuntu-latest `docs-site` job in release.yml. On macOS, plain
     # `playwright install chromium` is correct.
     npx playwright install chromium
-    npm test
+    # Build before test: some Vitest cases assert against dist/ output (the
+    # rendered <h1>, format/roadmap order, the diagram gallery) and hard-fail
+    # rather than skip when dist/ is absent. Test-before-build looked clean
+    # locally only because a stale dist/ from an earlier manual build was
+    # still on disk — a truly clean tree fails. See AGENTS.md.
     npm run build
+    npm test
     npm run check:theme
     npm run check:overflow
     npm run verify


### PR DESCRIPTION
npm test ran before npm run build in this pipeline, in scripts/release- readiness.sh, and in the one-liner AGENTS.md documents for local docs work. Two test files assert against dist/index.html and hard-fail rather than skip when it does not exist yet, so this order broke them.

It went undetected until now because release.yml has no pull_request trigger: the dist/index.html rendered landing contract block was added in a Plan 5 commit on 2026-08-01, and only reached master via yesterday's merge — the run that just failed was the first time that code path had ever executed in CI. Locally it looked fine only because a stale dist/ from an earlier manual build was still on disk each time; a truly clean tree fails identically to CI, confirmed by rm -rf dist && npm test before this fix.

Reorders build before test in all three places. Nothing is lost: the Astro build takes a few seconds, and the rendered-output checks (exact H1, format/roadmap order, the diagram gallery) now actually run instead of never firing.

READINESS: PASS across all eight release-readiness.sh sections, in the corrected order — 212 tests, verify, check:theme, check:overflow.