### PR TITLE
fix: address code-review findings and release 1.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ One Kotlin API for **AdMob on Compose Multiplatform**. Write your ad code once i
 
 ```kotlin
 // commonMain
-implementation("dev.avinya.ads:admob-cmp:1.1.0")
+implementation("dev.avinya.ads:admob-cmp:1.1.1")
 ```
 
 If your project runs Kotlin/Native tests (`:yourModule:iosSimulatorArm64Test`), also apply the Gradle plugin. Without it the test link fails with `Undefined symbols … _OBJC_CLASS_$_GAD*`, because a Kotlin/Native test executable has no Xcode to resolve the Swift packages for it:
 
 ```kotlin
 plugins {
-    id("dev.avinya.ads.admob-cmp") version "1.1.0"
+    id("dev.avinya.ads.admob-cmp") version "1.1.1"
 }
 ```
 
@@ -144,11 +144,12 @@ Use a static, finite placement id. Never generate one per row (`"feed_item_$inde
 
 | admob-cmp | Kotlin | Compose Multiplatform | Android `minSdk` | iOS deployment target |
 |---|---|---|---|---|
+| 1.1.1 | 2.3.20 | 1.11.1 | 26 | 15.0 |
 | 1.1.0 | 2.3.20 | 1.11.1 | 26 | 15.0 |
 | 1.0.2 | 2.3.20 | 1.11.1 | 26 | 15.0 |
 | 1.0.0 | 2.3.20 | 1.11.1 | 26 | 15.0 |
 
-Underlying Google SDKs bound by 1.1.0:
+Underlying Google SDKs bound by 1.1.1:
 
 | SDK | Version |
 |---|---|

--- a/admob-cmp-compose/build.gradle.kts
+++ b/admob-cmp-compose/build.gradle.kts
@@ -61,7 +61,6 @@ kotlin {
             implementation(libs.kotlinx.coroutines.core)
         }
         androidMain.dependencies {
-            implementation(libs.compose.uiTooling)
             implementation(libs.androidx.activity.compose)
             implementation(libs.google.ads.mobile.sdk)
             implementation(libs.google.user.messaging.platform)

--- a/admob-cmp-compose/src/androidMain/kotlin/dev/avinya/ads/nativead/rendering/AndroidNativeAdLayoutRenderer.kt
+++ b/admob-cmp-compose/src/androidMain/kotlin/dev/avinya/ads/nativead/rendering/AndroidNativeAdLayoutRenderer.kt
@@ -73,7 +73,6 @@ internal class AndroidNativeAdLayoutRenderer(
                 oldBottom: Int,
             ) {
                 if (view.width <= 0 || view.height <= 0) return
-                view.removeOnLayoutChangeListener(this)
 
                 val rootBounds = view.screenBounds()
                 val issues = listOfNotNull(
@@ -81,7 +80,7 @@ internal class AndroidNativeAdLayoutRenderer(
                     nativeAdView.bodyView?.let { "body" to it },
                     nativeAdView.callToActionView?.let { "callToAction" to it },
                     nativeAdView.iconView?.let { "icon" to it },
-                    nativeAdView.mediaView?.let { "media" to it },
+                    renderedMediaView?.let { "media" to it },
                     nativeAdView.advertiserView?.let { "advertiser" to it },
                     nativeAdView.priceView?.let { "price" to it },
                     nativeAdView.storeView?.let { "store" to it },
@@ -98,6 +97,7 @@ internal class AndroidNativeAdLayoutRenderer(
                     return
                 }
 
+                view.removeOnLayoutChangeListener(this)
                 nativeAdView.registerNativeAd(nativeAd, renderedMediaView)
                 AdLogger.d(
                     "Android native renderer registered after containment. " +

--- a/admob-cmp-compose/src/androidMain/kotlin/dev/avinya/ads/ui/AndroidNativeAdView.kt
+++ b/admob-cmp-compose/src/androidMain/kotlin/dev/avinya/ads/ui/AndroidNativeAdView.kt
@@ -133,6 +133,9 @@ public actual fun NativeAdView(
                     // Do not rebuild or re-register NativeAdView during normal recomposition.
                     // The SDK-owned view tree is recreated only when token or layout identity changes.
                 },
+                onRelease = { nativeAdView ->
+                    nativeAdView.destroy()
+                },
                 modifier = modifier
             )
         }

--- a/admob-cmp-compose/src/commonMain/kotlin/dev/avinya/ads/AdComposition.kt
+++ b/admob-cmp-compose/src/commonMain/kotlin/dev/avinya/ads/AdComposition.kt
@@ -8,9 +8,18 @@ import androidx.compose.runtime.staticCompositionLocalOf
 /**
  * An immutable, Compose-stable holder for a list of [AdPlacement]s.
  * Provides lookup by id via [AdPlacements.placement].
+ *
+ * [items] is defensively copied at construction. `@Immutable` is a promise to the Compose
+ * runtime that nothing observable here can change after construction, and it acts on that
+ * promise by skipping recomposition. Retaining the caller's `List` reference broke the
+ * promise: passing a `MutableList` and mutating it later changed placement lookups behind
+ * Compose's back, with no identity change to signal it.
  */
 @Immutable
-public class AdPlacements(public val items: List<AdPlacement>)
+public class AdPlacements(items: List<AdPlacement>) {
+    /** The placements held by this instance. */
+    public val items: List<AdPlacement> = items.toList()
+}
 
 /**
  * CompositionLocal providing the active [AdManager] to the composable tree.

--- a/admob-cmp-compose/src/commonMain/kotlin/dev/avinya/ads/debug/AdDebugRecorder.kt
+++ b/admob-cmp-compose/src/commonMain/kotlin/dev/avinya/ads/debug/AdDebugRecorder.kt
@@ -1,3 +1,5 @@
+@file:OptIn(dev.avinya.ads.InternalAdMobCmpApi::class)
+
 package dev.avinya.ads.debug
 
 import dev.avinya.ads.AdEvent

--- a/admob-cmp-compose/src/commonMain/kotlin/dev/avinya/ads/nativead/layout/AdLayoutValidator.kt
+++ b/admob-cmp-compose/src/commonMain/kotlin/dev/avinya/ads/nativead/layout/AdLayoutValidator.kt
@@ -55,44 +55,68 @@ public object AdLayoutValidator {
         val errors = mutableListOf<AdLayoutValidationIssue>()
         val assets = mutableSetOf<String>()
 
-        fun visit(node: AdNode, path: String) {
+        fun isVisible(node: AdNode, parentVisible: Boolean): Boolean {
+            if (!parentVisible) return false
+            val m = node.modifier
+            if (m.display != AdDisplay.Visible) return false
+            if (m.alpha <= 0f) return false
+            if (m.width is AdLayoutSize.Fixed && m.width.dp <= 0f) return false
+            if (m.height is AdLayoutSize.Fixed && m.height.dp <= 0f) return false
+            return true
+        }
+
+        fun visit(node: AdNode, path: String, parentVisible: Boolean = true) {
+            val visible = isVisible(node, parentVisible)
             when (node) {
                 is AdContainerNode.Row -> {
                     if (node.children.isEmpty()) warnings += warning("empty_container", "Row has no children.", path)
-                    node.children.forEachIndexed { index, child -> visit(child, "$path/row[$index]") }
+                    node.children.forEachIndexed { index, child -> visit(child, "$path/row[$index]", visible) }
                 }
                 is AdContainerNode.Column -> {
                     if (node.children.isEmpty()) warnings += warning("empty_container", "Column has no children.", path)
-                    node.children.forEachIndexed { index, child -> visit(child, "$path/column[$index]") }
+                    node.children.forEachIndexed { index, child -> visit(child, "$path/column[$index]", visible) }
                 }
                 is AdContainerNode.Box -> {
                     if (node.children.isEmpty()) warnings += warning("empty_container", "Box has no children.", path)
-                    node.children.forEachIndexed { index, child -> visit(child, "$path/box[$index]") }
+                    node.children.forEachIndexed { index, child -> visit(child, "$path/box[$index]", visible) }
                 }
                 is AdSpacer -> Unit
                 is AdStaticText -> {
                     if (node.text.isBlank()) warnings += warning("blank_static_text", "Static text is blank.", path)
                 }
-                is AdAssetNode.Headline -> assets += "headline"
-                is AdAssetNode.Body -> assets += "body"
-                is AdAssetNode.CallToAction -> assets += "call_to_action"
-                is AdAssetNode.Icon -> assets += "icon"
-                is AdAssetNode.Media -> assets += "media"
-                is AdAssetNode.Advertiser -> assets += "advertiser"
-                is AdAssetNode.Price -> assets += "price"
-                is AdAssetNode.Store -> assets += "store"
-                is AdAssetNode.StarRating -> assets += "star_rating"
-                is AdAssetNode.AdChoices -> assets += "ad_choices"
-                is AdAssetNode.AdBadge -> assets += "ad_badge"
+                is AdAssetNode -> {
+                    if (visible) {
+                        val key = when (node) {
+                            is AdAssetNode.Headline -> "headline"
+                            is AdAssetNode.Body -> "body"
+                            is AdAssetNode.CallToAction -> "call_to_action"
+                            is AdAssetNode.Icon -> "icon"
+                            is AdAssetNode.Media -> "media"
+                            is AdAssetNode.Advertiser -> "advertiser"
+                            is AdAssetNode.Price -> "price"
+                            is AdAssetNode.Store -> "store"
+                            is AdAssetNode.StarRating -> "star_rating"
+                            is AdAssetNode.AdChoices -> "ad_choices"
+                            is AdAssetNode.AdBadge -> "ad_badge"
+                        }
+                        assets += key
+                    } else {
+                        warnings += warning("hidden_asset", "Asset ${node::class.simpleName} is hidden (gone, alpha=0, or 0 size).", path)
+                    }
+                }
             }
         }
 
         visit(root, "root")
 
-        fun containsAdBadge(node: AdNode): Boolean = when (node) {
-            is AdAssetNode.AdBadge -> true
-            is AdContainerNode -> node.children.any(::containsAdBadge)
-            else -> false
+        fun containsAdBadge(node: AdNode, parentVisible: Boolean = true): Boolean {
+            val visible = isVisible(node, parentVisible)
+            if (!visible) return false
+            return when (node) {
+                is AdAssetNode.AdBadge -> true
+                is AdContainerNode -> node.children.any { containsAdBadge(it, visible) }
+                else -> false
+            }
         }
         val topRegion = when (root) {
             is AdContainerNode.Column -> root.children.firstOrNull()

--- a/admob-cmp-compose/src/commonTest/kotlin/dev/avinya/ads/AdLayoutValidatorVisibilityTest.kt
+++ b/admob-cmp-compose/src/commonTest/kotlin/dev/avinya/ads/AdLayoutValidatorVisibilityTest.kt
@@ -1,0 +1,204 @@
+package dev.avinya.ads
+
+import androidx.compose.ui.unit.dp
+import dev.avinya.ads.nativead.layout.AdAssetNode
+import dev.avinya.ads.nativead.layout.AdContainerNode
+import dev.avinya.ads.nativead.layout.AdDisplay
+import dev.avinya.ads.nativead.layout.AdLayout
+import dev.avinya.ads.nativead.layout.AdModifier
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AdLayoutValidatorVisibilityTest {
+
+    @Test
+    fun `hidden AdDisplay node is flagged as hidden_asset`() {
+        val layout = AdLayout(
+            root = AdContainerNode.Column(
+                modifier = AdModifier.empty,
+                children = listOf(
+                    AdAssetNode.Headline(modifier = AdModifier.empty.copy(display = AdDisplay.Gone)),
+                    AdAssetNode.AdBadge(),
+                    AdAssetNode.AdChoices(),
+                    AdAssetNode.Body(),
+                )
+            )
+        )
+        val warnings = layout.validation.warnings
+        assertTrue(warnings.any { it.code == "hidden_asset" && it.nodePath == "root/column[0]" })
+        assertTrue(warnings.any { it.code == "missing_headline" })
+    }
+
+    @Test
+    fun `zero-alpha node is flagged as hidden_asset`() {
+        val layout = AdLayout(
+            root = AdContainerNode.Column(
+                modifier = AdModifier.empty,
+                children = listOf(
+                    AdAssetNode.Headline(modifier = AdModifier.empty.copy(alpha = 0f)),
+                    AdAssetNode.AdBadge(),
+                    AdAssetNode.AdChoices(),
+                    AdAssetNode.Body(),
+                )
+            )
+        )
+        val warnings = layout.validation.warnings
+        assertTrue(warnings.any { it.code == "hidden_asset" && it.nodePath == "root/column[0]" })
+        assertTrue(warnings.any { it.code == "missing_headline" })
+    }
+
+    @Test
+    fun `zero-dimension node is flagged as hidden_asset`() {
+        val layoutWidth0 = AdLayout(
+            root = AdContainerNode.Column(
+                modifier = AdModifier.empty,
+                children = listOf(
+                    AdAssetNode.Headline(modifier = AdModifier.empty.width(0.dp)),
+                    AdAssetNode.AdBadge(),
+                    AdAssetNode.AdChoices(),
+                    AdAssetNode.Body(),
+                )
+            )
+        )
+        assertTrue(layoutWidth0.validation.warnings.any { it.code == "hidden_asset" })
+
+        val layoutHeight0 = AdLayout(
+            root = AdContainerNode.Column(
+                modifier = AdModifier.empty,
+                children = listOf(
+                    AdAssetNode.Headline(modifier = AdModifier.empty.height(0.dp)),
+                    AdAssetNode.AdBadge(),
+                    AdAssetNode.AdChoices(),
+                    AdAssetNode.Body(),
+                )
+            )
+        )
+        assertTrue(layoutHeight0.validation.warnings.any { it.code == "hidden_asset" })
+    }
+
+    @Test
+    fun `hidden required content asset fails validation when no other content asset is visible`() {
+        val layout = AdLayout(
+            root = AdContainerNode.Column(
+                modifier = AdModifier.empty,
+                children = listOf(
+                    AdAssetNode.Headline(modifier = AdModifier.empty.copy(display = AdDisplay.Gone)),
+                    AdAssetNode.AdBadge(),
+                    AdAssetNode.AdChoices(),
+                )
+            )
+        )
+        val validation = layout.validation
+        assertFalse(validation.isValid, "Layout with only hidden content assets must not be valid")
+        assertTrue(validation.errors.any { it.code == "missing_renderable_asset" })
+    }
+
+    // The policy cases below are the reason the visibility rules exist. A native ad that
+    // renders with no visible "Ad" attribution is an AdMob policy violation, and the validator
+    // previously certified these as compliant because it recorded assets by node type alone.
+
+    @Test
+    fun `gone ad badge is reported as missing attribution`() {
+        val layout = AdLayout(
+            root = AdContainerNode.Column(
+                modifier = AdModifier.empty,
+                children = listOf(
+                    AdAssetNode.AdBadge(modifier = AdModifier.empty.copy(display = AdDisplay.Gone)),
+                    AdAssetNode.Headline(),
+                    AdAssetNode.AdChoices(),
+                )
+            )
+        )
+        val warnings = layout.validation.warnings
+        assertTrue(
+            warnings.any { it.code == "missing_ad_badge" },
+            "an ad badge hidden with gone() must not satisfy the attribution requirement; got $warnings"
+        )
+    }
+
+    @Test
+    fun `zero-alpha ad badge is reported as missing attribution`() {
+        val layout = AdLayout(
+            root = AdContainerNode.Column(
+                modifier = AdModifier.empty,
+                children = listOf(
+                    AdAssetNode.AdBadge(modifier = AdModifier.empty.copy(alpha = 0f)),
+                    AdAssetNode.Headline(),
+                    AdAssetNode.AdChoices(),
+                )
+            )
+        )
+        assertTrue(
+            layout.validation.warnings.any { it.code == "missing_ad_badge" },
+            "an ad badge with alpha=0 must not satisfy the attribution requirement"
+        )
+    }
+
+    @Test
+    fun `ad badge inside a gone container is reported as missing attribution`() {
+        val layout = AdLayout(
+            root = AdContainerNode.Column(
+                modifier = AdModifier.empty,
+                children = listOf(
+                    AdContainerNode.Row(
+                        modifier = AdModifier.empty.copy(display = AdDisplay.Gone),
+                        children = listOf(AdAssetNode.AdBadge())
+                    ),
+                    AdAssetNode.Headline(),
+                    AdAssetNode.AdChoices(),
+                )
+            )
+        )
+        assertTrue(
+            layout.validation.warnings.any { it.code == "missing_ad_badge" },
+            "a badge inside a gone container is not visible and must not satisfy attribution"
+        )
+    }
+
+    @Test
+    fun `visible ad badge at the top satisfies attribution`() {
+        val layout = AdLayout(
+            root = AdContainerNode.Column(
+                modifier = AdModifier.empty,
+                children = listOf(
+                    AdAssetNode.AdBadge(),
+                    AdAssetNode.Headline(),
+                    AdAssetNode.AdChoices(),
+                )
+            )
+        )
+        val warnings = layout.validation.warnings
+        // Guards against over-correction: the visibility rules must not start reporting
+        // correctly-built layouts as non-compliant.
+        assertFalse(
+            warnings.any { it.code == "missing_ad_badge" },
+            "a plain visible adBadge() must satisfy attribution; got $warnings"
+        )
+        assertFalse(
+            warnings.any { it.code == "ad_attribution_not_at_top" },
+            "a badge as the first child of the root column is at the top; got $warnings"
+        )
+        assertFalse(
+            warnings.any { it.code == "hidden_asset" },
+            "nothing in this layout is hidden; got $warnings"
+        )
+    }
+
+    @Test
+    fun `hidden parent container marks all children as hidden_asset`() {
+        val layout = AdLayout(
+            root = AdContainerNode.Column(
+                modifier = AdModifier.empty.copy(display = AdDisplay.Gone),
+                children = listOf(
+                    AdAssetNode.Headline(),
+                    AdAssetNode.AdBadge(),
+                    AdAssetNode.AdChoices(),
+                )
+            )
+        )
+        val warnings = layout.validation.warnings
+        val hiddenAssets = warnings.filter { it.code == "hidden_asset" }
+        assertTrue(hiddenAssets.size >= 3, "All children of hidden container should be reported as hidden_asset")
+    }
+}

--- a/admob-cmp-core/src/androidMain/kotlin/dev/avinya/ads/AndroidBannerAdController.kt
+++ b/admob-cmp-core/src/androidMain/kotlin/dev/avinya/ads/AndroidBannerAdController.kt
@@ -77,8 +77,9 @@ internal class AndroidBannerAdController internal constructor(
 
     override fun destroy(banner: AndroidLoadedBanner) = banner.destroy()
 
-    override fun responseInfo(banner: AndroidLoadedBanner): AdResponseInfo? =
-        banner.ad.getResponseInfo().toCommon()
+    // Pure field read of a value snapshotted on Main at load time, so this is safe to call
+    // from whatever dispatcher BannerCore's caller resumed on.
+    override fun responseInfo(banner: AndroidLoadedBanner): AdResponseInfo? = banner.responseInfo
 
     override suspend fun loadBanner(
         size: AdSize,
@@ -130,7 +131,11 @@ internal class AndroidBannerAdController internal constructor(
                     // loaded ad immediately so the SDK's server-driven refresh loop is cancelled;
                     // BannerCore remains the single owner of refresh/load-once semantics.
                     val detachedAd = adView.unregisterBannerAd() ?: ad
-                    val loaded = AndroidLoadedBanner(adView, detachedAd)
+                    // Capture response info HERE, on Main. This callback is Main-confined, but
+                    // BannerCore resumes on whatever dispatcher its caller used, so reading it
+                    // there put a GMA access on an arbitrary thread (CLAUDE.md invariant #5).
+                    // Response info is fixed once the ad is loaded, so a snapshot loses nothing.
+                    val loaded = AndroidLoadedBanner(adView, detachedAd, detachedAd.getResponseInfo().toCommon())
                     continuation.resume(
                         AdAttemptResult.Success(loaded),
                         onCancellation = { _, _, _ -> loaded.destroy() }
@@ -151,6 +156,8 @@ internal class AndroidBannerAdController internal constructor(
 internal data class AndroidLoadedBanner(
     val view: AdView,
     val ad: BannerAd,
+    /** Snapshotted on Main at load time — see the capture site in `loadBanner`. */
+    val responseInfo: AdResponseInfo?,
 ) {
     fun destroy() {
         val cleanup = {

--- a/admob-cmp-core/src/androidMain/kotlin/dev/avinya/ads/AndroidGoogleAdManager.kt
+++ b/admob-cmp-core/src/androidMain/kotlin/dev/avinya/ads/AndroidGoogleAdManager.kt
@@ -369,9 +369,11 @@ internal class AndroidGoogleAdManager(
                 val initializationConfig = InitializationConfig.Builder(config.androidAppId)
                     .setRequestConfiguration(requestedIdentity.globalRequestConfiguration.toAndroidRequestConfiguration())
                     .build()
-                suspendCancellableCoroutine { continuation ->
-                    MobileAds.initialize(appContext, initializationConfig) {
-                        if (continuation.isActive) continuation.resume(Unit)
+                withContext(Dispatchers.IO) {
+                    suspendCancellableCoroutine { continuation ->
+                        MobileAds.initialize(appContext, initializationConfig) {
+                            if (continuation.isActive) continuation.resume(Unit)
+                        }
                     }
                 }
                 config.globalRequestConfiguration.publisherFirstPartyIdEnabled?.let {

--- a/admob-cmp-core/src/androidMain/kotlin/dev/avinya/ads/appopen/ForegroundSignal.android.kt
+++ b/admob-cmp-core/src/androidMain/kotlin/dev/avinya/ads/appopen/ForegroundSignal.android.kt
@@ -16,15 +16,14 @@ internal actual fun appForegroundState(): Flow<Boolean> = callbackFlow {
     val observer = LifecycleEventObserver { _, event ->
         when (event) {
             Lifecycle.Event.ON_START -> trySend(true)
-            Lifecycle.Event.ON_STOP -> trySend(false)
+            Lifecycle.Event.ON_STOP  -> trySend(false)
             else -> Unit
         }
     }
-    // Lifecycle observers must be (un)registered on the main thread regardless of
-    // which dispatcher collects this flow.
-    withContext(Dispatchers.Main.immediate) { owner.lifecycle.addObserver(observer) }
+    val handler = Handler(Looper.getMainLooper())
+    handler.post { owner.lifecycle.addObserver(observer) }
     awaitClose {
-        Handler(Looper.getMainLooper()).post { owner.lifecycle.removeObserver(observer) }
+        handler.post { owner.lifecycle.removeObserver(observer) }
     }
 }
 

--- a/admob-cmp-core/src/androidMain/kotlin/dev/avinya/ads/internal/FullScreenStateLock.android.kt
+++ b/admob-cmp-core/src/androidMain/kotlin/dev/avinya/ads/internal/FullScreenStateLock.android.kt
@@ -1,5 +1,8 @@
 package dev.avinya.ads.internal
 
+import dev.avinya.ads.InternalAdMobCmpApi
+
+@InternalAdMobCmpApi
 public actual class FullScreenStateLock public actual constructor() {
     private val monitor = Any()
 

--- a/admob-cmp-core/src/androidMain/kotlin/dev/avinya/ads/nativead/AndroidNativeAdPool.kt
+++ b/admob-cmp-core/src/androidMain/kotlin/dev/avinya/ads/nativead/AndroidNativeAdPool.kt
@@ -1,5 +1,7 @@
 package dev.avinya.ads.nativead
 
+import android.os.Handler
+import android.os.Looper
 import dev.avinya.ads.InternalAdMobCmpApi
 import dev.avinya.ads.AdAttemptResult
 import dev.avinya.ads.AdError
@@ -46,7 +48,7 @@ internal class AndroidNativeAdPool internal constructor(
     override val placement: AdPlacement,
     globalEvents: MutableSharedFlow<AdEvent>,
     private val adRequestBlockedError: () -> AdError?
-) : NativeAdPool, NativePoolPlatform<NativeAd> {
+) : NativeAdPool, NativePoolPlatform<AndroidLoadedNativeAd> {
 
     private val stateLock = Any()
     private val core = NativePoolCore(placement, this, globalEvents)
@@ -68,7 +70,8 @@ internal class AndroidNativeAdPool internal constructor(
     override fun clear() = core.clear()
 
     // Retained for AndroidNativeAdView, which needs the SDK handle to build the view tree.
-    fun peek(token: NativeAdToken): NativeAd? = core.peek(token)
+    // Unwraps the handle exactly as IosNativeAdPool.peek does.
+    fun peek(token: NativeAdToken): NativeAd? = core.peek(token)?.ad
 
     fun take(): NativeAd? = acquire()?.let(::peek)
 
@@ -76,27 +79,29 @@ internal class AndroidNativeAdPool internal constructor(
 
     override fun <T> withPoolLock(block: () -> T): T = synchronized(stateLock) { block() }
 
-    override fun destroy(ad: NativeAd) = ad.destroy()
-
-    override fun responseInfo(ad: NativeAd): AdResponseInfo? = ad.getResponseInfo().toCommon()
-
-    override fun mediaInfo(ad: NativeAd): NativeMediaInfo? {
-        val mediaContent = ad.mediaContent ?: return null
-        return NativeMediaInfo(
-            aspectRatio = (mediaContent.aspectRatio as? Float)?.takeIf { it > 0f },
-            hasVideoContent = mediaContent.hasVideoContent,
-            durationSeconds = mediaContent.duration.takeIf { it > 0f }?.toDouble()
-        )
+    override fun destroy(ad: AndroidLoadedNativeAd) {
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            ad.ad.destroy()
+        } else {
+            Handler(Looper.getMainLooper()).post { ad.ad.destroy() }
+        }
     }
+
+    // Both accessors are pure field reads of values snapshotted on Main at load time, so they
+    // are safe from whatever dispatcher the caller uses. mediaInfo() in particular is public,
+    // non-suspend API a consumer can call from any thread.
+    override fun responseInfo(ad: AndroidLoadedNativeAd): AdResponseInfo? = ad.responseInfo
+
+    override fun mediaInfo(ad: AndroidLoadedNativeAd): NativeMediaInfo? = ad.mediaInfo
 
     override suspend fun loadBatch(
         count: Int,
         requestOptions: AdRequestOptions,
         nativeOptions: NativeAdOptions,
         requiredGeneration: Long
-    ): AdAttemptResult<List<NativeAd>> = withContext(Dispatchers.Main.immediate) {
+    ): AdAttemptResult<List<AndroidLoadedNativeAd>> = withContext(Dispatchers.Main.immediate) {
         suspendCancellableCoroutine { continuation ->
-            val pending = mutableListOf<NativeAd>()
+            val pending = mutableListOf<AndroidLoadedNativeAd>()
             // Guarded by synchronized(pending): once cancellation has run its cleanup, this
             // flips so a late onNativeAdLoaded destroys its ad instead of adding it to an
             // already-drained list.
@@ -109,7 +114,7 @@ internal class AndroidNativeAdPool internal constructor(
             continuation.invokeOnCancellation {
                 synchronized(pending) {
                     cancelled = true
-                    pending.forEach { it.destroy() }
+                    pending.forEach { it.ad.destroy() }
                     pending.clear()
                 }
             }
@@ -123,12 +128,21 @@ internal class AndroidNativeAdPool internal constructor(
                     // Atomically check cancellation and add: if cancellation already drained
                     // pending, destroy this ad instead of leaking it into a list nothing
                     // will clean up.
+                    // Snapshot response/media info HERE, on the Main-confined loader callback.
+                    // NativePoolCore reads them back from an arbitrary dispatcher (mediaInfo() is
+                    // even public, non-suspend API), which put GMA accesses off Main — CLAUDE.md
+                    // invariant #5. Both are fixed once the ad is loaded.
+                    val loaded = AndroidLoadedNativeAd(
+                        ad = nativeAd,
+                        responseInfo = nativeAd.getResponseInfo().toCommon(),
+                        mediaInfo = nativeAd.readMediaInfo()
+                    )
                     val accepted = synchronized(pending) {
                         if (cancelled || !continuation.isActive) {
                             false
                         } else {
                             AdLogger.d("Android native ad loaded callback. placement=${placement.id} pendingBefore=${pending.size}")
-                            pending += nativeAd
+                            pending += loaded
                             true
                         }
                     }
@@ -146,7 +160,7 @@ internal class AndroidNativeAdPool internal constructor(
                 }
 
                 override fun onAdLoadingCompleted() {
-                    val loaded: List<NativeAd>
+                    val loaded: List<AndroidLoadedNativeAd>
                     val error: AdError?
                     val accepted: Boolean
                     // Claim the batch under the same lock that snapshots it. Checking
@@ -162,7 +176,7 @@ internal class AndroidNativeAdPool internal constructor(
                     }
                     AdLogger.i("Android native loading completed. placement=${placement.id} loaded=${loaded.size}")
                     if (!accepted) {
-                        loaded.forEach { it.destroy() }
+                        loaded.forEach { it.ad.destroy() }
                         return
                     }
                     // Resume once, here — the batch-complete signal. Any ad that loaded
@@ -172,7 +186,7 @@ internal class AndroidNativeAdPool internal constructor(
                         // never receives the batch, so destroy it here rather than leaking
                         // it into a dropped value.
                         continuation.resume(AdAttemptResult.Success(loaded)) { _, _, _ ->
-                            loaded.forEach { it.destroy() }
+                            loaded.forEach { it.ad.destroy() }
                         }
                     } else {
                         // Whole batch yielded nothing: report the captured per-ad error, or a
@@ -196,11 +210,11 @@ internal class AndroidNativeAdPool internal constructor(
     private fun installCallbacks(nativeAd: NativeAd) {
         nativeAd.adEventCallback = object : NativeAdEventCallback {
             override fun onAdImpression() =
-                core.emitInstanceScopedEvent({ it === nativeAd }) { id -> AdEvent.Impression(placement.id, id) }
+                core.emitInstanceScopedEvent({ it.ad === nativeAd }) { id -> AdEvent.Impression(placement.id, id) }
             override fun onAdClicked() =
-                core.emitInstanceScopedEvent({ it === nativeAd }) { id -> AdEvent.Clicked(placement.id, id) }
+                core.emitInstanceScopedEvent({ it.ad === nativeAd }) { id -> AdEvent.Clicked(placement.id, id) }
             override fun onAdPaid(value: com.google.android.libraries.ads.mobile.sdk.common.AdValue) {
-                core.emitInstanceScopedEvent({ it === nativeAd }) { id ->
+                core.emitInstanceScopedEvent({ it.ad === nativeAd }) { id ->
                     AdEvent.Paid(
                         placement.id,
                         PaidEvent(placement.id, value.toCommon(), nativeAd.getResponseInfo().toCommon()),
@@ -210,6 +224,28 @@ internal class AndroidNativeAdPool internal constructor(
             }
         }
     }
+}
+
+/**
+ * Android's native-ad handle: the SDK ad plus the metadata snapshotted on Main at load time.
+ *
+ * Mirrors iOS's [dev.avinya.ads.nativead.LoadedNativeAd]. The raw `NativeAd` used to be the
+ * pool's handle type directly, which left no place to cache metadata and forced the core to
+ * call back into GMA from arbitrary dispatchers.
+ */
+internal data class AndroidLoadedNativeAd(
+    val ad: NativeAd,
+    val responseInfo: AdResponseInfo?,
+    val mediaInfo: NativeMediaInfo?,
+)
+
+private fun NativeAd.readMediaInfo(): NativeMediaInfo? {
+    val mediaContent = mediaContent ?: return null
+    return NativeMediaInfo(
+        aspectRatio = (mediaContent.aspectRatio as? Float)?.takeIf { it > 0f },
+        hasVideoContent = mediaContent.hasVideoContent,
+        durationSeconds = mediaContent.duration.takeIf { it > 0f }?.toDouble()
+    )
 }
 
 @InternalAdMobCmpApi

--- a/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/AdConfig.kt
+++ b/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/AdConfig.kt
@@ -120,8 +120,15 @@ internal suspend fun AdConfig.dispatchInitializationHooks(phase: AdInitializatio
  */
 internal fun AdConfig.testModeWarningOrNull(): String? {
     if (!testMode) return null
-    val hasTestDeviceIds = testDeviceIds.isNotEmpty() || debugOptions.consentTestDeviceIds.isNotEmpty()
-    if (hasTestDeviceIds) return null
+    // ONLY GlobalRequestConfiguration.testDeviceIds counts. debugOptions.consentTestDeviceIds
+    // is deliberately not accepted: it reaches UMP's ConsentDebugSettings and nothing else
+    // (AndroidGoogleAdManager's consent debug builder / IosConsentController), and never
+    // touches GMA's RequestConfiguration (AndroidAdMappers.toAndroidRequestConfiguration,
+    // IosAdMappers.applyTo). Treating it as evidence of a GMA test configuration made this
+    // warning fail OPEN — a physical device with consent debugging on, and no GMA test
+    // registration at all, was told nothing while requesting live ads. Invariant #10: test
+    // safety fails closed.
+    if (testDeviceIds.isNotEmpty()) return null
     return "AdConfig.testMode is true but no test device IDs are configured. testMode alone " +
         "does NOT force GMA to serve test ads on a physical device — only emulators/simulators " +
         "qualify automatically. Populate GlobalRequestConfiguration.testDeviceIds with this " +

--- a/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/AdManager.kt
+++ b/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/AdManager.kt
@@ -35,8 +35,12 @@ public interface AdManager {
      *
      * **Best-effort delivery, not a durable log.** There is no replay and the buffer is
      * finite, so an event emitted with no collector attached — or during a burst that
-     * outruns a slow collector — is dropped. Drops are logged (tag `AdMobCMP`) but not
-     * retried.
+     * outruns a slow collector — is dropped. Nothing is retried.
+     *
+     * Only the second kind of drop is logged (tag `AdMobCMP`). An event emitted while no
+     * collector is attached is discarded **silently**: with no replay there is nothing to
+     * buffer it into, so the emission reports success and the SDK cannot observe the loss.
+     * Start collecting before the first ad operation if you need the early events.
      *
      * Fine for driving UI. **Do not use as the system of record for billing, revenue, or
      * impression accounting**; reconcile against AdMob reporting instead.

--- a/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/AdPlacement.kt
+++ b/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/AdPlacement.kt
@@ -49,7 +49,9 @@ public data class AdUnitIds(
  *   lookups via [List<AdPlacement>.placement].
  * @param strictTestMode When true, the placement throws at construction if any ad unit id
  *   is not a Google test ad unit. Opt-in and default false; intended for debug builds only.
- *   Does not affect production builds.
+ *   **Not build-type aware** — this throws wherever it is enabled, release builds included.
+ *   Gate it on your own debug flag (e.g. `strictTestMode = BuildConfig.DEBUG`) rather than
+ *   leaving it on in shared configuration.
  * @throws IllegalArgumentException if [id] is blank, [cachePolicy.maxSize] < 1, or
  *   [strictTestMode] is enabled and any ad unit id is not a test unit.
  */

--- a/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/appopen/AppOpenAdCoordinator.kt
+++ b/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/appopen/AppOpenAdCoordinator.kt
@@ -1,3 +1,5 @@
+@file:OptIn(dev.avinya.ads.InternalAdMobCmpApi::class)
+
 package dev.avinya.ads.appopen
 
 import dev.avinya.ads.AdManager
@@ -151,13 +153,19 @@ public class AppOpenAdCoordinator internal constructor(
     private suspend fun onForeground() {
         val backgroundDuration = backgroundedAtInstant?.let { elapsedSince(it) } ?: Duration.ZERO
         backgroundedAtInstant = null
+        // Capture scope BEFORE acquiring admission. If stop() already nulled it, skip the
+        // acquisition entirely — otherwise tryAcquireShowAdmission() takes the process-wide
+        // probe token and sets showInFlight, but scope?.launch returns null, and showNow()'s
+        // finally never runs to release them.
+        val activeScope = scope ?: return
         if (backgroundDuration >= config.minBackgroundDuration && tryAcquireShowAdmission()) {
-            showNow()
+            activeScope.launch {
+                showNow()
+                if (!controller.isReady()) controller.load()
+            }
+        } else if (!controller.isReady()) {
+            activeScope.launch { controller.load() }
         }
-        // Reload off the lifecycle collector so a slow/retrying load can't stall the
-        // collector and make us miss the next background/foreground transition (which would
-        // corrupt backgroundDuration accounting and silently drop later shows).
-        if (!controller.isReady()) scope?.launch { controller.load() }
     }
 
     /**

--- a/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/AdEventEmission.kt
+++ b/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/AdEventEmission.kt
@@ -8,10 +8,18 @@ import kotlinx.coroutines.flow.MutableSharedFlow
  * Publishes [event], logging when the buffer refuses it.
  *
  * P1-16: every emitter called `tryEmit` and discarded the Boolean. `AdEvent` flows have no
- * replay and a finite extra buffer, so a burst against a slow collector — or an emission with
- * no collector attached — dropped impressions, closes, show failures and paid events with no
- * trace anywhere. The stream is presented as a unified event stream but has best-effort
- * datagram semantics; this at least makes the loss observable instead of invisible.
+ * replay and a finite extra buffer, so a burst against a slow collector dropped impressions,
+ * closes, show failures and paid events with no trace anywhere. The stream is presented as a
+ * unified event stream but has best-effort datagram semantics; this at least makes *that*
+ * loss observable instead of invisible.
+ *
+ * **What this does NOT catch:** an emission with no collector attached. For a `replay = 0`
+ * flow there is nothing to buffer the value into, so it is dropped and `tryEmit` still
+ * returns `true` — the no-subscriber case is structurally invisible to this check, not
+ * merely unhandled. Detecting it would mean sampling `subscriptionCount`, which races the
+ * emission and, on the per-controller flows most consumers never collect, would log a
+ * warning for every single event. The public contract on `AdManager.events` states this
+ * limitation instead of pretending to cover it.
  *
  * This is deliberately the minimum. Durable analytics/revenue delivery needs a separate
  * contract — a synchronous sink or bounded channel with explicit overflow behaviour and event

--- a/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/BannerCore.kt
+++ b/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/BannerCore.kt
@@ -4,6 +4,7 @@ import dev.avinya.ads.AdAttemptResult
 import dev.avinya.ads.AdError
 import dev.avinya.ads.AdEvent
 import dev.avinya.ads.AdLoadState
+import dev.avinya.ads.AdLogger
 import dev.avinya.ads.AdPlacement
 import dev.avinya.ads.AdRequestOptions
 import dev.avinya.ads.AdResponseInfo
@@ -89,14 +90,27 @@ internal class BannerCore<V : Any, S : Any>(
     private var banner: V? = null
     private var generation = 0L
 
-    // Set by an actual load; this is the P1-4 replay source and always wins.
-    private var lastRequest: ResolvedBannerRequest<S>? = null
+    // Response info for the CURRENTLY OWNED banner, captured once at admission.
+    //
+    // Recovery paths (failOrRestore/onCancelled) must be able to republish Loaded without
+    // calling back into the platform. Reading it lazily instead was wrong twice over: it
+    // touched a GMA object while holding the state lock — which on iOS is also taken from GMA
+    // callback threads, the exact thing NativePoolCore.mediaInfo documents as forbidden — and
+    // it could read from a banner that clear() had already retired and destroyed. Mirrors
+    // NativePoolCore.lastResponseInfo.
+    private var bannerResponseInfo: AdResponseInfo? = null
 
-    // Set by the composable's container measurement WITHOUT loading, so a Manual-policy
-    // placement (which performs no automatic load) can still refresh() at the measured
-    // width. Kept separate from lastRequest so registering geometry can never overwrite the
-    // custom request options a real load resolved — that would silently undo P1-4.
-    private var registeredRequest: ResolvedBannerRequest<S>? = null
+    // The single record refresh() replays. Its fields have two DIFFERENT owners with
+    // different lifetimes, so it is merged on write rather than chosen between on read:
+    //   - requestOptions is owned by the load() caller. P1-4: a refresh must replay the
+    //     options that call resolved, never rebuild them from placement.requestOptions.
+    //   - size/sizePolicy are owned by the host's container measurement and change on every
+    //     resize (rotation, split-screen, fold).
+    // This was previously two records (lastRequest / registeredRequest) picked between in
+    // refresh(). That cannot work: choosing either whole record discards the other owner's
+    // half — preferring the load record replayed a stale width after a resize, preferring
+    // the geometry record dropped custom request options. See registerGeometry.
+    private var replayRequest: ResolvedBannerRequest<S>? = null
 
     // Count of live UI attachments (BannerAdView composables) bound to this controller.
     // The controller is manager-cached for the whole process, so it can't destroy its ad on
@@ -155,11 +169,10 @@ internal class BannerCore<V : Any, S : Any>(
 
     suspend fun refresh(blockedError: () -> AdError? = { null }): AdLoadState {
         val requiredGeneration = currentGeneration()
-        // P1-4: replay the WHOLE resolved request, not just the size. Both controllers
-        // previously kept only lastResolvedAdSize and rebuilt options from
-        // placement.requestOptions, silently dropping custom options from the original
-        // load — contradicting the KDoc.
-        val resolved = platform.withStateLock { lastRequest ?: registeredRequest }
+        // P1-4: replay the WHOLE resolved request, not just the size. There is exactly one
+        // replay record; load() and registerGeometry each update the fields they own, so no
+        // precedence decision is needed here.
+        val resolved = platform.withStateLock { replayRequest }
             ?: return failIfCurrent(
                 requiredGeneration,
                 AdError.message("Banner refresh requires a prior successful load to replay.")
@@ -175,18 +188,29 @@ internal class BannerCore<V : Any, S : Any>(
      * deliberately performs no automatic load but the consumer still drives [refresh].
      * Without it, such a placement could never refresh: it has no prior load to replay
      * and no way to hand geometry in.
+     *
+     * Updates ONLY the geometry-derived fields of the replay record. The host re-measures on
+     * every rotation, split-screen change and fold, and a re-measure is not a statement about
+     * request options — so [requestOptions] seeds the record only when no load has resolved
+     * options yet. Overwriting them here would undo P1-4; ignoring the new geometry would
+     * make [refresh] replay a stale width for the rest of the session.
      */
     fun registerGeometry(
         geometry: BannerGeometry,
         sizePolicy: AdSizePolicy,
         requestOptions: AdRequestOptions
     ) {
+        // resolveSize is a platform call and stays outside the state lock: on iOS that lock is
+        // also taken from GMA callback threads (the rule NativePoolCore documents).
+        val resolvedSize = platform.resolveSize(sizePolicy, geometry.widthDp)
         platform.withStateLock {
-            registeredRequest = ResolvedBannerRequest(
-                size = platform.resolveSize(sizePolicy, geometry.widthDp),
-                sizePolicy = sizePolicy,
-                requestOptions = requestOptions.ownedSnapshot()
-            )
+            val existing = replayRequest
+            replayRequest = existing?.copy(size = resolvedSize, sizePolicy = sizePolicy)
+                ?: ResolvedBannerRequest(
+                    size = resolvedSize,
+                    sizePolicy = sizePolicy,
+                    requestOptions = requestOptions.ownedSnapshot()
+                )
         }
     }
 
@@ -200,7 +224,9 @@ internal class BannerCore<V : Any, S : Any>(
     ): V? = loadMutex.withLock {
         val previousAd = platform.withStateLock {
             if (generation != requiredGeneration) return@withStateLock null
-            lastRequest = resolved
+            // An actual load is the authoritative source for every field, request options
+            // included — unlike registerGeometry, which owns only the geometry-derived half.
+            replayRequest = resolved
             _loadState.value = AdLoadState.Loading
             // Box so a null previous ad is distinguishable from a stale generation.
             Box(banner)
@@ -240,10 +266,22 @@ internal class BannerCore<V : Any, S : Any>(
             )
             when (result) {
                 is AdAttemptResult.Success -> {
-                    val responseInfo = platform.responseInfo(result.value)
+                    // The handle is UNOWNED until the admission below stores it. responseInfo is
+                    // a platform SDK call and can throw — the catch(Throwable) at the bottom of
+                    // this try exists precisely because SDK accessors do. Without destroying here
+                    // the freshly loaded banner would be neither retained nor torn down: a leak
+                    // that survives for the process lifetime. FullScreenSlotCore already uses
+                    // this unowned-until-admitted shape; this restores the parity.
+                    val responseInfo = try {
+                        platform.responseInfo(result.value)
+                    } catch (t: Throwable) {
+                        safelyDestroy(result.value)
+                        throw t
+                    }
                     val accepted = platform.withStateLock {
                         if (generation != requiredGeneration) false else {
                             banner = result.value
+                            bannerResponseInfo = responseInfo
                             _loadState.value = AdLoadState.Loaded(responseInfo)
                             true
                         }
@@ -272,9 +310,7 @@ internal class BannerCore<V : Any, S : Any>(
             // Cancelled mid-load: the previously displayed ad (if any) stays as-is. If the
             // SDK still delivers the in-flight ad, the platform's own isActive guard
             // destroys it there, so nothing leaks.
-            platform.withStateLock {
-                if (generation == requiredGeneration) _loadState.value = AdLoadState.Idle
-            }
+            onCancelled(requiredGeneration)
             throw e
         } catch (t: Throwable) {
             // P1-1: only cancellation was handled, so a throw from a beta SDK call or a
@@ -314,27 +350,64 @@ internal class BannerCore<V : Any, S : Any>(
         generation++
         val retired = banner
         banner = null
-        lastRequest = null
-        registeredRequest = null
+        bannerResponseInfo = null
+        replayRequest = null
         _loadState.value = AdLoadState.Idle
         return retired
     }
 
     /**
+     * Terminal state for a cancelled load: derive it from what the core still OWNS.
+     *
+     * Publishing [AdLoadState.Idle] unconditionally (what this did before) contradicted the
+     * cancellation comment two lines up — the previous banner really does stay displayed, but
+     * `BannerAdView` reads Idle as "cleared/destroyed, drop the reference" and blanked the
+     * slot. A restarted `LaunchedEffect`, a resize or an explicit cancel would wipe a perfectly
+     * live ad. This is the same inventory-blindness [NativePoolCore.onCancelled] fixed for the
+     * pool (P1-3); the banner never got the matching fix.
+     */
+    private fun onCancelled(requiredGeneration: Long) {
+        platform.withStateLock {
+            if (generation != requiredGeneration) return@withStateLock
+            _loadState.value = if (banner != null) {
+                AdLoadState.Loaded(bannerResponseInfo)
+            } else {
+                AdLoadState.Idle
+            }
+        }
+    }
+
+    /**
      * Terminal state for an unexpected (non-cancellation) failure: keep reporting [Loaded]
      * when a banner is still displayed, otherwise publish [AdLoadState.Failed].
+     *
+     * Decision and publication happen in ONE lock acquisition. Splitting them let `clear()`
+     * — which takes only the state lock, never [loadMutex] — land in between, so recovery
+     * republished Loaded over a generation that had just been retired and drained.
      */
     private fun failOrRestore(requiredGeneration: Long, error: AdError): AdLoadState {
-        val displayed = platform.withStateLock {
-            if (generation == requiredGeneration) banner else null
-        }
-        return if (displayed != null) {
-            platform.withStateLock {
-                _loadState.value = AdLoadState.Loaded(platform.responseInfo(displayed))
+        val restored = platform.withStateLock {
+            if (generation == requiredGeneration && banner != null) {
+                _loadState.value = AdLoadState.Loaded(bannerResponseInfo)
+                true
+            } else {
+                false
             }
-            _loadState.value
-        } else {
-            failIfCurrent(requiredGeneration, error)
+        }
+        return if (restored) _loadState.value else failIfCurrent(requiredGeneration, error)
+    }
+
+    /**
+     * Teardown that cannot itself derail an in-flight failure path. Used where the core is
+     * discarding a banner it has decided not to own; a throwing `destroy` there would replace
+     * the original failure with a confusing secondary one. Mirrors
+     * `FullScreenSlotCore.safelyDestroyAd` and `NativePoolCore.safelyDestroy`.
+     */
+    private fun safelyDestroy(banner: V) {
+        try {
+            platform.destroy(banner)
+        } catch (t: Throwable) {
+            AdLogger.e("Failed to destroy banner for ${placement.id}.", t)
         }
     }
 

--- a/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/FullScreenPresentationArbiter.kt
+++ b/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/FullScreenPresentationArbiter.kt
@@ -1,3 +1,5 @@
+@file:OptIn(dev.avinya.ads.InternalAdMobCmpApi::class)
+
 package dev.avinya.ads.internal
 
 import dev.avinya.ads.AdFormat

--- a/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/FullScreenSlotCore.kt
+++ b/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/FullScreenSlotCore.kt
@@ -1,3 +1,5 @@
+@file:OptIn(dev.avinya.ads.InternalAdMobCmpApi::class)
+
 package dev.avinya.ads.internal
 
 import dev.avinya.ads.AdAttemptResult
@@ -131,6 +133,7 @@ internal abstract class FullScreenSlotCore<AdT : Any>(
     private val activePresentation = AtomicReference<FullScreenPresentationHandle?>(null)
     private val reloadJob = AtomicReference<Job?>(null)
     private val reloadScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private val orphanedAds = mutableListOf<AdT>()
 
     override val loadState: StateFlow<AdLoadState> = LoadStateFlow(slotState)
     override val events: SharedFlow<AdEvent> = _events
@@ -411,7 +414,8 @@ internal abstract class FullScreenSlotCore<AdT : Any>(
                     cache = emptyList()
                 )
                 if (slotState.compareAndSet(current, cleared)) {
-                    result = current.cache.map { it.ad }
+                    val retiredOrphans = orphanedAds.toList().also { orphanedAds.clear() }
+                    result = current.cache.map { it.ad } + retiredOrphans
                     break
                 }
             }
@@ -454,10 +458,11 @@ internal abstract class FullScreenSlotCore<AdT : Any>(
             // load fall through into the load loop on iOS. Equality against the data
             // object is compiled correctly on both backends.
             val isLoading = nextLoadState == AdLoadState.Loading
+            val retiredOrphans = orphanedAds.toList().also { orphanedAds.clear() }
             return LoadPreparation(
                 immediateResult = if (isLoading) null else nextLoadState,
                 slotsToLoad = if (isLoading) placement.cachePolicy.maxSize - fresh.size else 0,
-                retiredAds = expired.map { it.ad }
+                retiredAds = expired.map { it.ad } + retiredOrphans
             )
         }
     }
@@ -562,10 +567,14 @@ internal abstract class FullScreenSlotCore<AdT : Any>(
             // activePresentation is already set.
             val token = if (selected != null) {
                 arbiter.tryAcquire(placement.id, placement.format)
-                    ?: return ShowPreparation(
-                        immediateResult = AdShowResult.NotReady,
-                        retiredAds = expired.map { it.ad }
-                    )
+                    ?: run {
+                        val cleaned = SlotState(current.generation, current.loadState, fresh)
+                        if (!slotState.compareAndSet(current, cleaned)) continue
+                        return ShowPreparation(
+                            immediateResult = AdShowResult.NotReady,
+                            retiredAds = expired.map { it.ad }
+                        )
+                    }
             } else {
                 null
             }
@@ -628,7 +637,13 @@ internal abstract class FullScreenSlotCore<AdT : Any>(
             // parallel release mechanism exists or should be added.
             arbiter.release(token)
             activePresentation.compareAndSet(handle, null)
-            if (destroyAfterPresentation(wasShown)) safelyDestroyAd(ad)
+            if (destroyAfterPresentation(wasShown)) {
+                safelyDestroyAd(ad)
+            } else {
+                publicationLock.withLock {
+                    orphanedAds.add(ad)
+                }
+            }
             if (wasShown && placement.cachePolicy.reloadAfterShow) scheduleReload(generation)
         }
         activePresentation.store(handle)

--- a/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/FullScreenStateLock.kt
+++ b/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/FullScreenStateLock.kt
@@ -1,6 +1,17 @@
 package dev.avinya.ads.internal
 
-/** Small blocking lock for non-suspending full-screen state transitions, including clear(). */
+import dev.avinya.ads.InternalAdMobCmpApi
+
+/**
+ * Small blocking lock for non-suspending full-screen state transitions, including clear().
+ *
+ * Public only because `admob-cmp-compose` consumes it across the module boundary
+ * (`AdDebugRecorder`), which `internal` cannot express — not because it is a consumer API.
+ * It carries no ad semantics and its shape may change in any release. The ABI is frozen
+ * (invariant #12), so it cannot simply be withdrawn; [InternalAdMobCmpApi] is the additive,
+ * non-breaking way to stop it reading as supported surface.
+ */
+@InternalAdMobCmpApi
 public expect class FullScreenStateLock() {
     public fun <T> withLock(block: () -> T): T
 }

--- a/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/NativePoolCore.kt
+++ b/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/NativePoolCore.kt
@@ -186,7 +186,16 @@ internal class NativePoolCore<A : Any>(
         if (loaded.isEmpty()) {
             return failIfCurrent(requiredGeneration, AdError.message("No native ads returned."))
         }
-        val info = platform.responseInfo(loaded.first())
+        // The batch is UNOWNED until the pool admits it below. responseInfo is a platform SDK
+        // call and can throw — the catch(Throwable) in preload() names "a response-info
+        // accessor" as an expected thrower — and a throw here would strand every ad in the
+        // batch: never cached, never destroyed, never reachable again.
+        val info = try {
+            platform.responseInfo(loaded.first())
+        } catch (t: Throwable) {
+            loaded.forEach { safelyDestroy(it) }
+            throw t
+        }
         val rejected = mutableListOf<A>()
         val published = platform.withPoolLock {
             if (generation != requiredGeneration) {
@@ -303,14 +312,35 @@ internal class NativePoolCore<A : Any>(
      *
      * A top-up preload that blows up must not erase the fact that earlier ads are still
      * cached and servable — that is the same inventory-blindness P1-3 fixed for cancellation.
+     *
+     * The inventory check and the publication happen in ONE lock acquisition. Split across two,
+     * a `clear()` landing in between — it takes only the pool lock, never [loadMutex] — was
+     * republished over: the pool went Idle with an empty deque, then recovery put Loaded back
+     * from its stale decision.
      */
     private fun failOrRestore(requiredGeneration: Long, error: AdError): AdLoadState {
-        val hasInventory = platform.withPoolLock { generation == requiredGeneration && ads.isNotEmpty() }
-        return if (hasInventory) {
-            platform.withPoolLock { _loadState.value = AdLoadState.Loaded(lastResponseInfo) }
-            _loadState.value
-        } else {
-            failIfCurrent(requiredGeneration, error)
+        val restored = platform.withPoolLock {
+            if (generation == requiredGeneration && ads.isNotEmpty()) {
+                _loadState.value = AdLoadState.Loaded(lastResponseInfo)
+                true
+            } else {
+                false
+            }
+        }
+        return if (restored) _loadState.value else failIfCurrent(requiredGeneration, error)
+    }
+
+    /**
+     * Teardown that cannot itself derail an in-flight failure path. Used where the pool is
+     * discarding ads it has decided not to own; a throwing `destroy` there would replace the
+     * original failure with a confusing secondary one. Mirrors
+     * `FullScreenSlotCore.safelyDestroyAd`.
+     */
+    private fun safelyDestroy(ad: A) {
+        try {
+            platform.destroy(ad)
+        } catch (t: Throwable) {
+            AdLogger.e("Failed to destroy native ad for ${placement.id}.", t)
         }
     }
 

--- a/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/NoOpControllerRegistry.kt
+++ b/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/NoOpControllerRegistry.kt
@@ -1,3 +1,5 @@
+@file:OptIn(dev.avinya.ads.InternalAdMobCmpApi::class)
+
 package dev.avinya.ads.internal
 
 import dev.avinya.ads.*

--- a/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/AdConfigTest.kt
+++ b/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/AdConfigTest.kt
@@ -95,12 +95,16 @@ class AdConfigTest {
     }
 
     @Test
-    fun `testMode with only consent debug test device ids does not warn`() {
+    fun `testMode with only consent debug test device ids still warns`() {
+        // consentTestDeviceIds configures UMP consent debugging and NEVER reaches GMA's
+        // RequestConfiguration, so it is no evidence the device will be served test ads.
+        // This previously asserted the opposite and locked in a warning that failed open.
         val warning = config().copy(
             debugOptions = AdDebugOptions(testMode = true, consentTestDeviceIds = listOf("HASHED_ID"))
         ).testModeWarningOrNull()
 
-        assertNull(warning)
+        assertNotNull(warning, "UMP consent debug ids must not satisfy the GMA test-device check")
+        assertTrue(warning.contains("testDeviceIds"))
     }
 
     @Test

--- a/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/BannerCoreTest.kt
+++ b/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/BannerCoreTest.kt
@@ -2,7 +2,11 @@ package dev.avinya.ads
 
 import dev.avinya.ads.internal.BannerCore
 import dev.avinya.ads.internal.BannerPlatform
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -31,17 +35,43 @@ class BannerCoreTest {
         /** Runs between loadBanner being entered and it returning — lets a test detach mid-load. */
         var beforeReturn: (suspend () -> Unit)? = null
 
+        /**
+         * Fires once, immediately after the NEXT state-lock body completes.
+         *
+         * The seam for testing check-then-write races deterministically: it models a competing
+         * caller taking the state lock at the earliest legal moment after the core released it.
+         * A transition that decides under one acquisition and publishes under a second is
+         * observably broken here; one that does both under a single acquisition is not.
+         */
+        var afterUnlock: (() -> Unit)? = null
+
+        /** Set to make the response-info accessor throw, modelling a beta SDK accessor blowing up. */
+        var responseInfoError: Throwable? = null
+
         // No real lock: commonTest has no multiplatform `synchronized`, and these tests
         // drive the core from a single runTest coroutine. Invoking directly is also
         // trivially reentrant, which is what the seam requires.
-        override fun <T> withStateLock(block: () -> T): T = block()
+        override fun <T> withStateLock(block: () -> T): T {
+            val result = block()
+            afterUnlock?.let { hook ->
+                // One-shot, and cleared BEFORE invoking so a hook that itself takes the lock
+                // (clear() does) cannot re-enter itself.
+                afterUnlock = null
+                hook()
+            }
+            return result
+        }
+
         override fun fallbackWidthDp(): Int? = fallbackWidth
         override fun resolveSize(sizePolicy: AdSizePolicy, widthDp: Int): Int = widthDp
         override fun destroy(banner: FakeBanner) {
             banner.destroyCount++
         }
 
-        override fun responseInfo(banner: FakeBanner): AdResponseInfo? = null
+        override fun responseInfo(banner: FakeBanner): AdResponseInfo? {
+            responseInfoError?.let { throw it }
+            return null
+        }
         override suspend fun loadBanner(
             size: Int,
             sizePolicy: AdSizePolicy,
@@ -317,5 +347,166 @@ class BannerCoreTest {
         core.refresh { null }
 
         assertEquals(listOf<AdSizePolicy>(policy, policy), platform.loadedPolicies)
+    }
+
+    // The replay record has two owners: load() owns requestOptions (P1-4), the host's
+    // container measurement owns size/sizePolicy. These two tests pin BOTH halves. They must
+    // pass together — an implementation that picks one whole record over another (rather than
+    // merging per-owner on write) fails exactly one of them, which is how this regressed twice.
+
+    @Test
+    fun `registerGeometry after a load updates the replayed width`() = runTest {
+        val policy = AdSizePolicy.LargeAnchoredAdaptive()
+        val platform = FakeBannerPlatform()
+        val core = core(platform)
+
+        // Portrait: a real load resolves the request at 411dp.
+        core.load(BannerGeometry(411), policy, AdRequestOptions()) { null }
+        assertEquals(411, platform.lastSize)
+
+        // Rotate. The composable re-measures and registers the new geometry without loading.
+        core.registerGeometry(BannerGeometry(891), policy, AdRequestOptions())
+        core.refresh { null }
+
+        assertEquals(
+            891,
+            platform.lastSize,
+            "refresh() must replay the newest measured width, not the width of the last load"
+        )
+    }
+
+    @Test
+    fun `registerGeometry preserves the request options a load resolved`() = runTest {
+        val policy = AdSizePolicy.LargeAnchoredAdaptive()
+        val platform = FakeBannerPlatform()
+        val core = core(platform)
+        val custom = AdRequestOptions(keywords = setOf("premium"), contentUrl = "https://example.com")
+
+        // A real load resolves custom options that are NOT placement.requestOptions.
+        core.load(BannerGeometry(411), policy, custom) { null }
+
+        // The composable re-measures, passing the placement defaults — a re-measure is not a
+        // statement about request options and must not overwrite them.
+        core.registerGeometry(BannerGeometry(891), policy, AdRequestOptions())
+        core.refresh { null }
+
+        assertEquals(891, platform.lastSize, "geometry half must still update")
+        assertEquals(
+            custom,
+            platform.lastRequestOptions,
+            "refresh() must replay the options load() resolved, not the re-measure's defaults"
+        )
+    }
+
+    @Test
+    fun `registerGeometry seeds the replay record when no load has happened`() = runTest {
+        val policy = AdSizePolicy.LargeAnchoredAdaptive()
+        val platform = FakeBannerPlatform()
+        val core = core(platform)
+        val manualOptions = AdRequestOptions(keywords = setOf("manual"))
+
+        // BannerRefreshPolicy.Manual: the composable registers geometry and never loads, so
+        // registerGeometry is the only source of request options for the first refresh().
+        core.registerGeometry(BannerGeometry(411), policy, manualOptions)
+        core.refresh { null }
+
+        assertEquals(411, platform.lastSize)
+        assertEquals(manualOptions, platform.lastRequestOptions)
+    }
+
+    @Test
+    fun `cancelling a refresh keeps the displayed banner reported as Loaded`() = runTest {
+        val platform = FakeBannerPlatform()
+        val displayed = FakeBanner(320)
+        platform.nextResult = { AdAttemptResult.Success(displayed) }
+        val core = core(platform)
+        core.load(BannerGeometry(320), AdSizePolicy.LargeAnchoredAdaptive(), testRequestOptions()) { null }
+        assertTrue(core.loadState.value is AdLoadState.Loaded)
+
+        // A replacement load is cancelled mid-flight — a restarted LaunchedEffect, a resize,
+        // or an explicit cancel. The previously displayed banner is untouched and still on
+        // screen, so the published state must say so. Publishing Idle here made BannerAdView
+        // drop its reference and blank a live ad.
+        val job = launch {
+            platform.beforeReturn = { awaitCancellation() }
+            core.refresh { null }
+        }
+        // runCurrent, NOT advanceUntilIdle: advancing the virtual clock fires the 30s load
+        // timeout first, and the test would then pass through failOrRestore without ever
+        // exercising cancellation. The currentTime assertion below keeps that honest.
+        runCurrent()
+        job.cancelAndJoin()
+
+        assertEquals(0L, testScheduler.currentTime, "the load timeout must not have fired")
+        assertTrue(
+            core.loadState.value is AdLoadState.Loaded,
+            "cancellation must not report Idle while the core still owns a displayed banner"
+        )
+        assertEquals(0, displayed.destroyCount, "the displayed banner must survive the cancelled load")
+    }
+
+    @Test
+    fun `cancelling the first load with no displayed banner reports Idle`() = runTest {
+        val platform = FakeBannerPlatform()
+        val core = core(platform)
+
+        // The mirror case: nothing is owned, so Idle is the correct terminal state. Guards
+        // against "restore Loaded" over-correcting into a Loaded state with no ad behind it.
+        val job = launch {
+            platform.beforeReturn = { awaitCancellation() }
+            core.load(BannerGeometry(320), AdSizePolicy.LargeAnchoredAdaptive(), testRequestOptions()) { null }
+        }
+        runCurrent()
+        job.cancelAndJoin()
+
+        assertEquals(0L, testScheduler.currentTime, "the load timeout must not have fired")
+        assertEquals(AdLoadState.Idle, core.loadState.value)
+    }
+
+    @Test
+    fun `clear racing failed recovery does not resurrect Loaded`() = runTest {
+        val platform = FakeBannerPlatform()
+        val displayed = FakeBanner(320)
+        platform.nextResult = { AdAttemptResult.Success(displayed) }
+        val core = core(platform)
+        core.load(BannerGeometry(320), AdSizePolicy.LargeAnchoredAdaptive(), testRequestOptions()) { null }
+        assertTrue(core.loadState.value is AdLoadState.Loaded)
+
+        // The refresh fails. Arm clear() to land at the earliest legal moment after the
+        // recovery path's decision — the window a check-then-write failOrRestore left open.
+        // clear() retires and destroys the displayed banner and publishes Idle.
+        platform.nextResult = { AdAttemptResult.Failure(AdError.message("refresh failed")) }
+        platform.beforeReturn = { platform.afterUnlock = { core.clear() } }
+        core.refresh { null }
+
+        assertEquals(
+            AdLoadState.Idle,
+            core.loadState.value,
+            "a completed clear() must not be overwritten by recovery's stale banner check"
+        )
+        assertTrue(displayed.destroyed, "clear() still owns teardown of the retired banner")
+    }
+
+    @Test
+    fun `a throwing response info accessor destroys the banner it could not admit`() = runTest {
+        val platform = FakeBannerPlatform()
+        val loaded = FakeBanner(320)
+        platform.nextResult = { AdAttemptResult.Success(loaded) }
+        platform.responseInfoError = IllegalStateException("SDK accessor blew up")
+        val core = core(platform)
+
+        // The banner never reaches the `banner` field, so no later clear()/detach can reach
+        // it — the load path is its only chance at teardown. (runCatching, not assertFailsWith:
+        // the latter's block is not a suspend lambda, so load() cannot be called inside it.)
+        val thrown = runCatching {
+            core.load(BannerGeometry(320), AdSizePolicy.LargeAnchoredAdaptive(), testRequestOptions()) { null }
+        }
+        assertTrue(
+            thrown.exceptionOrNull() is IllegalStateException,
+            "the accessor's throwable must propagate, not be swallowed"
+        )
+
+        assertTrue(loaded.destroyed, "a banner that failed admission must not leak")
+        assertNull(core.currentBanner())
     }
 }

--- a/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/FullScreenSlotCoreOrphanDrainTest.kt
+++ b/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/FullScreenSlotCoreOrphanDrainTest.kt
@@ -1,0 +1,174 @@
+package dev.avinya.ads
+
+import dev.avinya.ads.internal.FullScreenPresentationArbiter
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class FullScreenSlotCoreOrphanDrainTest {
+
+    private val rewardedPlacement = testPlacement.copy(
+        format = AdFormat.Rewarded,
+        cachePolicy = AdCachePolicy(maxSize = 2)
+    )
+
+    @Test
+    fun `shown rewarded ad is retained until next load then destroyed`() = runTest(StandardTestDispatcher()) {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        try {
+            val globalEvents = testGlobalEvents()
+            var currentTime = Instant.fromEpochMilliseconds(1_000_000L)
+            val slot = FakeFullScreenSlot(
+                placement = rewardedPlacement,
+                globalEvents = globalEvents,
+                adRequestBlockedError = unblockedAdRequestError(),
+                clock = { currentTime }
+            )
+
+            slot.enqueueLoadResult(AdAttemptResult.Success("rewarded_ad_1"))
+            slot.enqueueShowResult(AdShowResult.Shown)
+
+            // 1. Load the rewarded ad
+            val loadResult1 = slot.load()
+            assertIs<AdLoadState.Loaded>(loadResult1)
+
+            // 2. Show the rewarded ad (destroyAfterPresentation returns false for shown rewarded ads)
+            val showResult = slot.showRewardedForTest(testPlacement.fullScreenOptions) { /* reward callback */ }
+            assertIs<AdShowResult.Shown>(showResult)
+
+            // The ad should not be destroyed immediately after show because destroyAfterPresentation(wasShown=true) is false
+            assertTrue(
+                "rewarded_ad_1" !in slot.destroyedAds,
+                "Shown rewarded ad must not be destroyed immediately to allow late reward callbacks"
+            )
+
+            // 3. Next load triggers prepareLoad, which drains orphanedAds
+            slot.enqueueLoadResult(AdAttemptResult.Success("rewarded_ad_2"))
+            val loadResult2 = slot.load()
+            assertIs<AdLoadState.Loaded>(loadResult2)
+
+            // Now rewarded_ad_1 should have been drained and destroyed during prepareLoad
+            assertTrue(
+                "rewarded_ad_1" in slot.destroyedAds,
+                "Orphaned rewarded ad must be destroyed on subsequent load"
+            )
+        } finally {
+            Dispatchers.resetMain()
+        }
+    }
+
+    @Test
+    fun `orphaned rewarded ad is destroyed when slot is cleared`() = runTest(StandardTestDispatcher()) {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        try {
+            val globalEvents = testGlobalEvents()
+            var currentTime = Instant.fromEpochMilliseconds(1_000_000L)
+            val slot = FakeFullScreenSlot(
+                placement = rewardedPlacement,
+                globalEvents = globalEvents,
+                adRequestBlockedError = unblockedAdRequestError(),
+                clock = { currentTime }
+            )
+
+            slot.enqueueLoadResult(AdAttemptResult.Success("rewarded_ad_1"))
+            slot.enqueueShowResult(AdShowResult.Shown)
+
+            slot.load()
+            slot.showRewardedForTest(testPlacement.fullScreenOptions) {}
+
+            assertTrue("rewarded_ad_1" !in slot.destroyedAds)
+
+            // Clear should drain orphanedAds
+            slot.clear()
+
+            assertTrue(
+                "rewarded_ad_1" in slot.destroyedAds,
+                "Orphaned rewarded ad must be destroyed when clear() is called"
+            )
+        } finally {
+            Dispatchers.resetMain()
+        }
+    }
+
+    @Test
+    fun `arbiter loss during prepareShow removes expired ads from cache and destroys them`() = runTest(StandardTestDispatcher()) {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        try {
+            val globalEvents = testGlobalEvents()
+            var currentTime = Instant.fromEpochMilliseconds(1_000_000L)
+            val sharedArbiter = FullScreenPresentationArbiter()
+
+            // Pre-acquire the arbiter so slot loses arbitration
+            val blockingToken = sharedArbiter.tryAcquire("other_slot", AdFormat.Interstitial)
+            requireNotNull(blockingToken)
+
+            val slot = FakeFullScreenSlot(
+                placement = rewardedPlacement,
+                globalEvents = globalEvents,
+                adRequestBlockedError = unblockedAdRequestError(),
+                clock = { currentTime },
+                arbiter = sharedArbiter
+            )
+
+            // Load 2 ads: ad_old at t=0, ad_new at t=30m
+            slot.enqueueLoadResult(AdAttemptResult.Success("ad_old"))
+            slot.enqueueLoadResult(AdAttemptResult.Failure(AdError.message("stop")))
+            slot.load()
+
+            currentTime += 30.minutes
+            slot.enqueueLoadResult(AdAttemptResult.Success("ad_new"))
+            slot.enqueueLoadResult(AdAttemptResult.Failure(AdError.message("stop")))
+            slot.load()
+
+            // Advance time to t=65m (past 1 hour TTL for ad_old at age 65m, but ad_new is only 35m old)
+            currentTime += 35.minutes
+
+            // Attempt show — arbiter will reject because blockingToken is held
+            val showResult = slot.show()
+            assertEquals(AdShowResult.NotReady, showResult)
+
+            // The expired ad (ad_old) must have been removed from cache and destroyed
+            assertTrue(
+                "ad_old" in slot.destroyedAds,
+                "Expired ad should be destroyed when prepareShow handles arbiter loss"
+            )
+            assertTrue(
+                "ad_new" !in slot.destroyedAds,
+                "Fresh ad must remain in cache and not be destroyed"
+            )
+
+            // Release arbiter and verify ad_new can still be presented
+            sharedArbiter.release(blockingToken)
+            slot.enqueueShowResult(AdShowResult.Shown)
+            val showResult2 = slot.show()
+            assertEquals(AdShowResult.Shown, showResult2)
+            assertEquals(listOf("ad_new"), slot.presentedAds)
+
+            // The actual defect was destroying an ad that was never removed from the cache, so
+            // a later partition destroyed it a second time. Membership alone cannot see that —
+            // this counts. clear() re-partitions whatever the cache still holds.
+            slot.clear()
+            assertEquals(
+                1,
+                slot.destroyedAds.count { it == "ad_old" },
+                "ad_old must be destroyed exactly once: the arbiter-loss path has to remove it " +
+                    "from the cache in the same CAS that retires it, or a later partition " +
+                    "destroys it again. Destroys were: ${slot.destroyedAds}"
+            )
+        } finally {
+            Dispatchers.resetMain()
+        }
+    }
+}

--- a/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/NativePoolCoreTest.kt
+++ b/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/NativePoolCoreTest.kt
@@ -28,6 +28,19 @@ internal class FakeNativePlatform(
     /** Set to run arbitrary code (e.g. core.clear()) between the loader being invoked and it returning. */
     var beforeReturn: (suspend () -> Unit)? = null
 
+    /**
+     * Fires once, immediately after the NEXT pool-lock body completes.
+     *
+     * This is the seam for testing check-then-write races deterministically: it models a
+     * competing caller acquiring the pool lock at the earliest legal moment after the core
+     * released it. A transition that reads state under one acquisition and publishes under a
+     * second is observably broken here; a transition that does both under one is not.
+     */
+    var afterUnlock: (() -> Unit)? = null
+
+    /** Set to make the response-info accessor throw, modelling a beta SDK accessor blowing up. */
+    var responseInfoError: Throwable? = null
+
     fun enqueue(result: AdAttemptResult<List<FakeAd>>) {
         batches += result
     }
@@ -36,7 +49,10 @@ internal class FakeNativePlatform(
         ad.destroyed = true
     }
 
-    override fun responseInfo(ad: FakeAd): AdResponseInfo? = null
+    override fun responseInfo(ad: FakeAd): AdResponseInfo? {
+        responseInfoError?.let { throw it }
+        return null
+    }
 
     override fun mediaInfo(ad: FakeAd): NativeMediaInfo? = null
 
@@ -56,7 +72,16 @@ internal class FakeNativePlatform(
     // core from a single runTest coroutine. Invoking directly is also trivially reentrant,
     // which is the property the seam actually requires (see NativePoolPlatform.withPoolLock).
     // The real locking contract is exercised by the platform pools, not here.
-    override fun <T> withPoolLock(block: () -> T): T = block()
+    override fun <T> withPoolLock(block: () -> T): T {
+        val result = block()
+        afterUnlock?.let { hook ->
+            // One-shot, and cleared BEFORE invoking so a hook that itself takes the lock
+            // (clear() does) cannot re-enter itself.
+            afterUnlock = null
+            hook()
+        }
+        return result
+    }
 }
 
 class NativePoolCoreTest {
@@ -357,5 +382,50 @@ class NativePoolCoreTest {
         val impression = seen.single { it is AdEvent.Impression } as AdEvent.Impression
         assertNull(impression.adInstanceId, "an untracked ad must not be attributed a stale token")
         collector.cancel()
+    }
+
+    @Test
+    fun `clear racing failed recovery does not resurrect Loaded`() = runTest {
+        val platform = FakeNativePlatform()
+        platform.enqueue(AdAttemptResult.Success(listOf(FakeAd(1), FakeAd(2))))
+        val pool = core(platform)
+        pool.preload(2, testRequestOptions(), testNativeOptions())
+        assertTrue(pool.loadState.value is AdLoadState.Loaded)
+
+        // Second (top-up) preload fails. Arm clear() to land at the earliest legal moment
+        // after the recovery path's decision — i.e. exactly in the window a check-then-write
+        // failOrRestore left open. clear() drains inventory, bumps the generation and
+        // publishes Idle; recovery must not overwrite that from its stale decision.
+        platform.enqueue(AdAttemptResult.Failure(AdError.message("top-up failed")))
+        platform.beforeReturn = { platform.afterUnlock = { pool.clear() } }
+        pool.preload(3, testRequestOptions(), testNativeOptions())
+
+        assertEquals(
+            AdLoadState.Idle,
+            pool.loadState.value,
+            "a completed clear() must not be overwritten by recovery's stale inventory check"
+        )
+        assertEquals(0, pool.availableCount())
+    }
+
+    @Test
+    fun `a throwing response info accessor destroys the batch it could not admit`() = runTest {
+        val platform = FakeNativePlatform()
+        val ads = listOf(FakeAd(1), FakeAd(2))
+        platform.enqueue(AdAttemptResult.Success(ads))
+        platform.responseInfoError = IllegalStateException("SDK accessor blew up")
+        val pool = core(platform)
+
+        // The ads never enter pool ownership, so nothing else can ever destroy them —
+        // admit() is their only chance. (runCatching, not assertFailsWith: the latter's block
+        // is not a suspend lambda, so preload() cannot be called inside it.)
+        val thrown = runCatching { pool.preload(2, testRequestOptions(), testNativeOptions()) }
+        assertTrue(
+            thrown.exceptionOrNull() is IllegalStateException,
+            "the accessor's throwable must propagate, not be swallowed"
+        )
+
+        assertTrue(ads.all { it.destroyed }, "ads that failed admission must not leak")
+        assertEquals(0, pool.availableCount())
     }
 }

--- a/admob-cmp-core/src/iosMain/kotlin/dev/avinya/ads/IosBannerAdController.kt
+++ b/admob-cmp-core/src/iosMain/kotlin/dev/avinya/ads/IosBannerAdController.kt
@@ -20,6 +20,10 @@ import kotlinx.coroutines.withContext
 import kotlinx.cinterop.CValue
 import platform.Foundation.NSError
 import platform.Foundation.NSRecursiveLock
+import platform.UIKit.UIApplication
+import platform.UIKit.UISceneActivationStateForegroundActive
+import platform.UIKit.UIWindow
+import platform.UIKit.UIWindowScene
 import platform.darwin.NSObject
 import kotlin.native.ref.WeakReference
 import kotlinx.cinterop.ExperimentalForeignApi
@@ -92,8 +96,9 @@ internal class IosBannerAdController internal constructor(
 
     override fun destroy(banner: IosLoadedBanner) = teardownBanner(banner.view)
 
-    override fun responseInfo(banner: IosLoadedBanner): AdResponseInfo? =
-        banner.view.responseInfo?.toCommon()
+    // Pure field read of a value snapshotted on Main at load time, so this is safe to call
+    // from whatever dispatcher BannerCore's caller resumed on.
+    override fun responseInfo(banner: IosLoadedBanner): AdResponseInfo? = banner.responseInfo
 
     override suspend fun loadBanner(
         size: CValue<GADAdSize>,
@@ -106,12 +111,28 @@ internal class IosBannerAdController internal constructor(
             val result = suspendCancellableCoroutine<AdAttemptResult<IosLoadedBanner>> { continuation ->
                 val banner = GADBannerView(size)
                 banner.adUnitID = placement.iosAdUnitId
-                banner.rootViewController = topViewController()
+                val windowScene = UIApplication.sharedApplication.connectedScenes
+                    .filterIsInstance<UIWindowScene>()
+                    .firstOrNull { it.activationState == UISceneActivationStateForegroundActive }
+                    ?: UIApplication.sharedApplication.connectedScenes.filterIsInstance<UIWindowScene>().firstOrNull()
+                val rootVC = (windowScene?.keyWindow
+                    ?: windowScene?.windows?.filterIsInstance<UIWindow>()?.firstOrNull())
+                    ?.rootViewController
+                banner.rootViewController = rootVC ?: topViewController()
                 lateinit var bannerDelegate: BannerDelegate
                 bannerDelegate = BannerDelegate(
                     onLoaded = {
                         if (continuation.isActive) {
-                            continuation.resume(AdAttemptResult.Success(IosLoadedBanner(banner, bannerDelegate)))
+                            // Capture response info HERE, on Main. GADBannerView is a UIView, and
+                            // BannerCore resumes on whatever dispatcher its caller used — reading
+                            // `.responseInfo` there was a UIKit property access off the main
+                            // thread (CLAUDE.md invariant #5). It is fixed once loaded, so
+                            // snapshotting it loses nothing.
+                            continuation.resume(
+                                AdAttemptResult.Success(
+                                    IosLoadedBanner(banner, bannerDelegate, banner.responseInfo?.toCommon())
+                                )
+                            )
                         }
                     },
                     onFailedToLoad = { error ->
@@ -192,7 +213,12 @@ internal class IosBannerAdController internal constructor(
 }
 
 /** Banner handle: the view plus the strong delegate reference it needs to outlive it. */
-internal data class IosLoadedBanner(val view: GADBannerView, val delegate: BannerDelegate)
+internal data class IosLoadedBanner(
+    val view: GADBannerView,
+    val delegate: BannerDelegate,
+    /** Snapshotted on Main at load time — see the capture site in `loadBanner`. */
+    val responseInfo: AdResponseInfo?,
+)
 
 internal class BannerDelegate(
     private val onLoaded: () -> Unit,

--- a/admob-cmp-core/src/iosMain/kotlin/dev/avinya/ads/IosFullScreenSlots.kt
+++ b/admob-cmp-core/src/iosMain/kotlin/dev/avinya/ads/IosFullScreenSlots.kt
@@ -211,8 +211,9 @@ internal class IosRewardedSlot(
             if (presentation.tryHandOffToCallbacks()) {
                 delegates.retain(loaded, delegate)
                 loaded.fullScreenContentDelegate = delegate
+                val weakLoaded = WeakReference(loaded)
                 loaded.presentFromRootViewController(rootVC) {
-                    val adReward = loaded.adReward
+                    val adReward = weakLoaded.value?.adReward
                     if (adReward != null) {
                         // amount is an NSDecimalNumber and may be fractional (P1-14 established
                         // the exact-decimal pattern for paid values; reuse it here so a mediated
@@ -324,8 +325,9 @@ internal class IosRewardedInterstitialSlot(
             if (presentation.tryHandOffToCallbacks()) {
                 delegates.retain(loaded, delegate)
                 loaded.fullScreenContentDelegate = delegate
+                val weakLoaded = WeakReference(loaded)
                 loaded.presentFromRootViewController(rootVC) {
-                    val adReward = loaded.adReward
+                    val adReward = weakLoaded.value?.adReward
                     if (adReward != null) {
                         // amount is an NSDecimalNumber and may be fractional (P1-14 established
                         // the exact-decimal pattern for paid values; reuse it here so a mediated

--- a/admob-cmp-core/src/iosMain/kotlin/dev/avinya/ads/RootViewController.kt
+++ b/admob-cmp-core/src/iosMain/kotlin/dev/avinya/ads/RootViewController.kt
@@ -19,8 +19,11 @@ internal fun topViewController(): UIViewController? {
         ?: return null
     var top = window.rootViewController ?: return null
     while (top.presentedViewController != null) {
-        top = top.presentedViewController!!
+        val presented = top.presentedViewController!!
+        if (presented.isBeingDismissed()) break
+        top = presented
     }
+    if (top.isBeingDismissed() || top.isBeingPresented()) return null
     return top
 }
 

--- a/admob-cmp-core/src/iosMain/kotlin/dev/avinya/ads/internal/FullScreenStateLock.ios.kt
+++ b/admob-cmp-core/src/iosMain/kotlin/dev/avinya/ads/internal/FullScreenStateLock.ios.kt
@@ -2,8 +2,10 @@
 
 package dev.avinya.ads.internal
 
+import dev.avinya.ads.InternalAdMobCmpApi
 import platform.Foundation.NSRecursiveLock
 
+@InternalAdMobCmpApi
 public actual class FullScreenStateLock public actual constructor() {
     private val lock = NSRecursiveLock()
 

--- a/admob-cmp-core/src/iosMain/kotlin/dev/avinya/ads/nativead/IosNativeAdPool.kt
+++ b/admob-cmp-core/src/iosMain/kotlin/dev/avinya/ads/nativead/IosNativeAdPool.kt
@@ -10,6 +10,7 @@ import dev.avinya.ads.InternalAdMobCmpApi
 import GoogleMobileAds.GADAdChoicesPosition
 import GoogleMobileAds.GADAdLoader
 import GoogleMobileAds.GADAdLoaderAdTypeNative
+import GoogleMobileAds.GADMediaContent
 import GoogleMobileAds.GADMultipleAdsAdLoaderOptions
 import GoogleMobileAds.GADNativeAd
 import GoogleMobileAds.GADNativeAdDelegateProtocol
@@ -105,19 +106,12 @@ internal class IosNativeAdPool(
     // deterministic ad.destroy() the Android pool performs on the same paths.
     override fun destroy(ad: LoadedNativeAd) = teardownNativeAdOnMain(ad.ad)
 
-    override fun responseInfo(ad: LoadedNativeAd): AdResponseInfo? = ad.ad.responseInfo?.toCommon()
+    // Both accessors are pure field reads of values snapshotted on Main at load time, so they
+    // are safe from whatever dispatcher the caller uses. The core resolves the handle under the
+    // pool lock and calls these outside it.
+    override fun responseInfo(ad: LoadedNativeAd): AdResponseInfo? = ad.responseInfo
 
-    // The core resolves the handle under the pool lock and calls this outside it. The
-    // previous shape returned non-locally from inside the inline locked{} lambda — correct
-    // only because locked is inline, and silently broken if that ever changed.
-    override fun mediaInfo(ad: LoadedNativeAd): NativeMediaInfo? {
-        val mediaContent = ad.ad.mediaContent ?: return null
-        return NativeMediaInfo(
-            aspectRatio = mediaContent.aspectRatio.takeIf { it > 0.0 }?.toFloat(),
-            hasVideoContent = mediaContent.hasVideoContent,
-            durationSeconds = if (mediaContent.duration > 0f) mediaContent.duration.toDouble() else null
-        )
-    }
+    override fun mediaInfo(ad: LoadedNativeAd): NativeMediaInfo? = ad.mediaInfo
 
     override suspend fun loadBatch(
         count: Int,
@@ -209,7 +203,20 @@ internal class IosNativeAdPool(
     private data class NativeLoadBatch(val loader: GADAdLoader, val delegate: NativeAdLoaderDelegate)
 }
 
-internal class LoadedNativeAd(val ad: GADNativeAd, val delegates: List<NSObject>)
+internal class LoadedNativeAd(
+    val ad: GADNativeAd,
+    val delegates: List<NSObject>,
+    /** Snapshotted on Main at load time — see the capture site in the loader delegate. */
+    val responseInfo: AdResponseInfo?,
+    /** Snapshotted on Main at load time — see the capture site in the loader delegate. */
+    val mediaInfo: NativeMediaInfo?,
+)
+
+private fun GADMediaContent.toNativeMediaInfo(): NativeMediaInfo = NativeMediaInfo(
+    aspectRatio = aspectRatio.takeIf { it > 0.0 }?.toFloat(),
+    hasVideoContent = hasVideoContent,
+    durationSeconds = if (duration > 0f) duration.toDouble() else null
+)
 
 internal class NativeAdLoaderDelegate(
     private val placementId: String,
@@ -295,7 +302,7 @@ internal class NativeAdLoaderDelegate(
             val ad = weakAd.value
             val adValue = value?.toCommon()
             if (ad != null && adValue != null) {
-                emitInstanceScoped({ it.ad === didReceiveNativeAd }) { id ->
+                emitInstanceScoped({ it.ad === ad }) { id ->
                     AdEvent.Paid(placementId, PaidEvent(placementId, adValue, ad.responseInfo?.toCommon()), id)
                 }
             }
@@ -309,7 +316,16 @@ internal class NativeAdLoaderDelegate(
             mc.videoController.delegate = videoDelegate
             delegates.add(videoDelegate)
         }
-        val loaded = LoadedNativeAd(didReceiveNativeAd, delegates)
+        // Snapshot response/media info HERE, on the Main-confined delegate callback.
+        // NativePoolCore reads them back from an arbitrary dispatcher (mediaInfo() is even
+        // public, non-suspend API), which put GMA accesses off Main — CLAUDE.md invariant #5.
+        // Both are fixed once the ad is loaded.
+        val loaded = LoadedNativeAd(
+            ad = didReceiveNativeAd,
+            delegates = delegates,
+            responseInfo = didReceiveNativeAd.responseInfo?.toCommon(),
+            mediaInfo = mc?.toNativeMediaInfo()
+        )
         // Atomically check cancellation and add: if already cancelled/inactive, tear down
         // this ad instead of leaking it into a list nothing will drain.
         val accepted = locked {

--- a/admob-cmp-gradle-plugin/gradle.properties
+++ b/admob-cmp-gradle-plugin/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=dev.avinya.ads
-VERSION_NAME=1.1.0
+VERSION_NAME=1.1.1
 POM_ARTIFACT_ID=admob-cmp-gradle-plugin
 POM_NAME=AdMob CMP Gradle Plugin
 POM_DESCRIPTION=Links Google Mobile Ads and UMP into Kotlin/Native test executables for Kotlin Multiplatform consumers of admob-cmp, fixing "Undefined symbols: _OBJC_CLASS_$_GAD*" at iOS test link time. Not affiliated with or endorsed by Google. AdMob and Google Mobile Ads are trademarks of Google LLC.

--- a/admob-cmp-gradle-plugin/src/main/kotlin/dev/avinya/ads/gradle/AdMobCmpPlugin.kt
+++ b/admob-cmp-gradle-plugin/src/main/kotlin/dev/avinya/ads/gradle/AdMobCmpPlugin.kt
@@ -29,22 +29,34 @@ public abstract class AdMobCmpPlugin : Plugin<Project> {
             val downloadGma = target.tasks.register("downloadGmaIos", DownloadIosFramework::class.java) {
                 description = "Download the Google Mobile Ads iOS XCFramework (test linking only)"
                 group = "ios-setup"
-                baseUrl.set(GMA_DOWNLOAD_BASE)
-                version.set(AdMobCmpNativeDeps.gmaIosVersion)
-                expectedSha256.set(AdMobCmpNativeDeps.gmaIosSha256)
-                markerFile.set(frameworksDir.map { d ->
-                    d.file("GoogleMobileAds.xcframework/.gma_downloaded")
-                })
+                baseUrl.set(
+                    target.providers.gradleProperty("admobCmp.ios.baseUrl").orElse(GMA_DOWNLOAD_BASE)
+                )
+                version.set(
+                    target.providers.gradleProperty("admobCmp.gma.ios.version").orElse(AdMobCmpNativeDeps.gmaIosVersion)
+                )
+                expectedSha256.set(
+                    target.providers.gradleProperty("admobCmp.gma.ios.sha256").orElse(AdMobCmpNativeDeps.gmaIosSha256)
+                )
+                // frameworkDir is the tracked output; the marker is derived from it so the two
+                // can never drift apart.
+                frameworkDir.set(frameworksDir.map { d -> d.dir("GoogleMobileAds.xcframework") })
+                markerFile.set(frameworkDir.file(".gma_downloaded"))
             }
             val downloadUmp = target.tasks.register("downloadUmpIos", DownloadIosFramework::class.java) {
                 description = "Download the User Messaging Platform iOS XCFramework (test linking only)"
                 group = "ios-setup"
-                baseUrl.set(GMA_DOWNLOAD_BASE)
-                version.set(AdMobCmpNativeDeps.gmaUmpIosVersion)
-                expectedSha256.set(AdMobCmpNativeDeps.umpIosSha256)
-                markerFile.set(frameworksDir.map { d ->
-                    d.file("UserMessagingPlatform.xcframework/.ump_downloaded")
-                })
+                baseUrl.set(
+                    target.providers.gradleProperty("admobCmp.ios.baseUrl").orElse(GMA_DOWNLOAD_BASE)
+                )
+                version.set(
+                    target.providers.gradleProperty("admobCmp.ump.ios.version").orElse(AdMobCmpNativeDeps.gmaUmpIosVersion)
+                )
+                expectedSha256.set(
+                    target.providers.gradleProperty("admobCmp.ump.ios.sha256").orElse(AdMobCmpNativeDeps.umpIosSha256)
+                )
+                frameworkDir.set(frameworksDir.map { d -> d.dir("UserMessagingPlatform.xcframework") })
+                markerFile.set(frameworkDir.file(".ump_downloaded"))
             }
 
             val kotlin = target.extensions.getByType(KotlinMultiplatformExtension::class.java)

--- a/admob-cmp-gradle-plugin/src/main/kotlin/dev/avinya/ads/gradle/DownloadIosFramework.kt
+++ b/admob-cmp-gradle-plugin/src/main/kotlin/dev/avinya/ads/gradle/DownloadIosFramework.kt
@@ -7,10 +7,12 @@ import java.security.MessageDigest
 import java.util.zip.ZipInputStream
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import org.gradle.work.DisableCachingByDefault
 
@@ -27,19 +29,41 @@ public abstract class DownloadIosFramework : DefaultTask() {
     @get:Input
     public abstract val expectedSha256: Property<String>
 
-    @get:OutputFile
+    /**
+     * The extracted `<name>.xcframework` directory — the task's real product.
+     *
+     * Declaring only the marker as an `@OutputFile` tracked that one file and nothing else, so
+     * deleting an architecture slice or truncating a binary left the marker intact, the task
+     * UP-TO-DATE, and the damage to surface downstream in cinterop or the native link instead.
+     * An `@OutputDirectory` fingerprints the tree, so any damage inside it re-runs extraction.
+     *
+     * Deliberately the per-framework directory, NOT the shared parent both download tasks
+     * extract into: declaring the parent would make the two tasks overlap on outputs.
+     */
+    @get:OutputDirectory
+    public abstract val frameworkDir: DirectoryProperty
+
+    /**
+     * Records the catalog version the tree was extracted from, so a version bump invalidates it.
+     * Lives inside [frameworkDir] and is therefore already covered by that output; `@Internal`
+     * keeps it from being declared twice.
+     */
+    @get:Internal
     public abstract val markerFile: RegularFileProperty
 
     @TaskAction
     fun download() {
         val mf = markerFile.get().asFile
-        // The marker stores the version it was extracted from, so a catalog bump
-        // invalidates the cache instead of silently keeping stale frameworks.
-        if (mf.exists() && mf.readText().trim() == version.get()) return
-        val frameworksBase = mf.parentFile.parentFile
-        mf.parentFile.deleteRecursively()
-        mf.parentFile.mkdirs()
-        val baseName = mf.parentFile.name
+        val fwDir = frameworkDir.get().asFile
+        // The marker records the version, but it is NOT evidence the extraction is intact — a
+        // deleted slice leaves it untouched. Gradle re-runs this task when the output tree
+        // changes; short-circuiting on the marker alone would skip the very repair it was
+        // re-run to perform. Both conditions must hold.
+        if (mf.exists() && mf.readText().trim() == version.get() && expectedSlice(fwDir).isDirectory) return
+        val frameworksBase = fwDir.parentFile
+        fwDir.deleteRecursively()
+        fwDir.mkdirs()
+        val baseName = fwDir.name
         // Note: the UMP zip URL is not version-pinned by Google; the marker records
         // the catalog version that triggered the download.
         val zipPath = when {
@@ -89,10 +113,13 @@ public abstract class DownloadIosFramework : DefaultTask() {
                 }
             }
         }
-        if (!File(mf.parentFile, "ios-arm64").exists()) {
-            throw GradleException("Extraction did not produce ${mf.parentFile}/ios-arm64 — zip layout changed?")
+        if (!expectedSlice(fwDir).exists()) {
+            throw GradleException("Extraction did not produce ${expectedSlice(fwDir)} — zip layout changed?")
         }
         mf.writeText(version.get())
-        logger.lifecycle("Extracted to ${mf.parentFile}")
+        logger.lifecycle("Extracted to $fwDir")
     }
+
+    /** The slice whose presence stands in for "the extraction produced a usable framework". */
+    private fun expectedSlice(fwDir: File): File = File(fwDir, "ios-arm64")
 }

--- a/admob-cmp/CLAUDE.md
+++ b/admob-cmp/CLAUDE.md
@@ -56,8 +56,10 @@ AGENTS.md, not this file.
 4. **iOS ObjC delegates are weak.** Keep a strong Kotlin ref alongside the ad
    (pool `NativeEntry`, slot `delegate` fields); capture ads in paid-event
    handlers via `WeakReference` to avoid ARC cycles.
-5. **All GMA/UMP calls happen on `Dispatchers.Main`** (`.immediate`). The consent
-   gate (`adRequestBlockedError()`) is checked in **both** `load()` and `show()`,
+5. **All GMA/UMP calls happen on `Dispatchers.Main`** (`.immediate`), **except
+   `MobileAds.initialize()` which is `@WorkerThread` in GMA Next-Gen and runs on
+   `Dispatchers.IO`** (its completion callback fires on Main regardless of calling thread).
+   The consent gate (`adRequestBlockedError()`) is checked in **both** `load()` and `show()`,
    and `canPresent()` is re-checked at present time — don't remove either check.
 6. **Banner controllers have no layout context.** Geometry is host-supplied:
    `load(geometry: BannerGeometry?, …)` takes the width, and `BannerAdView` measures

--- a/admob-cmp/README.md
+++ b/admob-cmp/README.md
@@ -15,7 +15,7 @@ stream. See [Architecture](https://ads.avinya.dev/reference/architecture/) for t
 
 ```kotlin
 // commonMain
-implementation("dev.avinya.ads:admob-cmp:1.1.0")
+implementation("dev.avinya.ads:admob-cmp:1.1.1")
 ```
 
 If your project runs Kotlin/Native tests (`:yourModule:iosSimulatorArm64Test`), also apply
@@ -23,7 +23,7 @@ the Gradle plugin — without it the test link fails on `Undefined symbols … _
 
 ```kotlin
 plugins {
-    id("dev.avinya.ads.admob-cmp") version "1.1.0"
+    id("dev.avinya.ads.admob-cmp") version "1.1.1"
 }
 ```
 
@@ -42,6 +42,7 @@ compatible compiler.
 
 | admob-cmp | Kotlin | Compose Multiplatform | Android minSdk | iOS deployment target |
 |---|---|---|---|---|
+| 1.1.1 | 2.3.20 | 1.11.1 | 26 | 15.0 |
 | 1.1.0 | 2.3.20 | 1.11.1 | 26 | 15.0 |
 | 1.0.2 | 2.3.20 | 1.11.1 | 26 | 15.0 |
 | 1.0.0 | 2.3.20 | 1.11.1 | 26 | 15.0 |

--- a/docs-site/src/content/docs/index.mdx
+++ b/docs-site/src/content/docs/index.mdx
@@ -42,7 +42,7 @@ The SDK provides a single-coordinate facade (`dev.avinya.ads:admob-cmp`) for And
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            implementation("dev.avinya.ads:admob-cmp:1.1.0")
+            implementation("dev.avinya.ads:admob-cmp:1.1.1")
         }
     }
 }

--- a/docs-site/src/content/docs/reference/changelog.mdx
+++ b/docs-site/src/content/docs/reference/changelog.mdx
@@ -12,17 +12,27 @@ import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
 All published artifacts live under `dev.avinya.ads` on Maven Central:
 `admob-cmp`, `admob-cmp-core`, `admob-cmp-compose`, and the
 `dev.avinya.ads.admob-cmp.gradle.plugin` marker. The current
-release is **1.1.0**.
+release is **1.1.1**.
 
 | Version | Status | Highlights |
 |---|---|---|
-| 1.1.0 | Current | Gradle test plugin, explicit banner geometry inputs, refresh option replaying |
+| 1.1.1 | Current | Banner and native state-machine fixes, main-thread confinement of SDK metadata reads, stricter test-mode warning |
+| 1.1.0 | Superseded | Gradle test plugin, explicit banner geometry inputs, refresh option replaying |
 | 1.0.2 | Superseded | Module split into `admob-cmp-core` and `admob-cmp-compose` |
 | 1.0.1 | Superseded | Maintenance and bug-fix release |
 | 1.0.0 | Superseded | Initial public release of `dev.avinya.ads:admob-cmp` |
 
 Release details and release assets for all versions are published on the
 [GitHub releases page](https://github.com/Meet-Miyani/admob-compose-multiplatform/releases).
+
+## What changed in 1.1.1?
+
+- **Cancelled banner loads no longer blank a live ad:** cancelling a banner load or refresh — a restarted effect, a resize, an explicit cancel — published `Idle`, which `BannerAdView` reads as "the ad is gone". A banner that was still loaded and on screen disappeared. The published state is now derived from the ad the controller actually still owns. See [Banner ads](/formats/banner/).
+- **Ad state can no longer be resurrected after `clear()`:** the banner controller and native pool published their post-failure recovery state across two separate lock acquisitions, so a `clear()` landing in between was overwritten and the state reported `Loaded` for inventory that had just been released. Both now transition atomically.
+- **Ads are no longer leaked when metadata reads fail:** if a platform response-info accessor threw after a successful load, the newly loaded banner or native batch was neither retained nor destroyed. Such ads are now torn down.
+- **Ad SDK metadata is read on the main thread:** response and media info are captured while still on the main thread during load, rather than read back later from whichever dispatcher the caller used. `NativeAdPool.mediaInfo(token)` is consequently safe to call from any thread; its value is a load-time snapshot.
+- **`testMode` warning no longer suppressed by consent debug IDs:** `AdDebugOptions.consentTestDeviceIds` configures UMP consent debugging only and never registers a GMA test device, so it no longer counts as evidence that test ads will be served. Configurations relying on it now correctly warn that live ads may be requested. See [Test ads and safety](/reference/compatibility/).
+- **`AdPlacements` is genuinely immutable:** the placement list is copied at construction, so it can no longer be mutated behind Compose's back after being marked `@Immutable`.
 
 ## What changed in 1.1.0?
 

--- a/docs-site/src/content/docs/reference/compatibility.mdx
+++ b/docs-site/src/content/docs/reference/compatibility.mdx
@@ -14,6 +14,7 @@ Every row in the matrix reflects the exact toolchain and platform SDK bindings p
 
 | `admob-cmp` | Kotlin | Compose Multiplatform | Android `minSdk` | iOS deployment target |
 |---|---|---|---|---|
+| 1.1.1 | 2.3.20 | 1.11.1 | 26 | 15.0 |
 | 1.1.0 | 2.3.20 | 1.11.1 | 26 | 15.0 |
 | 1.0.2 | 2.3.20 | 1.11.1 | 26 | 15.0 |
 | 1.0.1 | 2.3.20 | 1.11.1 | 26 | 15.0 |

--- a/docs-site/src/content/docs/reference/troubleshooting.mdx
+++ b/docs-site/src/content/docs/reference/troubleshooting.mdx
@@ -25,7 +25,7 @@ Applying the `dev.avinya.ads.admob-cmp` Gradle plugin resolves this issue automa
 ```kotlin
 // shared/build.gradle.kts
 plugins {
-    id("dev.avinya.ads.admob-cmp") version "1.1.0"
+    id("dev.avinya.ads.admob-cmp") version "1.1.1"
 }
 ```
 

--- a/docs-site/src/content/docs/start/android-setup.mdx
+++ b/docs-site/src/content/docs/start/android-setup.mdx
@@ -55,7 +55,7 @@ Removing `AD_ID` disables access to the device advertising identifier on Android
 
 ## Android build requirements
 
-AdMob CMP 1.1.0 is built and tested against the following toolchain specifications:
+AdMob CMP 1.1.1 is built and tested against the following toolchain specifications:
 
 | Setting | Tested Version / Specification |
 |---|---|

--- a/docs-site/src/content/docs/start/installation.mdx
+++ b/docs-site/src/content/docs/start/installation.mdx
@@ -38,7 +38,7 @@ Most Compose Multiplatform applications should depend on the umbrella coordinate
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            implementation("dev.avinya.ads:admob-cmp:1.1.0")
+            implementation("dev.avinya.ads:admob-cmp:1.1.1")
         }
     }
 }
@@ -50,8 +50,8 @@ The umbrella artifact includes both `admob-cmp-core` and `admob-cmp-compose`.
 
 For projects that do not use Compose Multiplatform or require decoupled architectures, the underlying modules can be imported individually:
 
-- `dev.avinya.ads:admob-cmp-core:1.1.0`: Contains core controllers (`AdManager`, `BannerAdController`, `InterstitialAdController`), lifecycle state machines, ad caching, retry policies, and platform adapters. Has no Compose Multiplatform dependencies.
-- `dev.avinya.ads:admob-cmp-compose:1.1.0`: Contains Compose Multiplatform composables (`rememberAdManager()`, `BannerAdView`, `NativeAdView`). Depends on `admob-cmp-core`.
+- `dev.avinya.ads:admob-cmp-core:1.1.1`: Contains core controllers (`AdManager`, `BannerAdController`, `InterstitialAdController`), lifecycle state machines, ad caching, retry policies, and platform adapters. Has no Compose Multiplatform dependencies.
+- `dev.avinya.ads:admob-cmp-compose:1.1.1`: Contains Compose Multiplatform composables (`rememberAdManager()`, `BannerAdView`, `NativeAdView`). Depends on `admob-cmp-core`.
 
 ## Version catalog configuration
 
@@ -60,7 +60,7 @@ For multi-module Gradle projects, manage library dependencies and plugin definit
 ```toml
 # gradle/libs.versions.toml
 [versions]
-admob-cmp = "1.1.0"
+admob-cmp = "1.1.1"
 
 [libraries]
 admob-cmp = { module = "dev.avinya.ads:admob-cmp", version.ref = "admob-cmp" }
@@ -95,7 +95,7 @@ To resolve Kotlin/Native test linking, apply the `dev.avinya.ads.admob-cmp` Grad
 ```kotlin
 // shared/build.gradle.kts
 plugins {
-    id("dev.avinya.ads.admob-cmp") version "1.1.0"
+    id("dev.avinya.ads.admob-cmp") version "1.1.1"
 }
 ```
 

--- a/docs-site/src/content/docs/start/ios-setup.mdx
+++ b/docs-site/src/content/docs/start/ios-setup.mdx
@@ -20,10 +20,10 @@ AdMob CMP distributes Objective-C cinterop bindings in its Kotlin Multiplatform 
 1. In Xcode, open your iOS project and select **File → Add Package Dependencies...**
 2. Enter the Google Mobile Ads SPM repository URL:
    `https://github.com/googleads/swift-package-manager-google-mobile-ads.git`
-   Select the **GoogleMobileAds** product and specify version rule **Up to Next Major** with **13.x** (AdMob CMP 1.1.0 binds GMA iOS 13.7.0).
+   Select the **GoogleMobileAds** product and specify version rule **Up to Next Major** with **13.x** (AdMob CMP 1.1.1 binds GMA iOS 13.7.0).
 3. Enter the User Messaging Platform SPM repository URL:
    `https://github.com/googleads/swift-package-manager-google-user-messaging-platform.git`
-   Select the **GoogleUserMessagingPlatform** product and specify version rule **Up to Next Major** with **3.x** (AdMob CMP 1.1.0 binds UMP iOS 3.1.0).
+   Select the **GoogleUserMessagingPlatform** product and specify version rule **Up to Next Major** with **3.x** (AdMob CMP 1.1.1 binds UMP iOS 3.1.0).
 
 </Steps>
 
@@ -109,7 +109,7 @@ Executing Kotlin/Native test tasks (such as `./gradlew :shared:iosSimulatorArm64
 ```kotlin
 // shared/build.gradle.kts
 plugins {
-    id("dev.avinya.ads.admob-cmp") version "1.1.0"
+    id("dev.avinya.ads.admob-cmp") version "1.1.1"
 }
 ```
 

--- a/docs-site/src/content/docs/start/quickstart.mdx
+++ b/docs-site/src/content/docs/start/quickstart.mdx
@@ -19,7 +19,7 @@ Add the umbrella library coordinate to your shared module's build script:
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            implementation("dev.avinya.ads:admob-cmp:1.1.0")
+            implementation("dev.avinya.ads:admob-cmp:1.1.1")
         }
     }
 }
@@ -32,7 +32,7 @@ If your project executes Kotlin/Native unit tests (`:shared:iosSimulatorArm64Tes
 ```kotlin
 // shared/build.gradle.kts
 plugins {
-    id("dev.avinya.ads.admob-cmp") version "1.1.0"
+    id("dev.avinya.ads.admob-cmp") version "1.1.1"
 }
 ```
 

--- a/docs-site/src/content/docs/start/what-is-admob-cmp.mdx
+++ b/docs-site/src/content/docs/start/what-is-admob-cmp.mdx
@@ -12,7 +12,7 @@ import PlatformMatrix from '../../../components/diagrams/PlatformMatrix.astro';
 
 AdMob CMP is a Kotlin Multiplatform (KMP) library that provides a unified Kotlin API for Google Mobile Ads (GMA) and User Messaging Platform (UMP) consent across Android and iOS. Built primarily for Compose Multiplatform applications, it enables developers to manage ad lifecycles, load states, and user privacy compliance using declarative Kotlin constructs.
 
-The published facade dependency coordinate is `dev.avinya.ads:admob-cmp:1.1.0`. The library wraps Google Mobile Ads SDKs on both platforms:
+The published facade dependency coordinate is `dev.avinya.ads:admob-cmp:1.1.1`. The library wraps Google Mobile Ads SDKs on both platforms:
 - **Android**: Binds the GMA Next-Gen SDK (version 1.3.0) and UMP SDK (version 4.0.0) transitively via Maven.
 - **iOS**: Provides cinterop bindings for the GMA iOS SDK (version 13.x) and UMP iOS SDK (version 3.x), with the host application linking Google's framework binaries directly via Swift Package Manager.
 

--- a/docs-site/src/data/landing.ts
+++ b/docs-site/src/data/landing.ts
@@ -120,8 +120,8 @@ export interface LandingMeta {
 }
 
 export const landingMeta: LandingMeta = {
-  mavenCoordinate: 'dev.avinya.ads:admob-cmp:1.1.0',
-  gradlePlugin: 'dev.avinya.ads.admob-cmp:1.1.0',
+  mavenCoordinate: 'dev.avinya.ads:admob-cmp:1.1.1',
+  gradlePlugin: 'dev.avinya.ads.admob-cmp:1.1.1',
   kotlinVersion: '2.3.20',
   composeMultiplatformVersion: '1.11.1',
   androidMinSdk: 26,

--- a/docs-site/test/landing.test.ts
+++ b/docs-site/test/landing.test.ts
@@ -576,8 +576,8 @@ describe('index.mdx quickstart, product facts, and iOS note', () => {
     expect(source).not.toMatch(/5-minute/i);
   });
 
-  it('keeps the install line on the canonical Maven coordinate and version 1.1.0', () => {
-    expect(source).toMatch(/implementation\(["']dev\.avinya\.ads:admob-cmp:1\.1\.0["']\)/);
+  it('keeps the install line on the canonical Maven coordinate and version 1.1.1', () => {
+    expect(source).toMatch(/implementation\(["']dev\.avinya\.ads:admob-cmp:1\.1\.1["']\)/);
   });
 
   it('preserves the gatherConsentAndInitialize(AdConfig(...)) initialization shape', () => {

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ umpIosHeadersSha256=02b6b1925be8a6cfc294478c1a6bb1dd4de70cd9e4f31cbbfb789ab4de7b
 
 # Publishing metadata shared by all published artifacts.
 GROUP=dev.avinya.ads
-VERSION_NAME=1.1.0
+VERSION_NAME=1.1.1
 POM_NAME=AdMob CMP
 POM_DESCRIPTION=Plug-and-play Compose Multiplatform AdMob SDK for Android GMA Next-Gen and iOS Google Mobile Ads. Not affiliated with or endorsed by Google. AdMob and Google Mobile Ads are trademarks of Google LLC.
 POM_URL=https://github.com/Meet-Miyani/admob-compose-multiplatform

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,7 +26,6 @@ gmaUmp = "4.0.0"        # Android UMP (also pulled transitively by gmaNextGen)
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
-compose-uiTooling = { module = "org.jetbrains.compose.ui:ui-tooling", version.ref = "composeMultiplatform" }
 androidx-lifecycle-viewmodelCompose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-runtimeCompose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
 compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "composeMultiplatform" }
@@ -34,6 +33,7 @@ compose-foundation = { module = "org.jetbrains.compose.foundation:foundation", v
 compose-material3 = { module = "org.jetbrains.compose.material3:material3", version.ref = "material3" }
 compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "composeMultiplatform" }
 compose-components-resources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "composeMultiplatform" }
+compose-uiTooling = { module = "org.jetbrains.compose.ui:ui-tooling", version.ref = "composeMultiplatform" }
 compose-uiToolingPreview = { module = "org.jetbrains.compose.ui:ui-tooling-preview", version.ref = "composeMultiplatform" }
 kotlinx-coroutinesSwing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
 


### PR DESCRIPTION
Squashed branch. Three pieces of work:

1. First review pass — "address code-review findings across core, platform layers and packaging" (was 85263ba1).

2. Second review pass over the findings raised against that work. Every finding was verified against the source before acting; the ones that did not survive that check are listed at the end rather than silently actioned.

   Core state machines
   - BannerCore/NativePoolCore: failOrRestore() decided and published across two separate lock acquisitions, so a clear() — which takes the state lock but never loadMutex — could land in between and be republished over. Both now transition under a single acquisition.
   - BannerCore caches responseInfo at admission. Recovery previously called platform.responseInfo() while holding the state lock (forbidden on iOS, where that lock is also taken from GMA callback threads) and could read from a banner clear() had already retired and destroyed.
   - Banner cancellation published Idle unconditionally, which BannerAdView reads as "cleared, drop the reference" — blanking a still-live ad. It now derives the terminal state from what the core owns, mirroring the fix NativePoolCore already had for the pool (P1-3).
   - Both cores treat platform handles as unowned until admission: a throwing response-info accessor now destroys the new banner/batch rather than stranding it, matching FullScreenSlotCore.

   Thread affinity (invariant #5)
   - Response and media info are captured inside the Main-confined load callbacks on both platforms, making the accessors pure field reads. The cores previously called back into GMA from whatever dispatcher the caller resumed on. Worst on iOS, where GADBannerView is a UIView. NativeAdPool.mediaInfo() is public and non-suspend, so a Main hop was not available against the frozen ABI.
   - Android's native handle gains AndroidLoadedNativeAd, mirroring iOS's LoadedNativeAd, so it has somewhere to carry that snapshot.

   Test safety
   - testModeWarningOrNull() no longer accepts UMP consentTestDeviceIds as evidence of a GMA test configuration; they only reach ConsentDebugSettings and never RequestConfiguration, so the warning was failing open.

   API hygiene
   - AdPlacements copies its list; @Immutable promised the Compose runtime something a retained caller reference could not deliver.
   - FullScreenStateLock marked @InternalAdMobCmpApi. It is public out of necessity (admob-cmp-compose consumes it across a module boundary), so the additive opt-in marker stands in for removal against the frozen ABI.

   Packaging
   - DownloadIosFramework declares the extracted .xcframework as an @OutputDirectory instead of tracking only a marker file, and no longer short-circuits on the marker alone. A deleted architecture slice now re-runs extraction rather than reporting UP-TO-DATE and failing later in cinterop. Verified by deleting a slice and observing re-download.

   Docs
   - AdManager.events no longer claims no-collector drops are logged: with replay = 0, tryEmit returns true and that loss is structurally undetectable.
   - strictTestMode no longer claims it does not affect production builds.

   Not taken: the destroy-off-Main claims (every teardown path was already
   Main-confined), the "acquire() empties the pool" race (Loaded with zero
   inventory is normal by design — availableAds is the availability signal),
   and per-view banner event filtering (needs an additive public event type;
   tracked as P1-8 under sub-project G).

3. Release 1.1.1. VERSION_NAME bumped in gradle.properties and admob-cmp-gradle-plugin/gradle.properties in lockstep — that pair is the only thing that triggers release.yml. Patch level: checkKotlinAbi is unchanged on both published modules. Every live install coordinate moves to 1.1.1 (both READMEs, the docs-site install/quickstart/setup pages, the version-catalog snippet, src/data/landing.ts and its test); compatibility matrices gain a 1.1.1 row and the changelog a "What changed in 1.1.1?" section rather than rewriting 1.1.0's history.

Verified with scripts/release-readiness.sh: READINESS: PASS, including the published-consumer round trip against the new coordinates and 238 docs tests.