### PR TITLE
Add CTA text-case, renderer updates, tests, docs

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "docs-site-preview",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["--prefix", "docs-site", "run", "preview", "--", "--port", "4321"],
+      "port": 4321
+    }
+  ]
+}

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug report
+about: Something in admob-cmp doesn't work as documented
+title: ""
+labels: bug
+assignees: ""
+---
+
+## Description
+
+<!-- What happened, and what did you expect instead? -->
+
+## Reproduction
+
+<!-- Minimal steps, or a link to a minimal reproduction project. -->
+
+## Environment
+
+- `admob-cmp` version:
+- Platform: Android / iOS (delete one, or both)
+- Kotlin version:
+- Compose Multiplatform version (if applicable):
+- Device / OS version:
+
+## Logs or stack trace
+
+<!-- Paste relevant output. Use a code block. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Documentation
+    url: https://ads.avinya.dev
+    about: Guides, ad format references, and the API reference.
+  - name: Troubleshooting guide
+    url: https://ads.avinya.dev/reference/troubleshooting/
+    about: Check known issues (undefined GAD symbols, consent gates, native ad reload) before filing a bug.
+  - name: Security vulnerability
+    url: https://github.com/Meet-Miyani/admob-compose-multiplatform/security/advisories/new
+    about: Please report vulnerabilities privately — do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Propose new or changed behavior for admob-cmp
+title: ""
+labels: enhancement
+assignees: ""
+---
+
+## Problem
+
+<!-- What are you trying to do that the SDK doesn't support today? -->
+
+## Proposed solution
+
+<!-- What would the API or behavior look like? -->
+
+## Alternatives considered
+
+<!-- Any workarounds you're using now, or other approaches you considered. -->
+
+## Additional context
+
+<!-- Anything else — links, screenshots, related issues. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+## What does this change?
+
+<!-- One or two sentences. Link an issue if there is one. -->
+
+## Checklist
+
+- [ ] Added or updated a test that fails before this change and passes after it
+- [ ] Ran `./gradlew :admob-cmp-core:testAndroidHostTest` and `:admob-cmp-core:iosSimulatorArm64Test`
+- [ ] If this touches the public API of `admob-cmp-core` or `admob-cmp-compose`: ran
+      `updateKotlinAbi` and committed the regenerated `api/*.klib.api` dump
+- [ ] Updated docs in `docs-site/src/content/docs/` in this PR, if user-facing behavior changed
+- [ ] Updated [the changelog](https://ads.avinya.dev/reference/changelog/), if behavior a consumer can observe changed
+- [ ] Ran `./scripts/release-readiness.sh` locally and got `READINESS: PASS` (or explained why it couldn't be run)
+
+## Notes for the reviewer
+
+<!-- Anything skipped, anything you're unsure about, anything that needs a second look. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,63 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics,
+gender identity and expression, level of experience, education,
+socio-economic status, nationality, personal appearance, race, religion, or
+sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our
+  mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political
+  attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+The maintainer is responsible for clarifying and enforcing standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior deemed inappropriate, threatening, offensive, or
+harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces for this project —
+issues, pull requests, and discussions — and also applies when an individual
+is officially representing the project in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the maintainer at **miyanimeet02@gmail.com**. All complaints
+will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org), version 2.1,
+available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,95 @@
+# Contributing to AdMob CMP
+
+Issues and pull requests are welcome. The narrative version of this guide —
+with the reasoning behind each rule — lives at
+[ads.avinya.dev/project/contributing/](https://ads.avinya.dev/project/contributing/).
+This file is the quick reference.
+
+## Building and testing
+
+```bash
+./gradlew :admob-cmp-core:iosSimulatorArm64Test       # common tests, iOS runner
+./gradlew :admob-cmp-core:testAndroidHostTest         # common tests, JVM runner
+./gradlew :admob-cmp-core:checkKotlinAbi :admob-cmp-compose:checkKotlinAbi # public API surface check
+./gradlew :admob-cmp-core:updateKotlinAbi :admob-cmp-compose:updateKotlinAbi # regenerate api/ after an intentional API change
+./gradlew :admob-cmp-core:doctorIos                   # diagnose iOS consumer integration
+```
+
+Tests live in `commonTest` only, using hand-written fakes rather than a
+mocking framework, with injectable `clock` and `foregroundEvents` seams. The
+suite is a contract test for the library's common code — native behavior
+that calls into Google Mobile Ads is not exercised by it.
+
+## The public ABI is frozen
+
+`admob-cmp-core/api/admob-cmp-core.klib.api` and
+`admob-cmp-compose/api/admob-cmp-compose.klib.api` are committed records of
+the public surface. Any intentional API change must regenerate and commit
+them in the same PR:
+
+```bash
+./gradlew :admob-cmp-core:updateKotlinAbi :admob-cmp-compose:updateKotlinAbi
+git add admob-cmp-core/api/ admob-cmp-compose/api/
+```
+
+If `checkKotlinAbi` fails and the change was **not** intentional, fix the
+code, not the dump — the dump records the agreed public surface. See the
+[architecture reference](https://ads.avinya.dev/reference/architecture/) for
+the full rationale, including why `AdManager` is never constructed directly
+by consumers.
+
+## Before you open a pull request
+
+This repository runs **no SDK tests in CI**, by design. The single
+[`.github/workflows/release.yml`](.github/workflows/release.yml) workflow
+runs only on `master` and on `workflow_dispatch`, and it only publishes,
+tags, and deploys — there is no pull-request CI and no verification job in
+the pipeline. Verification is local and is the contributor's responsibility:
+
+1. Run `./scripts/release-readiness.sh` on macOS with **Xcode 26** installed.
+   It runs the Android host tests, publication-metadata and Central
+   task-graph checks, the iOS tests and klib ABI check, the Maven Local
+   round trip, the Xcode consumer build, and the docs build. It exits with
+   `READINESS: PASS` on success. Use `--skip-docs` for changes that do not
+   touch the published modules, `gradle/libs.versions.toml`,
+   `gradle.properties`, or `docs-site/`.
+2. There is no remote fallback. If you cannot run the script (no macOS, no
+   Xcode 26), say so in the PR rather than describing it as verified.
+3. A clean `READINESS: PASS` is a prerequisite for *asking* the maintainer
+   to open or merge the PR — it is not authorization to do so unilaterally.
+   The maintainer decides.
+
+**Do not propose adding verification jobs to `release.yml`.** Keeping CI
+free of SDK tests is a standing, reaffirmed decision. If coverage needs to
+move, it moves into `scripts/release-readiness.sh`.
+
+## Pull request checklist
+
+- Has a test that fails before the change and passes after it.
+- Runs both test tasks and `checkKotlinAbi` locally, and passes
+  `./scripts/release-readiness.sh`.
+- Ships its documentation in the same pull request — docs live at
+  `docs-site/src/content/docs/`, so an API change and its guide update
+  version together.
+- Updates [the changelog](https://ads.avinya.dev/reference/changelog/) when
+  it changes behavior a consumer can observe.
+- Keeps the trademark and neutrality rules intact: nominative use of
+  "AdMob" only, and no comparative claims about other projects beyond
+  verifiable capability facts.
+
+## Core repository invariants
+
+Stated so a contribution does not propose changing them in good faith:
+
+- The published Maven coordinate stays `dev.avinya.ads:admob-cmp`.
+- The public ABI stays frozen absent a deliberate major version.
+- The iOS distribution stays bindings-only — never add `staticLibraries` to
+  the cinterop `.def` files.
+- `AdManager` implementations are never constructed directly by consumers.
+
+## Releasing
+
+Releases are cut by bumping `VERSION_NAME` in lockstep across both
+`gradle.properties` files — this is a maintainer decision, not something a
+contributing PR should do. The full procedure is in
+[`admob-cmp/docs/PUBLISHING.md`](admob-cmp/docs/PUBLISHING.md).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![AdMob CMP Header Banner](.github/readme-header.png)
+![AdMob CMP — Compose Multiplatform AdMob SDK for Android and iOS](.github/readme-header.png)
 
 # AdMob CMP — Compose Multiplatform AdMob SDK for Android and iOS
 
@@ -6,14 +6,20 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Kotlin](https://img.shields.io/badge/Kotlin-2.3.20-7F52FF?logo=kotlin&logoColor=white)](https://kotlinlang.org)
 [![Platforms](https://img.shields.io/badge/Platforms-Android%20%7C%20iOS-3DDC84)](#compatibility)
+[![API reference](https://img.shields.io/badge/docs-API%20reference-1793D1)](https://ads.avinya.dev/reference/api/)
+
+**[Quickstart](#30-second-quickstart) · [Ad formats](#ad-formats) · [Compatibility](#compatibility) · [Showcase](#showcase-app--fieldnotes) · [Contributing](#contributing)**
 
 AdMob CMP is an open-source Kotlin Multiplatform SDK for Google AdMob in Compose Multiplatform apps. Use one `commonMain` API for banner, interstitial, rewarded, rewarded interstitial, app-open, and native ads on Android and iOS.
 
 The SDK wraps Google Mobile Ads Next-Gen on Android and Google Mobile Ads on iOS while preserving familiar AdMob concepts such as `AdValue`, `ResponseInfo`, adaptive banner sizes, UMP consent states, and native asset names. Its shared API uses suspend functions, `StateFlow` state, and a sealed `AdEvent` stream, with consent, ATT ordering, paid events, and mediation integrated into initialization.
 
+> [!NOTE]
 > **Brand, repository, coordinate.** The library is branded **AdMob CMP**, the repository is **`admob-compose-multiplatform`**, and the Maven coordinate is **`dev.avinya.ads:admob-cmp`**. The coordinate has not changed across any release and will not change.
 
-**Documentation: [ads.avinya.dev](https://ads.avinya.dev)** · [Quickstart](https://ads.avinya.dev/start/quickstart/) · [Installation](https://ads.avinya.dev/start/installation/) · [iOS setup](https://ads.avinya.dev/start/ios-setup/) · [Troubleshooting](https://ads.avinya.dev/reference/troubleshooting/)
+**Documentation: [ads.avinya.dev](https://ads.avinya.dev)** · [What is AdMob CMP?](https://ads.avinya.dev/start/what-is-admob-cmp/) · [Quickstart](https://ads.avinya.dev/start/quickstart/) · [Installation](https://ads.avinya.dev/start/installation/) · [iOS setup](https://ads.avinya.dev/start/ios-setup/) · [Troubleshooting](https://ads.avinya.dev/reference/troubleshooting/)
+
+Coming from a hand-rolled `expect class AdManager`? See the [migration guide](https://ads.avinya.dev/start/migrate-from-expect-actual/).
 
 ## Install
 
@@ -22,13 +28,14 @@ The SDK wraps Google Mobile Ads Next-Gen on Android and Google Mobile Ads on iOS
 implementation("dev.avinya.ads:admob-cmp:2.0.1")
 ```
 
-If your project runs Kotlin/Native tests (`:yourModule:iosSimulatorArm64Test`), also apply the Gradle plugin. Without it the test link fails with `Undefined symbols … _OBJC_CLASS_$_GAD*`, because a Kotlin/Native test executable has no Xcode to resolve the Swift packages for it:
-
-```kotlin
-plugins {
-    id("dev.avinya.ads.admob-cmp") version "2.0.1"
-}
-```
+> [!IMPORTANT]
+> If your project runs Kotlin/Native tests (`:yourModule:iosSimulatorArm64Test`), also apply the Gradle plugin. Without it the test link fails with `Undefined symbols … _OBJC_CLASS_$_GAD*`, because a Kotlin/Native test executable has no Xcode to resolve the Swift packages for it:
+>
+> ```kotlin
+> plugins {
+>     id("dev.avinya.ads.admob-cmp") version "2.0.1"
+> }
+> ```
 
 Platform setup — the Android manifest entry, and on iOS the two Swift packages plus `Info.plist` keys — is required. Follow the [Android setup](https://ads.avinya.dev/start/android-setup/) and [iOS setup](https://ads.avinya.dev/start/ios-setup/) guides, then verify with `./gradlew :admob-cmp-core:doctorIos`.
 
@@ -134,7 +141,8 @@ val session = rememberNativeAdFeedSession(
 NativeAdView(session = session, slotKey = "after-article-3", placement = nativePlacement, layout = layout)
 ```
 
-Use a static, finite placement id and stable model-owned slot keys. Never generate either from a row index. The default active session retains three records; the process-wide governor bounds loaded plus reserved ads at soft 4 / hard 6. A temporary tab exit deactivates the session and retains one anchor; permanently discarded destinations close it. Per-placement native TTL remains one hour by default.
+> [!WARNING]
+> Use a static, finite placement id and stable model-owned slot keys. Never generate either from a row index. The default active session retains three records; the process-wide governor bounds loaded plus reserved ads at soft 4 / hard 6. A temporary tab exit deactivates the session and retains one anchor; permanently discarded destinations close it. Per-placement native TTL remains one hour by default.
 
 ## Why AdMob CMP
 
@@ -179,9 +187,9 @@ Underlying Google SDKs bound by 2.0.1:
 
 Full guides, diagrams, and the generated API reference live at **[ads.avinya.dev](https://ads.avinya.dev)**.
 
-- [Quickstart](https://ads.avinya.dev/start/quickstart/) — a rendering test ad in five minutes
+- [What is AdMob CMP?](https://ads.avinya.dev/start/what-is-admob-cmp/) · [Quickstart](https://ads.avinya.dev/start/quickstart/) — a rendering test ad in five minutes
 - [Installation](https://ads.avinya.dev/start/installation/) — Gradle, version catalog, and the Gradle plugin
-- [Android setup](https://ads.avinya.dev/start/android-setup/) · [iOS setup](https://ads.avinya.dev/start/ios-setup/)
+- [Android setup](https://ads.avinya.dev/start/android-setup/) · [iOS setup](https://ads.avinya.dev/start/ios-setup/) · [Migrate from expect/actual](https://ads.avinya.dev/start/migrate-from-expect-actual/)
 - [Banner](https://ads.avinya.dev/formats/banner/) · [Interstitial](https://ads.avinya.dev/formats/interstitial/) · [Rewarded](https://ads.avinya.dev/formats/rewarded/) · [App-open](https://ads.avinya.dev/formats/app-open/) · [Native](https://ads.avinya.dev/formats/native/)
 - [UMP consent](https://ads.avinya.dev/privacy/consent/) · [App Tracking Transparency](https://ads.avinya.dev/privacy/app-tracking-transparency/) · [Play Data safety](https://ads.avinya.dev/privacy/play-data-safety/)
 - [Mediation](https://ads.avinya.dev/advanced/mediation/) · [Revenue events](https://ads.avinya.dev/advanced/revenue-events/) · [Caching, retry and timeouts](https://ads.avinya.dev/advanced/caching-retry-timeouts/) · [Test safety](https://ads.avinya.dev/advanced/test-safety/)
@@ -191,7 +199,8 @@ Full guides, diagrams, and the generated API reference live at **[ads.avinya.dev
 
 Integrating with an AI coding agent? Point it at [`admob-cmp/AGENTS.md`](admob-cmp/AGENTS.md) and <https://ads.avinya.dev/llms.txt> — the latter is the canonical, machine-readable bundle of the full site.
 
-## Repository layout
+<details>
+<summary><strong>Repository layout</strong></summary>
 
 This repository is the SDK plus a Kotlin Multiplatform demo that exercises it.
 
@@ -203,6 +212,8 @@ This repository is the SDK plus a Kotlin Multiplatform demo that exercises it.
 | `admob-cmp-gradle-plugin/` | Links Google Mobile Ads and UMP into Kotlin/Native test executables |
 | `shared/`, `androidApp/`, `iosApp/`, `desktopApp/`, `webApp/` | The demo application. Ads render on the Android and iOS targets; desktop and web build without the ad surface. |
 
+</details>
+
 ## Running the demo
 
 Android and iOS open directly into the AdMob debug console, which exercises every format against Google's official sample ad units with `strictTestMode` validation on every placement.
@@ -213,7 +224,8 @@ Android and iOS open directly into the AdMob debug console, which exercises ever
 ./gradlew :webApp:wasmJsBrowserDevelopmentRun # Web (no ads)
 ```
 
-For iOS, open [`iosApp/`](iosApp) in Xcode and run. Compose Multiplatform requires **Xcode 26** (and the iOS 26 SDK) because of `UIViewLayoutRegion` linkage.
+> [!IMPORTANT]
+> For iOS, open [`iosApp/`](iosApp) in Xcode and run. Compose Multiplatform requires **Xcode 26** (and the iOS 26 SDK) because of `UIViewLayoutRegion` linkage.
 
 Tests:
 
@@ -226,107 +238,22 @@ Tests:
 
 ## Contributing
 
-Issues and pull requests are welcome. Questions, integration help, and feature ideas belong in [Discussions](https://github.com/Meet-Miyani/admob-compose-multiplatform/discussions).
+Issues are open for bugs and feature ideas. This repository runs **no SDK tests in CI**, by design — verification is local and is the contributor's responsibility. Before opening a PR, run `./scripts/release-readiness.sh` and get a clean `READINESS: PASS`; a pass is a prerequisite for asking the owner to open the PR, not authorization to open it unilaterally.
 
-The public ABI is frozen. Additive changes are fine; any breaking change needs a written migration plan. After any public API change, run `./gradlew :admob-cmp-core:updateKotlinAbi` and commit the regenerated `api/*.klib.api` dump. Nothing in CI checks this — `checkKotlinAbi` runs only in `./scripts/release-readiness.sh`.
-
-### Before you open a PR
-
-This repository runs **no SDK tests in CI**, by design. The single
-[`.github/workflows/release.yml`](.github/workflows/release.yml) workflow runs
-only on `master` and on `workflow_dispatch`, and it only publishes, tags, and
-deploys. There is no pull-request CI and no verification job in the pipeline,
-so nothing checks a branch before *or* after merge. Verification is local and
-is the contributor's responsibility:
-
-1. Run `./scripts/release-readiness.sh` on macOS with **Xcode 26** installed.
-   It runs the Android host tests, the publication-metadata and Central
-   task-graph checks, the iOS tests and klib ABI check, the Maven Local
-   round trip, the Xcode consumer build, and the docs build. It exits with
-   `READINESS: PASS` on success and names the first failing section on
-   failure. Use `--skip-docs` for changes that do not touch the published
-   modules, `gradle/libs.versions.toml`, `gradle.properties`, or
-   `docs-site/`.
-2. There is no remote fallback. If you cannot run the script (no macOS, no
-   Xcode 26), say so in the PR rather than describing it as verified.
-3. Tagging, GitHub release creation, Maven Central publishing, and Cloudflare
-   deployment all happen automatically on merge to `master` when
-   `VERSION_NAME` has been bumped in both `gradle.properties` files. Two
-   Maven Central staging deployments still need a manual release in
-   [Central Portal](https://central.sonatype.com/publishing/deployments)
-   before the artifacts are publicly available — this is deliberate, because
-   Maven Central coordinates are immutable, and it is the last point at which
-   a bad release can be stopped.
+Full contributor guide, including the public-ABI rules and the release procedure: **[CONTRIBUTING.md](CONTRIBUTING.md)** and [ads.avinya.dev/project/contributing/](https://ads.avinya.dev/project/contributing/).
 
 ## Showcase app — Fieldnotes
 
-`showcase/` is a product-shaped Compose Multiplatform reference app named
-**Fieldnotes**. It demonstrates the SDK in real product flows with retained
-top-level navigation, a procedural editorial design system, and an in-app
-SDK Lab and telemetry Inspector.
+`showcase/` is a product-shaped Compose Multiplatform reference module named **Fieldnotes**. It exercises every ad format in real product flows — a chronological feed with interleaved native slots, section browsing, a rewarded coin economy, and an interstitial gated on natural transitions — with an in-app SDK Lab and telemetry Inspector. It is a **consumer** of `admob-cmp`; reusable ad lifecycle behavior belongs in the SDK, not in sample-only workarounds.
 
-It is a **consumer** of `admob-cmp`; reusable ad lifecycle behavior belongs
-in the SDK rather than in sample-only workarounds.
+> [!NOTE]
+> `showcase/` is currently a library module with its own test suite, not a launchable app — `androidApp`/`iosApp` embed the separate `shared` debug console described in [Running the demo](#running-the-demo). Explore Fieldnotes through its source under `showcase/src/`:
+>
+> ```bash
+> ./gradlew :showcase:testAndroidHostTest :showcase:iosSimulatorArm64Test :showcase:compileKotlinIosSimulatorArm64 --no-configuration-cache
+> ```
 
-### Destinations
-
-- **Today** — curated chronological feed. Native slots interleaved (first
-  after 4 stories, then every 8) using `rememberNativeAdFeedSession`. Feeds
-  carry zero banners.
-- **Discover** — section browsing and local search. Native slots in query and
-  category result feeds with query-scoped sessions debounced and closed on query
-  change.
-- **Library** — saved, in-progress, and unlocked stories. **Zero ads, by design**
-  — demonstrating integration restraint.
-- **Profile** — appearance, privacy options, ATT status, consent debug tools,
-  and entry points to Rewards and the SDK Lab.
-- **Rewards** — secondary destination off Profile. Premium story unlocks via
-  a coin economy; rewarded ads and rewarded interstitials with idempotent
-  wallet credits driven by `onRewardEarned`.
-- **SDK Lab** — secondary destination off Profile. Exercises every supported
-  format in isolation (Banner, Native layouts & validator, Full screen,
-  App open gates, Privacy/ATT, and Diagnostics).
-- **Article** — full-screen reader. Inline native ad after the first section,
-  an anchored collapsible banner at the bottom, and an interstitial on exit
-  governed by `AdPolicy`.
-
-### Telemetry Inspector
-
-Available from the top bar (when enabled in Profile) as a modal bottom sheet:
-
-- **Placements** — live placement configs, native session slot states, and
-  global loaded/reserved capacity.
-- **Events** — rolling `ad_events` telemetry interleaved with `policy_decisions`
-  and explicit suppression reasons.
-- **Revenue** — per-placement aggregates (`AdValuePrecision` preserved) and raw
-  `paid_events`.
-
-### Format coverage
-
-| Format | Where | What it proves |
-|---|---|---|
-| Native | Today, Discover | Bounded session, stable slot keys, viewport retention across recycling/tabs |
-| Native | Article (inline) | Single-slot session, layout DSL reuse |
-| Banner | Article (bottom) | Anchored collapsible banner (`AdSizePolicy.LargeAnchoredAdaptive(CollapsiblePlacement.Bottom)`) |
-| Rewarded | Rewards | `onRewardEarned` correctness, idempotent grant key, wallet balance |
-| Rewarded interstitial | Rewards (daily pass) | Offer dialog, reward callback |
-| Interstitial | Article exit | Natural break timing, `AdPolicy` cooldown & frequency capping, suppression reasons |
-| App-open | App-wide | `AppOpenAdCoordinator`, `AppOpenEligibilityPolicy` suppression over sensitive flows |
-
-### Run it
-
-```bash
-./gradlew :androidApp:installDebug          # Android
-open iosApp/iosApp.xcodeproj                # iOS — build and run in Xcode
-```
-
-All placements use Google's test ad units with `strictTestMode = true`.
-
-Tests and verification:
-
-```bash
-./gradlew :showcase:testAndroidHostTest :showcase:iosSimulatorArm64Test :showcase:compileKotlinIosSimulatorArm64 --no-configuration-cache
-```
+Full destination tour, format-coverage table, and the Telemetry Inspector: **[ads.avinya.dev/project/showcase/](https://ads.avinya.dev/project/showcase/)**.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+## Supported versions
+
+AdMob CMP publishes a single line of releases; only the **latest published
+version** on [Maven Central](https://central.sonatype.com/artifact/dev.avinya.ads/admob-cmp)
+is supported. There are no maintained older major versions.
+
+## Reporting a vulnerability
+
+Please **do not** open a public GitHub issue for a security vulnerability.
+
+Instead, use
+[GitHub's private vulnerability reporting](https://github.com/Meet-Miyani/admob-compose-multiplatform/security/advisories/new)
+for this repository, or email **miyanimeet02@gmail.com** with:
+
+- A description of the vulnerability and its potential impact.
+- Steps to reproduce, or a minimal reproduction project if possible.
+- The `admob-cmp` version(s) affected.
+
+This is a single-maintainer open-source project; there is no formal SLA, but
+reports are reviewed as soon as practical and a fix or mitigation is
+prioritized once confirmed. Credit is given in the release notes unless you
+ask to remain anonymous.
+
+## Scope
+
+`admob-cmp` is a thin Kotlin Multiplatform wrapper around Google Mobile Ads
+and User Messaging Platform. Vulnerabilities in the underlying Google SDKs
+themselves should be reported to Google, not here — see the
+[compatibility page](https://ads.avinya.dev/reference/compatibility/) for
+the exact GMA/UMP versions each release binds.

--- a/admob-cmp-compose/api/admob-cmp-compose.klib.api
+++ b/admob-cmp-compose/api/admob-cmp-compose.klib.api
@@ -10,6 +10,17 @@ open annotation class dev.avinya.ads.nativead.layout/AdLayoutDsl : kotlin/Annota
     constructor <init>() // dev.avinya.ads.nativead.layout/AdLayoutDsl.<init>|<init>(){}[0]
 }
 
+final enum class dev.avinya.ads.nativead.layout/AdButtonTextCase : kotlin/Enum<dev.avinya.ads.nativead.layout/AdButtonTextCase> { // dev.avinya.ads.nativead.layout/AdButtonTextCase|null[0]
+    enum entry AsProvided // dev.avinya.ads.nativead.layout/AdButtonTextCase.AsProvided|null[0]
+    enum entry SentenceCase // dev.avinya.ads.nativead.layout/AdButtonTextCase.SentenceCase|null[0]
+
+    final val entries // dev.avinya.ads.nativead.layout/AdButtonTextCase.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<dev.avinya.ads.nativead.layout/AdButtonTextCase> // dev.avinya.ads.nativead.layout/AdButtonTextCase.entries.<get-entries>|<get-entries>#static(){}[0]
+
+    final fun valueOf(kotlin/String): dev.avinya.ads.nativead.layout/AdButtonTextCase // dev.avinya.ads.nativead.layout/AdButtonTextCase.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<dev.avinya.ads.nativead.layout/AdButtonTextCase> // dev.avinya.ads.nativead.layout/AdButtonTextCase.values|values#static(){}[0]
+}
+
 final enum class dev.avinya.ads.nativead.layout/AdColorRole : kotlin/Enum<dev.avinya.ads.nativead.layout/AdColorRole> { // dev.avinya.ads.nativead.layout/AdColorRole|null[0]
     enum entry Background // dev.avinya.ads.nativead.layout/AdColorRole.Background|null[0]
     enum entry Muted // dev.avinya.ads.nativead.layout/AdColorRole.Muted|null[0]
@@ -532,7 +543,7 @@ final class dev.avinya.ads.debug/AdDebugCatalog { // dev.avinya.ads.debug/AdDebu
 }
 
 final class dev.avinya.ads.nativead.layout/AdButtonStyle { // dev.avinya.ads.nativead.layout/AdButtonStyle|null[0]
-    constructor <init>(dev.avinya.ads.nativead.layout/AdTextStyle = ..., kotlin/Long = ..., kotlin/Float = ..., kotlin/Float = ...) // dev.avinya.ads.nativead.layout/AdButtonStyle.<init>|<init>(dev.avinya.ads.nativead.layout.AdTextStyle;kotlin.Long;kotlin.Float;kotlin.Float){}[0]
+    constructor <init>(dev.avinya.ads.nativead.layout/AdTextStyle = ..., kotlin/Long = ..., kotlin/Float = ..., kotlin/Float = ..., dev.avinya.ads.nativead.layout/AdButtonTextCase = ...) // dev.avinya.ads.nativead.layout/AdButtonStyle.<init>|<init>(dev.avinya.ads.nativead.layout.AdTextStyle;kotlin.Long;kotlin.Float;kotlin.Float;dev.avinya.ads.nativead.layout.AdButtonTextCase){}[0]
 
     final val backgroundArgb // dev.avinya.ads.nativead.layout/AdButtonStyle.backgroundArgb|{}backgroundArgb[0]
         final fun <get-backgroundArgb>(): kotlin/Long // dev.avinya.ads.nativead.layout/AdButtonStyle.backgroundArgb.<get-backgroundArgb>|<get-backgroundArgb>(){}[0]
@@ -540,6 +551,8 @@ final class dev.avinya.ads.nativead.layout/AdButtonStyle { // dev.avinya.ads.nat
         final fun <get-cornerRadiusDp>(): kotlin/Float // dev.avinya.ads.nativead.layout/AdButtonStyle.cornerRadiusDp.<get-cornerRadiusDp>|<get-cornerRadiusDp>(){}[0]
     final val horizontalPaddingDp // dev.avinya.ads.nativead.layout/AdButtonStyle.horizontalPaddingDp|{}horizontalPaddingDp[0]
         final fun <get-horizontalPaddingDp>(): kotlin/Float // dev.avinya.ads.nativead.layout/AdButtonStyle.horizontalPaddingDp.<get-horizontalPaddingDp>|<get-horizontalPaddingDp>(){}[0]
+    final val textCase // dev.avinya.ads.nativead.layout/AdButtonStyle.textCase|{}textCase[0]
+        final fun <get-textCase>(): dev.avinya.ads.nativead.layout/AdButtonTextCase // dev.avinya.ads.nativead.layout/AdButtonStyle.textCase.<get-textCase>|<get-textCase>(){}[0]
     final val textStyle // dev.avinya.ads.nativead.layout/AdButtonStyle.textStyle|{}textStyle[0]
         final fun <get-textStyle>(): dev.avinya.ads.nativead.layout/AdTextStyle // dev.avinya.ads.nativead.layout/AdButtonStyle.textStyle.<get-textStyle>|<get-textStyle>(){}[0]
 
@@ -547,7 +560,8 @@ final class dev.avinya.ads.nativead.layout/AdButtonStyle { // dev.avinya.ads.nat
     final fun component2(): kotlin/Long // dev.avinya.ads.nativead.layout/AdButtonStyle.component2|component2(){}[0]
     final fun component3(): kotlin/Float // dev.avinya.ads.nativead.layout/AdButtonStyle.component3|component3(){}[0]
     final fun component4(): kotlin/Float // dev.avinya.ads.nativead.layout/AdButtonStyle.component4|component4(){}[0]
-    final fun copy(dev.avinya.ads.nativead.layout/AdTextStyle = ..., kotlin/Long = ..., kotlin/Float = ..., kotlin/Float = ...): dev.avinya.ads.nativead.layout/AdButtonStyle // dev.avinya.ads.nativead.layout/AdButtonStyle.copy|copy(dev.avinya.ads.nativead.layout.AdTextStyle;kotlin.Long;kotlin.Float;kotlin.Float){}[0]
+    final fun component5(): dev.avinya.ads.nativead.layout/AdButtonTextCase // dev.avinya.ads.nativead.layout/AdButtonStyle.component5|component5(){}[0]
+    final fun copy(dev.avinya.ads.nativead.layout/AdTextStyle = ..., kotlin/Long = ..., kotlin/Float = ..., kotlin/Float = ..., dev.avinya.ads.nativead.layout/AdButtonTextCase = ...): dev.avinya.ads.nativead.layout/AdButtonStyle // dev.avinya.ads.nativead.layout/AdButtonStyle.copy|copy(dev.avinya.ads.nativead.layout.AdTextStyle;kotlin.Long;kotlin.Float;kotlin.Float;dev.avinya.ads.nativead.layout.AdButtonTextCase){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // dev.avinya.ads.nativead.layout/AdButtonStyle.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // dev.avinya.ads.nativead.layout/AdButtonStyle.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // dev.avinya.ads.nativead.layout/AdButtonStyle.toString|toString(){}[0]

--- a/admob-cmp-compose/src/androidMain/kotlin/dev/avinya/ads/nativead/rendering/AndroidNativeAdLayoutRenderer.kt
+++ b/admob-cmp-compose/src/androidMain/kotlin/dev/avinya/ads/nativead/rendering/AndroidNativeAdLayoutRenderer.kt
@@ -202,7 +202,7 @@ internal class AndroidNativeAdLayoutRenderer(
                 renderedMediaView = this
             }
             is AdAssetNode.CallToAction -> Button(context).apply {
-                text = nativeAd.callToAction.orEmpty()
+                text = resolveCallToActionText(nativeAd.callToAction.orEmpty(), node.style.textCase)
                 isAllCaps = false
                 disableDirectInteractionForNativeAdAsset()
                 setTextColor(node.style.textStyle.colorArgb.toAndroidColor())

--- a/admob-cmp-compose/src/commonMain/kotlin/dev/avinya/ads/nativead/layout/AdLayoutPreview.kt
+++ b/admob-cmp-compose/src/commonMain/kotlin/dev/avinya/ads/nativead/layout/AdLayoutPreview.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.zIndex
 import dev.avinya.ads.nativead.rendering.resolveCallToActionContentInsets
+import dev.avinya.ads.nativead.rendering.resolveCallToActionText
 import dev.avinya.ads.nativead.rendering.resolveNativeAdBackgroundArgb
 import dev.avinya.ads.nativead.rendering.withoutPadding
 
@@ -135,7 +136,7 @@ private fun RenderAdLayoutPreviewNode(
         is AdAssetNode.Headline -> PreviewText(data.headline, node.style, node.maxLines, nodeModifier, node.visibilityPolicy)
         is AdAssetNode.Body -> PreviewText(data.body, node.style, node.maxLines, nodeModifier, node.visibilityPolicy)
         is AdAssetNode.CallToAction -> PreviewButton(
-            text = data.callToAction,
+            text = resolveCallToActionText(data.callToAction, node.style.textCase),
             style = node.style,
             nodeModifier = node.modifier,
             modifier = modifier.then(node.modifier.withoutPadding().toComposeModifier()),

--- a/admob-cmp-compose/src/commonMain/kotlin/dev/avinya/ads/nativead/layout/AdStyle.kt
+++ b/admob-cmp-compose/src/commonMain/kotlin/dev/avinya/ads/nativead/layout/AdStyle.kt
@@ -86,6 +86,31 @@ public data class AdTextStyle(
 }
 
 /**
+ * Letter casing applied to a call-to-action label before it is rendered.
+ *
+ * Creatives do not agree on casing: some ship `"Install"`, others `"INSTALL"`. The renderer
+ * displays the creative's text verbatim, so a feed can end up with one shouting button among
+ * several quiet ones. This is the opt-in lever for normalising that.
+ */
+public enum class AdButtonTextCase {
+    /**
+     * Render the creative's call-to-action exactly as delivered. Default, and the right choice
+     * unless the host UI has a specific casing convention.
+     */
+    AsProvided,
+
+    /**
+     * Rewrite a call-to-action written **entirely in capitals** into sentence case — `"INSTALL"`
+     * becomes `"Install"`, `"LEARN MORE"` becomes `"Learn more"`.
+     *
+     * Text that already contains lowercase letters is left untouched, so `"Book now"` and
+     * `"Shop at H&M"` survive intact. Only strings carrying no case information to begin with are
+     * rewritten, which keeps the transformation from destroying deliberate capitalisation.
+     */
+    SentenceCase,
+}
+
+/**
  * Style configuration for call-to-action buttons in native ad layouts.
  */
 @Immutable
@@ -97,7 +122,9 @@ public data class AdButtonStyle(
     /** Corner radius in dp. */
     val cornerRadiusDp: Float = 8f,
     /** Horizontal padding inside the button in dp. */
-    val horizontalPaddingDp: Float = 12f
+    val horizontalPaddingDp: Float = 12f,
+    /** Casing applied to the creative's label. Defaults to [AdButtonTextCase.AsProvided]. */
+    val textCase: AdButtonTextCase = AdButtonTextCase.AsProvided
 ) {
     public companion object {
         /** Filled button preset (blue background, white text). */

--- a/admob-cmp-compose/src/commonMain/kotlin/dev/avinya/ads/nativead/rendering/NativeAdRendererResolution.kt
+++ b/admob-cmp-compose/src/commonMain/kotlin/dev/avinya/ads/nativead/rendering/NativeAdRendererResolution.kt
@@ -1,6 +1,7 @@
 package dev.avinya.ads.nativead.rendering
 
 import dev.avinya.ads.nativead.layout.AdButtonStyle
+import dev.avinya.ads.nativead.layout.AdButtonTextCase
 import dev.avinya.ads.nativead.layout.AdInsets
 import dev.avinya.ads.nativead.layout.AdModifier
 
@@ -22,6 +23,33 @@ internal fun resolveCallToActionContentInsets(
         startDp = style.horizontalPaddingDp,
         endDp = style.horizontalPaddingDp,
     )
+
+/**
+ * Applies [AdButtonStyle.textCase] to a creative's call-to-action label.
+ *
+ * Shared by every renderer (Android, iOS, preview) so a layout previews with the same wording it
+ * ships with — the divergence that made the old media-background bug invisible until runtime.
+ */
+internal fun resolveCallToActionText(text: String, textCase: AdButtonTextCase): String =
+    when (textCase) {
+        AdButtonTextCase.AsProvided -> text
+        AdButtonTextCase.SentenceCase -> text.sentenceCaseIfAllCaps()
+    }
+
+/**
+ * Sentence-cases a string only when it carries no case information of its own — i.e. it contains
+ * letters and every one of them is uppercase. Mixed-case labels are returned untouched so
+ * deliberate capitalisation ("Shop at H&M") is never flattened.
+ */
+private fun String.sentenceCaseIfAllCaps(): String {
+    val firstLetter = indexOfFirst(Char::isLetter)
+    if (firstLetter < 0) return this
+    if (any { it.isLetter() && it.isLowerCase() }) return this
+    val lowered = lowercase()
+    return lowered.substring(0, firstLetter) +
+        lowered[firstLetter].uppercaseChar() +
+        lowered.substring(firstLetter + 1)
+}
 
 internal fun AdModifier.withoutPadding(): AdModifier = copy(padding = AdInsets())
 

--- a/admob-cmp-compose/src/commonTest/kotlin/dev/avinya/ads/nativead/rendering/NativeAdRendererResolutionTest.kt
+++ b/admob-cmp-compose/src/commonTest/kotlin/dev/avinya/ads/nativead/rendering/NativeAdRendererResolutionTest.kt
@@ -1,6 +1,7 @@
 package dev.avinya.ads.nativead.rendering
 
 import dev.avinya.ads.nativead.layout.AdButtonStyle
+import dev.avinya.ads.nativead.layout.AdButtonTextCase
 import dev.avinya.ads.nativead.layout.AdImageStyle
 import dev.avinya.ads.nativead.layout.AdInsets
 import dev.avinya.ads.nativead.layout.AdModifier
@@ -83,5 +84,41 @@ class NativeAdRendererResolutionTest {
                 style = AdButtonStyle(horizontalPaddingDp = 24f),
             ),
         )
+    }
+}
+
+class CallToActionTextCaseTest {
+
+    @Test
+    fun asProvidedNeverRewritesTheCreativesLabel() {
+        assertEquals("INSTALL", resolveCallToActionText("INSTALL", AdButtonTextCase.AsProvided))
+        assertEquals("Book now", resolveCallToActionText("Book now", AdButtonTextCase.AsProvided))
+    }
+
+    @Test
+    fun sentenceCaseRewritesAllCapsLabels() {
+        assertEquals("Install", resolveCallToActionText("INSTALL", AdButtonTextCase.SentenceCase))
+        assertEquals("Learn more", resolveCallToActionText("LEARN MORE", AdButtonTextCase.SentenceCase))
+    }
+
+    @Test
+    fun sentenceCaseLeavesMixedCaseLabelsAlone() {
+        // Deliberate capitalisation must survive: these already carry case information.
+        assertEquals("Book now", resolveCallToActionText("Book now", AdButtonTextCase.SentenceCase))
+        assertEquals("Shop at H&M", resolveCallToActionText("Shop at H&M", AdButtonTextCase.SentenceCase))
+        assertEquals("iBooks", resolveCallToActionText("iBooks", AdButtonTextCase.SentenceCase))
+    }
+
+    @Test
+    fun sentenceCaseCapitalisesTheFirstLetterNotTheFirstCharacter() {
+        // A leading symbol must not swallow the capital that belongs to the first word.
+        assertEquals("→ Install", resolveCallToActionText("→ INSTALL", AdButtonTextCase.SentenceCase))
+        assertEquals("  Install", resolveCallToActionText("  INSTALL", AdButtonTextCase.SentenceCase))
+    }
+
+    @Test
+    fun sentenceCaseIsSafeOnLabelsWithoutLetters() {
+        assertEquals("", resolveCallToActionText("", AdButtonTextCase.SentenceCase))
+        assertEquals("$9.99", resolveCallToActionText("$9.99", AdButtonTextCase.SentenceCase))
     }
 }

--- a/admob-cmp-compose/src/iosMain/kotlin/dev/avinya/ads/nativead/rendering/IosNativeAdRenderer.kt
+++ b/admob-cmp-compose/src/iosMain/kotlin/dev/avinya/ads/nativead/rendering/IosNativeAdRenderer.kt
@@ -161,8 +161,9 @@ internal class IosNativeAdRenderer(
     }
 
     private fun renderCallToAction(node: AdAssetNode.CallToAction): UIView {
-        val title = nativeAd.callToAction
-        if (title == null || title.isEmpty()) return missingView(node.modifier, node.visibilityPolicy)
+        val provided = nativeAd.callToAction
+        if (provided == null || provided.isEmpty()) return missingView(node.modifier, node.visibilityPolicy)
+        val title = resolveCallToActionText(provided, node.style.textCase)
         val button = platform.UIKit.UIButton.buttonWithType(platform.UIKit.UIButtonTypeSystem)
         val insets = resolveCallToActionContentInsets(node.modifier, node.style)
         val configuration = UIButtonConfiguration.plainButtonConfiguration().apply {

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -283,6 +283,7 @@ export default defineConfig({
           label: 'Project',
           items: [
             { slug: 'project/roadmap' },
+            { slug: 'project/showcase' },
             { slug: 'project/contributing' },
             // Was a true orphan: in the sitemap, but with no inbound link from
             // any page, component or sidebar entry in the repository.

--- a/docs-site/src/content/docs/project/showcase.mdx
+++ b/docs-site/src/content/docs/project/showcase.mdx
@@ -1,0 +1,99 @@
+---
+title: "Fieldnotes — the AdMob CMP showcase app"
+description: "Fieldnotes is a product-shaped Compose Multiplatform reference app that exercises every AdMob CMP ad format in real product flows, with a telemetry Inspector."
+sidebar:
+  label: "Showcase — Fieldnotes"
+---
+
+import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
+
+## What Fieldnotes is
+
+`showcase/` in the repository is a product-shaped Compose Multiplatform
+reference app named **Fieldnotes**. It demonstrates AdMob CMP in real
+product flows with retained top-level navigation, a procedural editorial
+design system, and an in-app SDK Lab and telemetry Inspector — rather than
+one screen per format in isolation.
+
+Fieldnotes is a **consumer** of `admob-cmp`, in the same sense any
+application is: it depends on the published API and has no special access.
+Reusable ad lifecycle behavior belongs in the SDK rather than in
+sample-only workarounds, so what you see in Fieldnotes is what the public
+API actually supports.
+
+## Destinations
+
+- **Today** — curated chronological feed. Native slots interleaved (first
+  after 4 stories, then every 8) using `rememberNativeAdFeedSession`. Feeds
+  carry zero banners.
+- **Discover** — section browsing and local search. Native slots in query
+  and category result feeds with query-scoped sessions debounced and closed
+  on query change.
+- **Library** — saved, in-progress, and unlocked stories. **Zero ads, by
+  design** — demonstrating integration restraint.
+- **Profile** — appearance, privacy options, ATT status, consent debug
+  tools, and entry points to Rewards and the SDK Lab.
+- **Rewards** — secondary destination off Profile. Premium story unlocks
+  via a coin economy; rewarded ads and rewarded interstitials with
+  idempotent wallet credits driven by `onRewardEarned`.
+- **SDK Lab** — secondary destination off Profile. Exercises every
+  supported format in isolation (Banner, Native layouts & validator, Full
+  screen, App open gates, Privacy/ATT, and Diagnostics).
+- **Article** — full-screen reader. Inline native ad after the first
+  section, an anchored collapsible banner at the bottom, and an
+  interstitial on exit governed by `AdPolicy`.
+
+## Telemetry Inspector
+
+Available from the top bar (when enabled in Profile) as a modal bottom
+sheet:
+
+- **Placements** — live placement configs, native session slot states, and
+  global loaded/reserved capacity.
+- **Events** — rolling `ad_events` telemetry interleaved with
+  `policy_decisions` and explicit suppression reasons.
+- **Revenue** — per-placement aggregates (`AdValuePrecision` preserved) and
+  raw `paid_events`.
+
+## Format coverage
+
+| Format | Where | What it proves |
+|---|---|---|
+| Native | Today, Discover | Bounded session, stable slot keys, viewport retention across recycling/tabs |
+| Native | Article (inline) | Single-slot session, layout DSL reuse |
+| Banner | Article (bottom) | Anchored collapsible banner (`AdSizePolicy.LargeAnchoredAdaptive(CollapsiblePlacement.Bottom)`) |
+| Rewarded | Rewards | `onRewardEarned` correctness, idempotent grant key, wallet balance |
+| Rewarded interstitial | Rewards (daily pass) | Offer dialog, reward callback |
+| Interstitial | Article exit | Natural break timing, `AdPolicy` cooldown & frequency capping, suppression reasons |
+| App-open | App-wide | `AppOpenAdCoordinator`, `AppOpenEligibilityPolicy` suppression over sensitive flows |
+
+## Running it
+
+`showcase/` is currently a Kotlin Multiplatform library module with its own
+test suite — it does not have its own launcher. `androidApp` and `iosApp`
+embed the separate `shared` debug console (the app described in the root
+[Quickstart](/start/quickstart/)), not Fieldnotes. Explore Fieldnotes
+through its source under `showcase/src/` and its tests:
+
+```bash
+./gradlew :showcase:testAndroidHostTest :showcase:iosSimulatorArm64Test :showcase:compileKotlinIosSimulatorArm64 --no-configuration-cache
+```
+
+All placements exercised by the test suite use Google's test ad units with
+`strictTestMode = true`.
+
+<Aside type="tip">
+The **Library** destination is deliberately ad-free — if you are deciding
+where in your own app to *not* place ads, that restraint (in
+`showcase/src/commonMain/kotlin/dev/avinya/admob/showcase/feature/library/`)
+is the reference point, not an oversight.
+</Aside>
+
+## Where to next?
+
+<CardGrid>
+  <LinkCard title="Native ads" href="/formats/native/" description="The adLayout DSL, session ownership, and pooling that Today and Discover exercise." />
+  <LinkCard title="Rewarded" href="/formats/rewarded/" description="onRewardEarned and idempotent grant keys, as used by the Rewards destination." />
+  <LinkCard title="Architecture" href="/reference/architecture/" description="Why AdManager is a singleton and what that means for a consumer app like Fieldnotes." />
+  <LinkCard title="Repository (GitHub)" href="https://github.com/Meet-Miyani/admob-compose-multiplatform" description="Source for showcase/, the Android and iOS demo modules." />
+</CardGrid>


### PR DESCRIPTION
Introduce AdButtonTextCase and a textCase property on AdButtonStyle; add resolveCallToActionText to normalise call-to-action labels (SentenceCase vs AsProvided) and apply it in Android, iOS and preview renderers. Add unit tests covering casing behaviour and update the admob-cmp-compose API dump. Doc/site updates: README tweaks, new showcase page and sidebar entry, and astro config change. Repository metadata: CONTRIBUTING, CODE_OF_CONDUCT, SECURITY, issue/PR templates, and a .claude launch config added.