### PR TITLE
refactor(core): lift Android/iOS init orchestration into GoogleAdManagerBase

### DIFF
--- a/admob-cmp-core/src/androidMain/kotlin/dev/avinya/ads/AndroidGoogleAdManager.kt
+++ b/admob-cmp-core/src/androidMain/kotlin/dev/avinya/ads/AndroidGoogleAdManager.kt
@@ -1,115 +1,49 @@
 package dev.avinya.ads
 
 import android.app.Activity
-import android.app.Application
 import android.content.Context
-import dev.avinya.ads.internal.AdRequestAdmission
-import dev.avinya.ads.internal.AppliedConfigurationDecision
 import dev.avinya.ads.internal.InitializationTimeouts
-import dev.avinya.ads.internal.appliedConfigurationDecision
-import dev.avinya.ads.internal.awaitNativeCallback
-import dev.avinya.ads.internal.dispatchAfterInitializeHooks
-import dev.avinya.ads.internal.FullScreenPresentationArbiter
-import dev.avinya.ads.internal.deriveAdmission
-import dev.avinya.ads.internal.ConsentSessionState
-import dev.avinya.ads.internal.ownedSnapshot
 import dev.avinya.ads.internal.NativeAdManagerImpl
+import dev.avinya.ads.internal.awaitNativeCallback
 import dev.avinya.ads.internal.emitOrLogDrop
 import dev.avinya.ads.nativead.AndroidNativeAdPlatform
 import dev.avinya.ads.nativead.NativeAdManager
 import dev.avinya.ads.nativead.NativeAdMemoryPolicy
 import com.google.android.libraries.ads.mobile.sdk.MobileAds
 import com.google.android.libraries.ads.mobile.sdk.initialization.InitializationConfig
-import kotlin.coroutines.cancellation.CancellationException
 import kotlin.coroutines.resume
-import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.CoroutineStart
-import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.NonCancellable
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.async
-import kotlinx.coroutines.currentCoroutineContext
-import kotlinx.coroutines.ensureActive
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
-
-private data class AdSlotKey(val placementId: String, val format: AdFormat)
 
 internal class AndroidGoogleAdManager(
     val appContext: Context,
     val activityProvider: () -> Activity?
-) : AdManager, FullScreenPresenceAware {
-    private val _status = MutableStateFlow<AdManagerStatus>(AdManagerStatus.Idle)
-    private val _events = MutableSharedFlow<AdEvent>(extraBufferCapacity = 128)
-    private val registryLock = Any()
-
-    // Count of full-screen ads currently presenting across all slots. Observational only —
-    // admission is decided by fullScreenArbiter below, not by this counter. Updated from
-    // FullScreenSlotCore via onPresentationChanged. Guarded by presenceLock since shows can
-    // settle on different threads.
-    private val presenceLock = Any()
-    private var presenceCount = 0
-    private val _isFullScreenPresenting = MutableStateFlow(false)
-    override val isFullScreenPresenting: StateFlow<Boolean> = _isFullScreenPresenting
-
-    // The process-wide admission gate. AdMob.manager() is a per-process singleton, so this
-    // instance is the whole process's arbiter. Every full-screen slot this manager creates
-    // shares it, and AppOpenAdCoordinator probes it through FullScreenPresenceAware.
-    override val fullScreenArbiter: FullScreenPresentationArbiter = FullScreenPresentationArbiter()
+) : GoogleAdManagerBase() {
+    override val platformTag: String = "Android"
+    override val nativeInitializationDispatcher: CoroutineDispatcher = Dispatchers.Main.immediate
 
     /**
      * Shared by every full-screen slot, so a dismissed ad reverts audio to the global state this
      * manager actually applied to GMA rather than to hardcoded defaults.
      *
      * The supplier is deliberately lazy: slots are created before `initialize()` completes, and
-     * `null` correctly means "the host configured nothing, so GMA's own defaults apply".
+     * `null` correctly means "the host configured nothing, so GMA's own defaults apply". iOS has
+     * no equivalent — its slots take no audio controller at all.
      */
     private val fullScreenAudioController =
-        AndroidFullScreenAudioController { appliedConfigIdentity?.globalRequestConfiguration }
+        AndroidFullScreenAudioController { appliedConfigIdentitySnapshot()?.globalRequestConfiguration }
 
-    private fun onPresentationChanged(delta: Int) {
-        synchronized(presenceLock) {
-            presenceCount = (presenceCount + delta).coerceAtLeast(0)
-            _isFullScreenPresenting.value = presenceCount > 0
-        }
-    }
-
-    override val status: StateFlow<AdManagerStatus> = _status
-    override val events: SharedFlow<AdEvent> = _events
-    private val consentSession = ConsentSessionState()
     override val consent: ConsentController =
         AndroidConsentController(activityProvider, appContext, resume@{ config ->
-            val mode = consentSession.modeForPrivacyOptionsResume() ?: return@resume
+            val mode = privacyOptionsResumeMode() ?: return@resume
             initialize(config, mode)
         })
     private val androidDiagnostics = AndroidAdDiagnostics(activityProvider)
     override val diagnostics: AdDiagnostics = androidDiagnostics
     override val tracking: AdTrackingController = AndroidTrackingController
 
-    // Detects placement-id collisions: the same id used with a different ad unit /
-    // format / config silently reusing the first controller is a programming error.
-    private val registeredPlacements = mutableMapOf<String, AdPlacement>()
-
-    private fun checkPlacementCollision(placement: AdPlacement) {
-        val existing = registeredPlacements.getOrPut(placement.id) { placement }
-        check(existing == placement) {
-            "AdPlacement id '${placement.id}' is already registered with different configuration " +
-                "(existing=$existing, requested=$placement). Placement ids must be unique."
-        }
-    }
-
-    private val banners = mutableMapOf<String, BannerAdController>()
-    private val slots = mutableMapOf<AdSlotKey, FullScreenAdController>()
     private val nativeManager = NativeAdManagerImpl(
         policy = null,
         platform = AndroidNativeAdPlatform(),
@@ -118,509 +52,102 @@ internal class AndroidGoogleAdManager(
         // tryEmit and discarded the Boolean -- the exact pattern emitOrLogDrop was introduced to
         // remove -- so a dropped native event was silent, precisely where batching makes bursts
         // most likely.
-        eventSink = { _events.emitOrLogDrop(it, "NativeAds") },
+        eventSink = { mutableEvents.emitOrLogDrop(it, "NativeAds") },
     )
     override val nativeAds: NativeAdManager = nativeManager
 
-    /** Binds the deferred native facade only after this config has initialized GMA. */
-    internal fun configureNativeAdsAfterAcceptedInitialization(config: AdConfig) {
+    init {
+        // Must run after `consent` above is constructed — see GoogleAdManagerBase.startAdmissionTracking.
+        startAdmissionTracking()
+    }
+
+    internal override fun configureNativeAdsAfterAcceptedInitialization(config: AdConfig) {
         nativeManager.configure(config.nativeAdMemoryPolicy)
     }
-    private data class InitializationAttempt(
-        val identity: AdInitializationConfigIdentity,
-        val consentMode: ConsentMode,
-        val completion: CompletableDeferred<AdManagerStatus>
-    )
-    private sealed interface NativeInitializationResult {
-        data object Applied : NativeInitializationResult
-        data class Failed(val failure: Throwable) : NativeInitializationResult
-    }
-    private data class NativeInitialization(
-        val generation: Long,
-        val identity: AdInitializationConfigIdentity,
-        val completion: Deferred<NativeInitializationResult>
-    )
 
-    // Guards registration of the one in-flight consent -> GMA sequence. The
-    // narrower SDK mutex protects the native-applied identity and terminal state.
-    private val initializationStateMutex = Mutex()
-    private val mobileAdsInitializationMutex = Mutex()
-    // Main.immediate. Everything this scope runs — MobileAds.initialize and the global
-    // request-configuration writes that follow it — is a GMA call, and GMA calls belong
-    // on the main thread (CLAUDE.md invariant #5). The scope stays a detached
-    // SupervisorJob so cancelling one initialize() caller still cannot interrupt
-    // initialization; only the dispatcher changes here.
-    //
-    // iOS's equivalent scope (IosGoogleAdManager.nativeInitializationScope) uses plain
-    // Dispatchers.Main, not .immediate — an unexplained platform difference, not a
-    // deliberate one; nothing in this repo's history documents why. Do not read the
-    // asymmetry as intentional if you touch either scope.
-    private val nativeInitializationScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
-    private var pendingInitialization: InitializationAttempt? = null
-    private var nativeInitialization: NativeInitialization? = null
-    private var nativeInitializationGeneration = 0L
-    // Live admission state. Recomputed whenever consent mode or canRequestAds changes,
-    // so a revocation through the privacy options form immediately closes the gate.
-    // Replaces the previous sticky consentGateSatisfied latch.
-    private val _admission = MutableStateFlow(AdRequestAdmission.NotGathered)
+    override fun configuredNativePolicyOrNull(): NativeAdMemoryPolicy? = nativeManager.configuredPolicyOrNull()
 
-    // Own scope, deliberately NOT nativeInitializationScope, so the collector's lifetime
-    // is independent of initialization. Main.immediate matches the dispatcher every
-    // GMA/UMP call already uses, and matches iOS's own admissionScope
-    // (IosGoogleAdManager.admissionScope is Main.immediate too).
-    private val admissionScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
-
-    init {
-        admissionScope.launch {
-            consent.canRequestAds.collectLatest { canRequest ->
-                val next = consentSession.admission(canRequest)
-                val previous = _admission.value
-                if (previous == next) return@collectLatest
-                _admission.value = next
-                if (previous == AdRequestAdmission.Allowed && next == AdRequestAdmission.Revoked) {
-                    AdLogger.w("Android consent revoked. Closing ad request gate and purging cached inventory.")
-                    purgeOnRevocation()
-                }
-            }
-        }
-    }
-
-    @Volatile
-    private var appliedConfigIdentity: AdInitializationConfigIdentity? = null
-    @Volatile
-    private var appliedTerminalStatus: AdManagerStatus? = null
-
-    override suspend fun initialize(
-        config: AdConfig,
-        consentMode: ConsentMode
-    ): AdManagerStatus {
-        val ownedConfig = config.ownedSnapshot()
-        val requestedIdentity = ownedConfig.initializationIdentity(ownedConfig.androidAppId)
-        while (true) {
-            var leadsAttempt = false
-            var nativeCompletion: Deferred<NativeInitializationResult>? = null
-            val attempt = initializationStateMutex.withLock {
-                pendingInitialization?.let { return@withLock it }
-                nativeCompletion = mobileAdsInitializationMutex.withLock {
-                    nativeInitialization?.completion
-                }
-                if (nativeCompletion != null) return@withLock null
-                appliedOutcome(requestedIdentity, ownedConfig.nativeAdMemoryPolicy)?.let { return it }
-                InitializationAttempt(
-                    identity = requestedIdentity,
-                    consentMode = consentMode,
-                    completion = CompletableDeferred()
-                ).also {
-                    pendingInitialization = it
-                    leadsAttempt = true
-                }
-            }
-
-            val completionToAwait = nativeCompletion
-            if (completionToAwait != null) {
-                // Await outside admission so callers remain cancellable and no
-                // coordinator mutex is held while the native reservation settles.
-                completionToAwait.await()
-                continue
-            }
-            val admittedAttempt = checkNotNull(attempt)
-            if (leadsAttempt) {
-                return runInitializationAttempt(admittedAttempt, ownedConfig, consentMode)
-            }
-
-            val equivalentAttempt =
-                admittedAttempt.identity == requestedIdentity && admittedAttempt.consentMode == consentMode
-            val result = try {
-                admittedAttempt.completion.await()
-            } catch (leaderCancellation: CancellationException) {
-                currentCoroutineContext().ensureActive()
-                if (equivalentAttempt) throw leaderCancellation
-                continue
-            }
-            if (equivalentAttempt) return result
-            if (result == AdManagerStatus.Ready) {
-                appliedOutcome(requestedIdentity, config.nativeAdMemoryPolicy)?.let { return it }
-            }
-            // A distinct request waited for the process-wide slot but the leader
-            // did not initialize GMA. Register a new attempt for its own semantics.
-        }
-    }
-
-    private suspend fun runInitializationAttempt(
-        attempt: InitializationAttempt,
-        config: AdConfig,
-        consentMode: ConsentMode
-    ): AdManagerStatus {
-        AdLogger.i("Android initialize requested. consentMode=$consentMode")
-        config.testModeWarningOrNull()?.let(AdLogger::w)
-
-        val previousStatus = _status.value
-        _status.value = AdManagerStatus.Initializing
-
-        return try {
-            when (awaitAbandonedNativeInitialization()) {
-                NativeInitializationResult.Applied -> {
-                    val result = appliedOutcome(attempt.identity, config.nativeAdMemoryPolicy) ?: _status.value
-                    completeAttempt(attempt, result)
-                    return result
-                }
-                is NativeInitializationResult.Failed -> {
-                    appliedOutcome(attempt.identity, config.nativeAdMemoryPolicy)?.let { result ->
-                        completeAttempt(attempt, result)
-                        return result
-                    }
-                }
-                null -> Unit
-            }
-            // UMP guidance: request a consent info update on every app launch; do not
-            // rely on the previous session's cached state. Once this manager reaches
-            // Ready, equivalent calls are handled above and must not regress status or
-            // rerun consent, hooks, or the process-wide GMA singleton.
-            when (consentMode) {
-                ConsentMode.GatherBeforeInitialize -> consent.gatherConsent(config)
-                ConsentMode.InitializeOnlyIfAlreadyAllowed -> consent.requestConsentInfoUpdate(config)
-                ConsentMode.SkipConsent -> Unit
-            }
-            val effectiveCanRequest = withContext(Dispatchers.Main.immediate) {
-                consentSession.recordCompletedGate(consentMode)
-                val current = if (consentMode == ConsentMode.SkipConsent) true else consent.canRequestAds.value
-                val newAdmission = consentSession.admission(current)
-                _admission.value = newAdmission
-                current
-            }
-
-            AdLogger.i("Android consent gate complete. canRequestAds=$effectiveCanRequest mode=$consentMode")
-            if (!effectiveCanRequest) {
-                AdLogger.w("Android initialize deferred because consent does not allow ad requests yet.")
-                val result = AdManagerStatus.ConsentRequired.also {
-                    _status.value = it
-                }
-                completeAttempt(attempt, result)
-                return result
-            }
-
-            initializeMobileAds(config).also { completeAttempt(attempt, it) }
-        } catch (cancellation: CancellationException) {
-            cancelAttempt(attempt, cancellation, previousStatus)
-            throw cancellation
-        } catch (failure: Throwable) {
-            initializationFailed(failure).also { completeAttempt(attempt, it) }
-        }
-    }
-
-    private suspend fun completeAttempt(
-        attempt: InitializationAttempt,
-        result: AdManagerStatus
-    ) = withContext(NonCancellable) {
-        initializationStateMutex.withLock {
-            if (pendingInitialization === attempt) pendingInitialization = null
-        }
-        attempt.completion.complete(result)
-    }
-
-    private suspend fun cancelAttempt(
-        attempt: InitializationAttempt,
-        cancellation: CancellationException,
-        previousStatus: AdManagerStatus
-    ) = withContext(NonCancellable) {
-        _status.value = appliedTerminalStatus() ?: previousStatus
-        initializationStateMutex.withLock {
-            if (pendingInitialization === attempt) pendingInitialization = null
-        }
-        attempt.completion.completeExceptionally(cancellation)
-    }
-
-    private suspend fun appliedOutcome(
-        requestedIdentity: AdInitializationConfigIdentity,
-        requestedNativeAdMemoryPolicy: NativeAdMemoryPolicy,
-    ): AdManagerStatus? = mobileAdsInitializationMutex.withLock {
-        val decision = appliedConfigurationDecision(
-            appliedIdentity = appliedConfigIdentity,
-            requestedIdentity = requestedIdentity,
-            configuredNativePolicy = nativeManager.configuredPolicyOrNull(),
-            requestedNativePolicy = requestedNativeAdMemoryPolicy,
-            appliedTerminalStatus = appliedTerminalStatus,
-            currentStatus = _status.value,
-        )
-        when (decision) {
-            is AppliedConfigurationDecision.NotApplied -> null
-            is AppliedConfigurationDecision.Accepted ->
-                decision.publish?.let(::publishAppliedTerminalLocked)
-            is AppliedConfigurationDecision.Conflict -> {
-                AdLogger.w("Android MobileAds configuration conflict. ${decision.reason}")
-                // Publish the TRUE status, return the rejection. Publishing the rejection would
-                // make adRequestBlockedError() block every ad request process-wide, breaking the
-                // caller whose configuration was actually accepted.
-                publishAppliedTerminalLocked(decision.publish)
-                decision.rejection
-            }
-        }
-    }
-
-    private suspend fun appliedTerminalStatus(): AdManagerStatus? =
-        mobileAdsInitializationMutex.withLock { appliedTerminalStatus }
-
-    private suspend fun awaitAbandonedNativeInitialization(): NativeInitializationResult? {
-        val operation = mobileAdsInitializationMutex.withLock { nativeInitialization } ?: return null
-        return operation.completion.await()
-    }
-
-    private suspend fun initializeMobileAds(config: AdConfig): AdManagerStatus {
-        val requestedIdentity = config.initializationIdentity(config.androidAppId)
-        appliedOutcome(requestedIdentity, config.nativeAdMemoryPolicy)?.let { return it }
-
-        var operation = mobileAdsInitializationMutex.withLock { nativeInitialization }
-        if (operation == null) {
-            withContext(Dispatchers.Main.immediate) {
-                config.dispatchInitializationHooks(AdInitializationPhase.BeforeMobileAdsInitialize)
-            }
-            operation = startNativeInitialization(config, requestedIdentity)
-        }
-
-        val previousStatus = _status.value
-        _status.value = AdManagerStatus.Initializing
-        return try {
-            when (val nativeResult = operation.completion.await()) {
-                is NativeInitializationResult.Failed -> return initializationFailed(nativeResult.failure)
-                NativeInitializationResult.Applied -> Unit
-            }
-            AdLogger.i("Android MobileAds initialization succeeded.")
-            publishAppliedTerminal(previousStatus)
-        } catch (cancellation: CancellationException) {
-            withContext(NonCancellable) { publishAppliedTerminal(previousStatus) }
-            throw cancellation
-        } catch (failure: Throwable) {
-            recordAppliedFailure(requestedIdentity, failure)
-        }
-    }
-
-    private suspend fun startNativeInitialization(
-        config: AdConfig,
-        requestedIdentity: AdInitializationConfigIdentity
-    ): NativeInitialization = mobileAdsInitializationMutex.withLock {
-        nativeInitialization?.let { return@withLock it }
-        appliedConfigIdentity?.let {
-            return@withLock completedNativeInitialization(it)
-        }
-
-        val generation = ++nativeInitializationGeneration
-        // Runs on nativeInitializationScope (a detached SupervisorJob scope), not on any
-        // individual caller's coroutine, so cancelling one initialize() caller can never
-        // interrupt this operation — every caller (leader and followers) only awaits its
-        // result. THAT detachment is what makes AfterMobileAdsInitialize fire exactly once
-        // whenever native init succeeds; an earlier comment here credited the hook's position
-        // *before* publication, which was wrong and cost correctness elsewhere.
-        //
-        // Native acceptance MUST be committed BEFORE the hook runs. Commit it after, and a
-        // throwing publisher hook leaves appliedConfigIdentity null while GMA is already
-        // initialized, so a retry with a different app ID sails past appliedOutcome() and
-        // tries to reconfigure an immutable process singleton. The tradeoff is that a
-        // concurrent same-identity initialize() may observe Ready while the hook is still
-        // running — strictly better than desynchronizing the wrapper from native reality.
-        val completion = nativeInitializationScope.async(start = CoroutineStart.LAZY) {
-            val result = try {
-                AdLogger.d("Android initializing MobileAds with global request configuration.")
-                val initializationConfig = InitializationConfig.Builder(config.androidAppId)
-                    .setRequestConfiguration(requestedIdentity.globalRequestConfiguration.toAndroidRequestConfiguration())
-                    .build()
-                withContext(Dispatchers.IO) {
-                    // Bounded: GMA can accept the call and never invoke the callback, which used to
-                    // leave initialize() suspended forever. A timeout is NOT a CancellationException
-                    // (see awaitNativeCallback), so it reaches the catch below as a real failure and
-                    // leaves the identity uncommitted — making a retry the correct next step.
-                    awaitNativeCallback(
-                        operation = "MobileAds.initialize",
-                        timeout = InitializationTimeouts.nativeInitialize
-                    ) {
-                        suspendCancellableCoroutine { continuation ->
-                            MobileAds.initialize(appContext, initializationConfig) {
-                                if (continuation.isActive) continuation.resume(Unit)
-                            }
-                        }
-                    }
-                }
-                config.globalRequestConfiguration.publisherFirstPartyIdEnabled?.let {
-                    MobileAds.putPublisherFirstPartyIdEnabled(it)
-                }
-                config.globalRequestConfiguration.appMuted?.let {
-                    MobileAds.setUserMutedApp(it)
-                }
-                config.globalRequestConfiguration.appVolume?.let {
-                    MobileAds.setUserControlledAppVolume(it.coerceIn(0f, 1f))
-                }
-                // Already on nativeInitializationScope (Dispatchers.Main.immediate). Captured
-                // after MobileAds.initialize's callback so adapter statuses are populated,
-                // and before the After hook so a publisher hook can read them.
-                androidDiagnostics.captureSnapshotOnMain()
-                mobileAdsInitializationMutex.withLock {
-                    // Native GMA is initialized at this point and can never be reconfigured, so
-                    // the identity commit below must be unconditional. configureNativeAds can
-                    // throw -- NativeAdManagerImpl.configure has a check(existing == null) -- which
-                    // is the same trap as a throwing hook, one step earlier.
-                    try {
-                        configureNativeAdsAfterAcceptedInitialization(config)
-                    } catch (t: Throwable) {
-                        AdLogger.e(
-                            "Failed to bind the native ad memory policy after Android MobileAds " +
-                                "initialization. GMA stays initialized and Ready; native ad " +
-                                "capacity keeps its previously configured policy.",
-                            t
-                        )
-                    }
-                    appliedConfigIdentity = requestedIdentity
-                    appliedTerminalStatus = AdManagerStatus.Ready
-                }
-                // AFTER the commit, and isolated: a publisher hook is host code, so its failure is
-                // reported but must never make the native singleton look unapplied.
-                dispatchAfterInitializeHooks(config)
-                NativeInitializationResult.Applied
-            } catch (failure: Throwable) {
-                NativeInitializationResult.Failed(failure)
-            }
-            withContext(NonCancellable) {
-                mobileAdsInitializationMutex.withLock {
-                    if (nativeInitialization?.generation == generation) nativeInitialization = null
-                    if (result is NativeInitializationResult.Failed && appliedConfigIdentity == requestedIdentity) {
-                        val failed = failedInitializationStatus(result.failure)
-                        appliedTerminalStatus = failed
-                        publishAppliedTerminalLocked(failed)
-                    }
-                }
-            }
-            result
-        }
-        NativeInitialization(generation, requestedIdentity, completion).also {
-            nativeInitialization = it
-            completion.start()
-        }
-    }
-
-    private fun completedNativeInitialization(
-        identity: AdInitializationConfigIdentity
-    ): NativeInitialization = NativeInitialization(
-        generation = nativeInitializationGeneration,
-        identity = identity,
-        completion = CompletableDeferred(NativeInitializationResult.Applied)
-    )
-
-    private suspend fun publishAppliedTerminal(previousStatus: AdManagerStatus): AdManagerStatus =
-        mobileAdsInitializationMutex.withLock {
-            publishAppliedTerminalLocked(appliedTerminalStatus ?: previousStatus)
-        }
-
-    private fun publishAppliedTerminalLocked(terminal: AdManagerStatus): AdManagerStatus {
-        _status.value = terminal
-        return terminal
-    }
-
-    private suspend fun recordAppliedFailure(
-        requestedIdentity: AdInitializationConfigIdentity,
-        failure: Throwable
-    ): AdManagerStatus {
-        AdLogger.e("Android MobileAds initialization failed.", failure)
-        val failed = failedInitializationStatus(failure)
-        return withContext(NonCancellable) {
-            mobileAdsInitializationMutex.withLock {
-                if (appliedConfigIdentity == requestedIdentity) {
-                    appliedTerminalStatus = failed
-                    publishAppliedTerminalLocked(failed)
-                }
-            }
-            failed
-        }
-    }
-
-    private fun initializationFailed(failure: Throwable): AdManagerStatus {
-        AdLogger.e("Android MobileAds initialization failed.", failure)
-        return failedInitializationStatus(failure).also { failed -> _status.value = failed }
-    }
-
-    private fun failedInitializationStatus(failure: Throwable): AdManagerStatus.Failed =
-        AdManagerStatus.Failed(
-            error = AdError.message(failure.message ?: "Google Mobile Ads initialization failed."),
-            retryable = true
-        )
-
-    private fun adRequestBlockedError(): AdError? = when {
-        !_admission.value.permitsRequests -> AdError.consentRequired()
-        _status.value != AdManagerStatus.Ready -> AdError.sdkNotReady()
-        else -> null
-    }
-
-    /**
-     * Drops cached inventory across every registered controller after consent is
-     * revoked. Live full-screen presentations are deliberately NOT torn down: the
-     * ad is already owned by SDK callbacks, and destroying it mid-presentation is
-     * what caused the presentation-ownership defects fixed earlier (see the
-     * cancellation handling in FullScreenSlotCore.show()).
-     *
-     * Banner and native views may briefly render a destroyed SDK object after this
-     * runs; view-state coherence there is owned by BannerCore/NativeAdCoordinatorCore
-     * and is not addressed here.
-     */
-    private fun purgeOnRevocation() {
-        val (bannersSnapshot, slotsSnapshot) = synchronized(registryLock) {
-            Pair(banners.values.toList(), slots.values.toList())
-        }
-        bannersSnapshot.forEach { it.clear() }
-        slotsSnapshot.forEach { it.clear() }
+    override fun onNativeConsentRevoked() {
         nativeManager.onConsentRevoked()
-        AdLogger.i(
-            "Android revocation purge complete. banners=${bannersSnapshot.size} " +
-                "fullScreen=${slotsSnapshot.size} nativeSessions=${nativeAds.state.value.activeSessions}"
-        )
     }
 
-    override fun banner(placement: AdPlacement): BannerAdController = synchronized(registryLock) {
-        val ownedPlacement = placement.ownedSnapshot()
-        require(ownedPlacement.format == AdFormat.Banner) {
-            "AdPlacement '${ownedPlacement.id}' has format ${ownedPlacement.format} but was passed to a Banner factory. " +
-                "The factory function and placement.format must agree."
+    override fun appId(config: AdConfig): String = config.androidAppId
+
+    override fun captureDiagnosticsSnapshotOnMain() {
+        androidDiagnostics.captureSnapshotOnMain()
+    }
+
+    override suspend fun initializeMobileAdsNative(
+        config: AdConfig,
+        requestedIdentity: AdInitializationConfigIdentity,
+    ) {
+        AdLogger.d("Android initializing MobileAds with global request configuration.")
+        val initializationConfig = InitializationConfig.Builder(config.androidAppId)
+            .setRequestConfiguration(requestedIdentity.globalRequestConfiguration.toAndroidRequestConfiguration())
+            .build()
+        withContext(Dispatchers.IO) {
+            // MUST stay bounded: GMA can accept the call and never invoke the callback, which
+            // would leave initialize() suspended forever otherwise. A timeout is NOT a
+            // CancellationException (see awaitNativeCallback), so it reaches the catch below as
+            // a real failure and leaves the identity uncommitted — making a retry the correct
+            // next step.
+            awaitNativeCallback(
+                operation = "MobileAds.initialize",
+                timeout = InitializationTimeouts.nativeInitialize
+            ) {
+                suspendCancellableCoroutine { continuation ->
+                    MobileAds.initialize(appContext, initializationConfig) {
+                        if (continuation.isActive) continuation.resume(Unit)
+                    }
+                }
+            }
         }
-        checkPlacementCollision(ownedPlacement)
-        banners.getOrPut(ownedPlacement.id) {
-            AdLogger.d("Android banner controller created. placement=${ownedPlacement.id}")
-            AndroidBannerAdController(ownedPlacement, _events, ::adRequestBlockedError, activityProvider)
+        config.globalRequestConfiguration.publisherFirstPartyIdEnabled?.let {
+            MobileAds.putPublisherFirstPartyIdEnabled(it)
+        }
+        config.globalRequestConfiguration.appMuted?.let {
+            MobileAds.setUserMutedApp(it)
+        }
+        config.globalRequestConfiguration.appVolume?.let {
+            MobileAds.setUserControlledAppVolume(it.coerceIn(0f, 1f))
         }
     }
 
-    override fun interstitial(placement: AdPlacement): InterstitialAdController = synchronized(registryLock) {
-        val ownedPlacement = placement.ownedSnapshot()
-        require(ownedPlacement.format == AdFormat.Interstitial) {
-            "AdPlacement '${ownedPlacement.id}' has format ${ownedPlacement.format} but was passed to an Interstitial factory. " +
-                "The factory function and placement.format must agree."
+    override fun banner(placement: AdPlacement): BannerAdController =
+        registerBanner(placement) { owned ->
+            AdLogger.d("Android banner controller created. placement=${owned.id}")
+            AndroidBannerAdController(owned, mutableEvents, ::adRequestBlockedError, activityProvider)
         }
-        checkPlacementCollision(ownedPlacement)
-        slots.getOrPut(AdSlotKey(ownedPlacement.id, ownedPlacement.format)) { AndroidInterstitialSlot(ownedPlacement, activityProvider, _events, ::adRequestBlockedError, ::onPresentationChanged, fullScreenArbiter, fullScreenAudioController) } as InterstitialAdController
-    }
 
-    override fun rewarded(placement: AdPlacement): RewardedAdController = synchronized(registryLock) {
-        val ownedPlacement = placement.ownedSnapshot()
-        require(ownedPlacement.format == AdFormat.Rewarded) {
-            "AdPlacement '${ownedPlacement.id}' has format ${ownedPlacement.format} but was passed to a Rewarded factory. " +
-                "The factory function and placement.format must agree."
-        }
-        checkPlacementCollision(ownedPlacement)
-        slots.getOrPut(AdSlotKey(ownedPlacement.id, ownedPlacement.format)) { AndroidRewardedSlot(ownedPlacement, activityProvider, _events, ::adRequestBlockedError, ::onPresentationChanged, fullScreenArbiter, fullScreenAudioController) } as RewardedAdController
-    }
+    override fun interstitial(placement: AdPlacement): InterstitialAdController =
+        registerFullScreenSlot(placement, AdFormat.Interstitial) {
+            AndroidInterstitialSlot(
+                it, activityProvider, mutableEvents, ::adRequestBlockedError,
+                ::onPresentationChanged, fullScreenArbiter, fullScreenAudioController
+            )
+        } as InterstitialAdController
 
-    override fun rewardedInterstitial(placement: AdPlacement): RewardedInterstitialAdController = synchronized(registryLock) {
-        val ownedPlacement = placement.ownedSnapshot()
-        require(ownedPlacement.format == AdFormat.RewardedInterstitial) {
-            "AdPlacement '${ownedPlacement.id}' has format ${ownedPlacement.format} but was passed to a RewardedInterstitial factory. " +
-                "The factory function and placement.format must agree."
-        }
-        checkPlacementCollision(ownedPlacement)
-        slots.getOrPut(AdSlotKey(ownedPlacement.id, ownedPlacement.format)) { AndroidRewardedInterstitialSlot(ownedPlacement, activityProvider, _events, ::adRequestBlockedError, ::onPresentationChanged, fullScreenArbiter, fullScreenAudioController) } as RewardedInterstitialAdController
-    }
+    override fun rewarded(placement: AdPlacement): RewardedAdController =
+        registerFullScreenSlot(placement, AdFormat.Rewarded) {
+            AndroidRewardedSlot(
+                it, activityProvider, mutableEvents, ::adRequestBlockedError,
+                ::onPresentationChanged, fullScreenArbiter, fullScreenAudioController
+            )
+        } as RewardedAdController
 
-    override fun appOpen(placement: AdPlacement): AppOpenAdController = synchronized(registryLock) {
-        val ownedPlacement = placement.ownedSnapshot()
-        require(ownedPlacement.format == AdFormat.AppOpen) {
-            "AdPlacement '${ownedPlacement.id}' has format ${ownedPlacement.format} but was passed to an AppOpen factory. " +
-                "The factory function and placement.format must agree."
-        }
-        checkPlacementCollision(ownedPlacement)
-        slots.getOrPut(AdSlotKey(ownedPlacement.id, ownedPlacement.format)) { AndroidAppOpenSlot(ownedPlacement, activityProvider, _events, ::adRequestBlockedError, ::onPresentationChanged, fullScreenArbiter, fullScreenAudioController) } as AppOpenAdController
-    }
+    override fun rewardedInterstitial(placement: AdPlacement): RewardedInterstitialAdController =
+        registerFullScreenSlot(placement, AdFormat.RewardedInterstitial) {
+            AndroidRewardedInterstitialSlot(
+                it, activityProvider, mutableEvents, ::adRequestBlockedError,
+                ::onPresentationChanged, fullScreenArbiter, fullScreenAudioController
+            )
+        } as RewardedInterstitialAdController
+
+    override fun appOpen(placement: AdPlacement): AppOpenAdController =
+        registerFullScreenSlot(placement, AdFormat.AppOpen) {
+            AndroidAppOpenSlot(
+                it, activityProvider, mutableEvents, ::adRequestBlockedError,
+                ::onPresentationChanged, fullScreenArbiter, fullScreenAudioController
+            )
+        } as AppOpenAdController
 }

--- a/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/GoogleAdManagerBase.kt
+++ b/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/GoogleAdManagerBase.kt
@@ -1,0 +1,625 @@
+@file:OptIn(InternalAdMobCmpApi::class)
+
+package dev.avinya.ads
+
+import dev.avinya.ads.internal.AdRequestAdmission
+import dev.avinya.ads.internal.AppliedConfigurationDecision
+import dev.avinya.ads.internal.ConsentSessionState
+import dev.avinya.ads.internal.FullScreenPresentationArbiter
+import dev.avinya.ads.internal.FullScreenStateLock
+import dev.avinya.ads.internal.appliedConfigurationDecision
+import dev.avinya.ads.internal.dispatchAfterInitializeHooks
+import dev.avinya.ads.internal.ownedSnapshot
+import dev.avinya.ads.nativead.NativeAdMemoryPolicy
+import kotlin.concurrent.Volatile
+import kotlin.coroutines.cancellation.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+
+/** Registry key for a full-screen slot: one controller per (placement id, format) pair. */
+internal data class AdSlotKey(val placementId: String, val format: AdFormat)
+
+/**
+ * Shared initialization/registration orchestration for [AndroidGoogleAdManager] and
+ * [IosGoogleAdManager]. Everything here is platform-independent policy: the initialize()
+ * attempt-coalescing loop, the applied-configuration decision, native-init generation
+ * tracking and cleanup, terminal status publication, revocation purging, and placement
+ * registration/collision detection. A platform subclass implements only the hooks below —
+ * the actual GMA/GAD SDK calls, its own consent/diagnostics/tracking controllers, and its own
+ * per-format slot constructors (which take different constructor arguments per platform, e.g.
+ * Android's slots need an `Activity` provider and an audio controller that iOS has no
+ * equivalent for).
+ *
+ * Keep the fix at this altitude: if a change to the attempt-coalescing loop, the applied-outcome
+ * decision, or native-init cleanup seems to require touching `AndroidGoogleAdManager.kt` or
+ * `IosGoogleAdManager.kt`, that means shared policy has leaked into a platform subclass, not
+ * that this class needs a platform-specific branch.
+ */
+internal abstract class GoogleAdManagerBase : AdManager, FullScreenPresenceAware {
+    /** "Android" or "iOS" — the only textual difference in this class's log messages. */
+    protected abstract val platformTag: String
+
+    private val _status = MutableStateFlow<AdManagerStatus>(AdManagerStatus.Idle)
+    /** Mutable event sink. Not `_events`: detekt's underscore-prefix convention is reserved for
+     * `private` backing fields, and platform subclasses need to emit onto this directly. */
+    protected val mutableEvents = MutableSharedFlow<AdEvent>(extraBufferCapacity = 128)
+    override val status: StateFlow<AdManagerStatus> = _status
+    override val events: SharedFlow<AdEvent> = mutableEvents
+
+    // Guards the controller registries + collision map, and (separately) the process-wide
+    // presentation counter. FullScreenStateLock is synchronized(Any()) on Android and an
+    // NSRecursiveLock on iOS.
+    private val registryLock = FullScreenStateLock()
+    private val presenceLock = FullScreenStateLock()
+
+    // Count of full-screen ads currently presenting across all slots. Observational only —
+    // admission is decided by fullScreenArbiter below, not by this counter. Updated from
+    // FullScreenSlotCore via onPresentationChanged. Guarded by presenceLock since shows can
+    // settle on different threads.
+    private var presenceCount = 0
+    private val _isFullScreenPresenting = MutableStateFlow(false)
+    override val isFullScreenPresenting: StateFlow<Boolean> = _isFullScreenPresenting
+
+    // The process-wide admission gate. AdMob.manager() / IosAdMob.manager are per-process
+    // singletons, so this instance is the whole process's arbiter. Every full-screen slot this
+    // manager creates shares it, and AppOpenAdCoordinator probes it through
+    // FullScreenPresenceAware.
+    override val fullScreenArbiter: FullScreenPresentationArbiter = FullScreenPresentationArbiter()
+
+    protected fun onPresentationChanged(delta: Int) {
+        presenceLock.withLock {
+            presenceCount = (presenceCount + delta).coerceAtLeast(0)
+            _isFullScreenPresenting.value = presenceCount > 0
+        }
+    }
+
+    private val consentSession = ConsentSessionState()
+
+    // Detects placement-id collisions: the same id used with a different ad unit /
+    // format / config silently reusing the first controller is a programming error.
+    private val registeredPlacements = mutableMapOf<String, AdPlacement>()
+
+    private fun checkPlacementCollision(placement: AdPlacement) {
+        val existing = registeredPlacements.getOrPut(placement.id) { placement }
+        check(existing == placement) {
+            "AdPlacement id '${placement.id}' is already registered with different configuration " +
+                "(existing=$existing, requested=$placement). Placement ids must be unique."
+        }
+    }
+
+    private val banners = mutableMapOf<String, BannerAdController>()
+    private val slots = mutableMapOf<AdSlotKey, FullScreenAdController>()
+
+    /**
+     * Shared body of every `banner()` override: validates format, checks for a collision, and
+     * caches by placement id. [create] runs only on a genuine cache miss — put any
+     * creation-only logging (Android logs one line here) inside it.
+     */
+    protected fun registerBanner(
+        placement: AdPlacement,
+        create: (AdPlacement) -> BannerAdController,
+    ): BannerAdController = registryLock.withLock {
+        val ownedPlacement = placement.ownedSnapshot()
+        require(ownedPlacement.format == AdFormat.Banner) {
+            "AdPlacement '${ownedPlacement.id}' has format ${ownedPlacement.format} but was passed to a Banner factory. " +
+                "The factory function and placement.format must agree."
+        }
+        checkPlacementCollision(ownedPlacement)
+        banners.getOrPut(ownedPlacement.id) { create(ownedPlacement) }
+    }
+
+    /** Shared body of every full-screen `interstitial()`/`rewarded()`/... override. See [registerBanner]. */
+    protected fun registerFullScreenSlot(
+        placement: AdPlacement,
+        format: AdFormat,
+        create: (AdPlacement) -> FullScreenAdController,
+    ): FullScreenAdController = registryLock.withLock {
+        val ownedPlacement = placement.ownedSnapshot()
+        require(ownedPlacement.format == format) {
+            "AdPlacement '${ownedPlacement.id}' has format ${ownedPlacement.format} but was passed to a $format factory. " +
+                "The factory function and placement.format must agree."
+        }
+        checkPlacementCollision(ownedPlacement)
+        slots.getOrPut(AdSlotKey(ownedPlacement.id, ownedPlacement.format)) { create(ownedPlacement) }
+    }
+
+    /**
+     * Binds the deferred native facade only after this config has initialized GMA.
+     *
+     * `internal`, not `protected`: `AndroidGoogleAdManagerNativePolicyTest` and
+     * `IosGoogleAdManagerNativePolicyTest` call this directly as same-module white-box tests,
+     * not from a subclass.
+     */
+    internal abstract fun configureNativeAdsAfterAcceptedInitialization(config: AdConfig)
+
+    /** Forwards to the platform's own `NativeAdManagerImpl.onConsentRevoked()`, which is not
+     * part of the public [dev.avinya.ads.nativead.NativeAdManager] interface and whose concrete
+     * type differs per platform. */
+    protected abstract fun onNativeConsentRevoked()
+
+    /** `config.androidAppId` or `config.iosAppId` — the one field difference in identity resolution. */
+    protected abstract fun appId(config: AdConfig): String
+
+    /**
+     * Reads GMA's/GAD's version and adapter statuses onto the platform's diagnostics object.
+     * MUST run on Main, immediately after [initializeMobileAdsNative] returns and before
+     * [dev.avinya.ads.internal.dispatchAfterInitializeHooks] runs, so a publisher hook can read
+     * populated adapter statuses.
+     */
+    protected abstract fun captureDiagnosticsSnapshotOnMain()
+
+    /**
+     * Applies [requestedIdentity]'s global request configuration to the native SDK, starts it,
+     * and applies `publisherFirstPartyIdEnabled`/`appMuted`/`appVolume` from [config] — the one
+     * point where this class actually touches GMA (Android) or GAD (iOS). Must suspend until the
+     * SDK reports completion or [dev.avinya.ads.internal.InitializationTimeouts.nativeInitialize]
+     * elapses; a timeout must surface as a thrown failure, not a `CancellationException` (see
+     * `awaitNativeCallback`), so a retry after a timeout is possible.
+     */
+    protected abstract suspend fun initializeMobileAdsNative(
+        config: AdConfig,
+        requestedIdentity: AdInitializationConfigIdentity,
+    )
+
+    private data class InitializationAttempt(
+        val identity: AdInitializationConfigIdentity,
+        val consentMode: ConsentMode,
+        val completion: CompletableDeferred<AdManagerStatus>
+    )
+    private sealed interface NativeInitializationResult {
+        data object Applied : NativeInitializationResult
+        data class Failed(val failure: Throwable) : NativeInitializationResult
+    }
+    private data class NativeInitialization(
+        val generation: Long,
+        val identity: AdInitializationConfigIdentity,
+        val completion: Deferred<NativeInitializationResult>
+    )
+
+    // Guards registration of the one in-flight consent -> GMA sequence. The
+    // narrower SDK mutex protects the native-applied identity and terminal state.
+    private val initializationStateMutex = Mutex()
+    private val mobileAdsInitializationMutex = Mutex()
+
+    /**
+     * Dispatcher [nativeInitializationScope] runs on. Android uses `Dispatchers.Main.immediate`;
+     * iOS uses plain `Dispatchers.Main`. This is an unexplained platform difference, not a
+     * deliberate one — nothing in this repo documents why they diverge. Do not "fix" it by
+     * unifying the two without first finding out why.
+     */
+    protected abstract val nativeInitializationDispatcher: CoroutineDispatcher
+
+    // Runs on a detached SupervisorJob scope, not on any individual caller's coroutine, so
+    // cancelling one initialize() caller can never interrupt native initialization — every
+    // caller (leader and followers) only awaits its result. `by lazy`: [nativeInitializationDispatcher]
+    // is an abstract member a subclass overrides, and reading an overridden member from a base
+    // class's own eager property initializer would observe it before the subclass's
+    // initializer runs. Deferring construction to first use (always well after the whole object
+    // is constructed) sidesteps that entirely.
+    private val nativeInitializationScope by lazy { CoroutineScope(SupervisorJob() + nativeInitializationDispatcher) }
+    private var pendingInitialization: InitializationAttempt? = null
+    private var nativeInitialization: NativeInitialization? = null
+    private var nativeInitializationGeneration = 0L
+
+    // Live admission state. Recomputed whenever consent mode or canRequestAds changes, so a
+    // revocation through the privacy options form immediately closes the gate. Replaces the
+    // previous sticky consentGateSatisfied latch.
+    private val _admission = MutableStateFlow(AdRequestAdmission.NotGathered)
+
+    // Own scope, deliberately NOT nativeInitializationScope, so the collector's lifetime is
+    // independent of initialization. Main.immediate matches the dispatcher every GMA/UMP call
+    // already uses, and is identical on both platforms (unlike nativeInitializationDispatcher
+    // above).
+    private val admissionScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+
+    /**
+     * Starts the consent -> admission collector. Each platform subclass MUST call this from its
+     * own `init {}` block, after its own `consent` property is constructed — NOT from this base
+     * class's construction, because `consent` is an abstract member the subclass overrides with
+     * an eagerly-constructed property, and a base class's own init-time code runs strictly
+     * before a derived class's property initializers. Reading `consent` here during base
+     * construction would observe it before it exists.
+     */
+    protected fun startAdmissionTracking() {
+        admissionScope.launch {
+            consent.canRequestAds.collectLatest { canRequest ->
+                val next = consentSession.admission(canRequest)
+                val previous = _admission.value
+                if (previous == next) return@collectLatest
+                _admission.value = next
+                if (previous == AdRequestAdmission.Allowed && next == AdRequestAdmission.Revoked) {
+                    AdLogger.w("$platformTag consent revoked. Closing ad request gate and purging cached inventory.")
+                    purgeOnRevocation()
+                }
+            }
+        }
+    }
+
+    @Volatile
+    private var appliedConfigIdentity: AdInitializationConfigIdentity? = null
+    @Volatile
+    private var appliedTerminalStatus: AdManagerStatus? = null
+
+    /**
+     * The identity actually applied to the native SDK, or null before the first successful
+     * `initialize()`. Exposed so a platform's own per-presentation audio controller can read
+     * the applied [GlobalRequestConfiguration] without this base class needing to know that
+     * controller exists (only Android has one today).
+     */
+    protected fun appliedConfigIdentitySnapshot(): AdInitializationConfigIdentity? = appliedConfigIdentity
+
+    /** The consent mode to resume `initialize()` with after `showPrivacyOptions()` grants consent. */
+    protected fun privacyOptionsResumeMode(): ConsentMode? = consentSession.modeForPrivacyOptionsResume()
+
+    override suspend fun initialize(
+        config: AdConfig,
+        consentMode: ConsentMode
+    ): AdManagerStatus {
+        val ownedConfig = config.ownedSnapshot()
+        val requestedIdentity = ownedConfig.initializationIdentity(appId(ownedConfig))
+        while (true) {
+            var leadsAttempt = false
+            var nativeCompletion: Deferred<NativeInitializationResult>? = null
+            val attempt = initializationStateMutex.withLock {
+                pendingInitialization?.let { return@withLock it }
+                nativeCompletion = mobileAdsInitializationMutex.withLock {
+                    nativeInitialization?.completion
+                }
+                if (nativeCompletion != null) return@withLock null
+                appliedOutcome(requestedIdentity, ownedConfig.nativeAdMemoryPolicy)?.let { return it }
+                InitializationAttempt(
+                    identity = requestedIdentity,
+                    consentMode = consentMode,
+                    completion = CompletableDeferred()
+                ).also {
+                    pendingInitialization = it
+                    leadsAttempt = true
+                }
+            }
+
+            val completionToAwait = nativeCompletion
+            if (completionToAwait != null) {
+                // Await outside admission so callers remain cancellable and no
+                // coordinator mutex is held while the native reservation settles.
+                completionToAwait.await()
+                continue
+            }
+            val admittedAttempt = checkNotNull(attempt)
+            if (leadsAttempt) {
+                return runInitializationAttempt(admittedAttempt, ownedConfig, consentMode)
+            }
+
+            val equivalentAttempt =
+                admittedAttempt.identity == requestedIdentity && admittedAttempt.consentMode == consentMode
+            val result = try {
+                admittedAttempt.completion.await()
+            } catch (leaderCancellation: CancellationException) {
+                currentCoroutineContext().ensureActive()
+                if (equivalentAttempt) throw leaderCancellation
+                continue
+            }
+            if (equivalentAttempt) return result
+            if (result == AdManagerStatus.Ready) {
+                appliedOutcome(requestedIdentity, config.nativeAdMemoryPolicy)?.let { return it }
+            }
+            // A distinct request waited for the process-wide slot but the leader
+            // did not initialize GMA. Register a new attempt for its own semantics.
+        }
+    }
+
+    private suspend fun runInitializationAttempt(
+        attempt: InitializationAttempt,
+        config: AdConfig,
+        consentMode: ConsentMode
+    ): AdManagerStatus {
+        AdLogger.i("$platformTag initialize requested. consentMode=$consentMode")
+        config.testModeWarningOrNull()?.let(AdLogger::w)
+
+        val previousStatus = _status.value
+        _status.value = AdManagerStatus.Initializing
+
+        return try {
+            when (awaitAbandonedNativeInitialization()) {
+                NativeInitializationResult.Applied -> {
+                    val result = appliedOutcome(attempt.identity, config.nativeAdMemoryPolicy) ?: _status.value
+                    completeAttempt(attempt, result)
+                    return result
+                }
+                is NativeInitializationResult.Failed -> {
+                    appliedOutcome(attempt.identity, config.nativeAdMemoryPolicy)?.let { result ->
+                        completeAttempt(attempt, result)
+                        return result
+                    }
+                }
+                null -> Unit
+            }
+            // UMP guidance: request a consent info update on every app launch; do not
+            // rely on the previous session's cached state. Once this manager reaches
+            // Ready, equivalent calls are handled above and must not regress status or
+            // rerun consent, hooks, or the process-wide GMA singleton.
+            when (consentMode) {
+                ConsentMode.GatherBeforeInitialize -> consent.gatherConsent(config)
+                ConsentMode.InitializeOnlyIfAlreadyAllowed -> consent.requestConsentInfoUpdate(config)
+                ConsentMode.SkipConsent -> Unit
+            }
+            val effectiveCanRequest = withContext(Dispatchers.Main.immediate) {
+                consentSession.recordCompletedGate(consentMode)
+                val current = if (consentMode == ConsentMode.SkipConsent) true else consent.canRequestAds.value
+                val newAdmission = consentSession.admission(current)
+                _admission.value = newAdmission
+                current
+            }
+
+            AdLogger.i("$platformTag consent gate complete. canRequestAds=$effectiveCanRequest mode=$consentMode")
+            if (!effectiveCanRequest) {
+                AdLogger.w("$platformTag initialize deferred because consent does not allow ad requests yet.")
+                val result = AdManagerStatus.ConsentRequired.also {
+                    _status.value = it
+                }
+                completeAttempt(attempt, result)
+                return result
+            }
+
+            initializeMobileAds(config).also { completeAttempt(attempt, it) }
+        } catch (cancellation: CancellationException) {
+            cancelAttempt(attempt, cancellation, previousStatus)
+            throw cancellation
+        } catch (failure: Throwable) {
+            initializationFailed(failure).also { completeAttempt(attempt, it) }
+        }
+    }
+
+    private suspend fun completeAttempt(
+        attempt: InitializationAttempt,
+        result: AdManagerStatus
+    ) = withContext(NonCancellable) {
+        initializationStateMutex.withLock {
+            if (pendingInitialization === attempt) pendingInitialization = null
+        }
+        attempt.completion.complete(result)
+    }
+
+    private suspend fun cancelAttempt(
+        attempt: InitializationAttempt,
+        cancellation: CancellationException,
+        previousStatus: AdManagerStatus
+    ) = withContext(NonCancellable) {
+        _status.value = appliedTerminalStatus() ?: previousStatus
+        initializationStateMutex.withLock {
+            if (pendingInitialization === attempt) pendingInitialization = null
+        }
+        attempt.completion.completeExceptionally(cancellation)
+    }
+
+    private suspend fun appliedOutcome(
+        requestedIdentity: AdInitializationConfigIdentity,
+        requestedNativeAdMemoryPolicy: NativeAdMemoryPolicy,
+    ): AdManagerStatus? = mobileAdsInitializationMutex.withLock {
+        val decision = appliedConfigurationDecision(
+            appliedIdentity = appliedConfigIdentity,
+            requestedIdentity = requestedIdentity,
+            configuredNativePolicy = configuredNativePolicyOrNull(),
+            requestedNativePolicy = requestedNativeAdMemoryPolicy,
+            appliedTerminalStatus = appliedTerminalStatus,
+            currentStatus = _status.value,
+        )
+        when (decision) {
+            is AppliedConfigurationDecision.NotApplied -> null
+            is AppliedConfigurationDecision.Accepted ->
+                decision.publish?.let(::publishAppliedTerminalLocked)
+            is AppliedConfigurationDecision.Conflict -> {
+                AdLogger.w("$platformTag MobileAds configuration conflict. ${decision.reason}")
+                // Publish the TRUE status, return the rejection. Publishing the rejection would
+                // make adRequestBlockedError() block every ad request process-wide, breaking the
+                // caller whose configuration was actually accepted.
+                publishAppliedTerminalLocked(decision.publish)
+                decision.rejection
+            }
+        }
+    }
+
+    /** The platform's own `nativeManager.configuredPolicyOrNull()` — see [onNativeConsentRevoked]. */
+    protected abstract fun configuredNativePolicyOrNull(): NativeAdMemoryPolicy?
+
+    private suspend fun appliedTerminalStatus(): AdManagerStatus? =
+        mobileAdsInitializationMutex.withLock { appliedTerminalStatus }
+
+    private suspend fun awaitAbandonedNativeInitialization(): NativeInitializationResult? {
+        val operation = mobileAdsInitializationMutex.withLock { nativeInitialization } ?: return null
+        return operation.completion.await()
+    }
+
+    private suspend fun initializeMobileAds(config: AdConfig): AdManagerStatus {
+        val requestedIdentity = config.initializationIdentity(appId(config))
+        appliedOutcome(requestedIdentity, config.nativeAdMemoryPolicy)?.let { return it }
+
+        var operation = mobileAdsInitializationMutex.withLock { nativeInitialization }
+        if (operation == null) {
+            withContext(Dispatchers.Main.immediate) {
+                config.dispatchInitializationHooks(AdInitializationPhase.BeforeMobileAdsInitialize)
+            }
+            operation = startNativeInitialization(config, requestedIdentity)
+        }
+
+        val previousStatus = _status.value
+        _status.value = AdManagerStatus.Initializing
+        return try {
+            when (val nativeResult = operation.completion.await()) {
+                is NativeInitializationResult.Failed -> return initializationFailed(nativeResult.failure)
+                NativeInitializationResult.Applied -> Unit
+            }
+            AdLogger.i("$platformTag MobileAds initialization succeeded.")
+            publishAppliedTerminal(previousStatus)
+        } catch (cancellation: CancellationException) {
+            withContext(NonCancellable) { publishAppliedTerminal(previousStatus) }
+            throw cancellation
+        } catch (failure: Throwable) {
+            recordAppliedFailure(requestedIdentity, failure)
+        }
+    }
+
+    private suspend fun startNativeInitialization(
+        config: AdConfig,
+        requestedIdentity: AdInitializationConfigIdentity
+    ): NativeInitialization = mobileAdsInitializationMutex.withLock {
+        nativeInitialization?.let { return@withLock it }
+        appliedConfigIdentity?.let {
+            return@withLock completedNativeInitialization(it)
+        }
+
+        val generation = ++nativeInitializationGeneration
+        // MUST run on nativeInitializationScope (a detached SupervisorJob scope), not on any
+        // individual caller's coroutine: cancelling one initialize() caller must never interrupt
+        // this operation — every caller (leader and followers) only awaits its result. That
+        // detachment is what guarantees AfterMobileAdsInitialize fires exactly once whenever
+        // native init succeeds, regardless of which caller's coroutine gets cancelled.
+        //
+        // Native acceptance MUST be committed BEFORE the hook runs. Commit it after, and a
+        // throwing publisher hook leaves appliedConfigIdentity null while GMA is already
+        // initialized, so a retry with a different app ID sails past appliedOutcome() and
+        // tries to reconfigure an immutable process singleton. The tradeoff is that a
+        // concurrent same-identity initialize() may observe Ready while the hook is still
+        // running — strictly better than desynchronizing the wrapper from native reality.
+        val completion = nativeInitializationScope.async(start = CoroutineStart.LAZY) {
+            val result = try {
+                initializeMobileAdsNative(config, requestedIdentity)
+                // Captured after the native call returns so adapter statuses are populated, and
+                // before the After hook so a publisher hook can read them.
+                captureDiagnosticsSnapshotOnMain()
+                mobileAdsInitializationMutex.withLock {
+                    // Native GMA is initialized at this point and can never be reconfigured, so
+                    // the identity commit below must be unconditional. configureNativeAds can
+                    // throw -- NativeAdManagerImpl.configure has a check(existing == null) -- which
+                    // is the same trap as a throwing hook, one step earlier.
+                    try {
+                        configureNativeAdsAfterAcceptedInitialization(config)
+                    } catch (t: Throwable) {
+                        AdLogger.e(
+                            "Failed to bind the native ad memory policy after $platformTag MobileAds " +
+                                "initialization. GMA stays initialized and Ready; native ad " +
+                                "capacity keeps its previously configured policy.",
+                            t
+                        )
+                    }
+                    appliedConfigIdentity = requestedIdentity
+                    appliedTerminalStatus = AdManagerStatus.Ready
+                }
+                // AFTER the commit, and isolated: a publisher hook is host code, so its failure is
+                // reported but must never make the native singleton look unapplied.
+                dispatchAfterInitializeHooks(config)
+                NativeInitializationResult.Applied
+            } catch (failure: Throwable) {
+                NativeInitializationResult.Failed(failure)
+            }
+            withContext(NonCancellable) {
+                mobileAdsInitializationMutex.withLock {
+                    if (nativeInitialization?.generation == generation) nativeInitialization = null
+                    if (result is NativeInitializationResult.Failed && appliedConfigIdentity == requestedIdentity) {
+                        val failed = failedInitializationStatus(result.failure)
+                        appliedTerminalStatus = failed
+                        publishAppliedTerminalLocked(failed)
+                    }
+                }
+            }
+            result
+        }
+        NativeInitialization(generation, requestedIdentity, completion).also {
+            nativeInitialization = it
+            completion.start()
+        }
+    }
+
+    private fun completedNativeInitialization(
+        identity: AdInitializationConfigIdentity
+    ): NativeInitialization = NativeInitialization(
+        generation = nativeInitializationGeneration,
+        identity = identity,
+        completion = CompletableDeferred(NativeInitializationResult.Applied)
+    )
+
+    private suspend fun publishAppliedTerminal(previousStatus: AdManagerStatus): AdManagerStatus =
+        mobileAdsInitializationMutex.withLock {
+            publishAppliedTerminalLocked(appliedTerminalStatus ?: previousStatus)
+        }
+
+    private fun publishAppliedTerminalLocked(terminal: AdManagerStatus): AdManagerStatus {
+        _status.value = terminal
+        return terminal
+    }
+
+    private suspend fun recordAppliedFailure(
+        requestedIdentity: AdInitializationConfigIdentity,
+        failure: Throwable
+    ): AdManagerStatus {
+        AdLogger.e("$platformTag MobileAds initialization failed.", failure)
+        val failed = failedInitializationStatus(failure)
+        return withContext(NonCancellable) {
+            mobileAdsInitializationMutex.withLock {
+                if (appliedConfigIdentity == requestedIdentity) {
+                    appliedTerminalStatus = failed
+                    publishAppliedTerminalLocked(failed)
+                }
+            }
+            failed
+        }
+    }
+
+    private fun initializationFailed(failure: Throwable): AdManagerStatus {
+        AdLogger.e("$platformTag MobileAds initialization failed.", failure)
+        return failedInitializationStatus(failure).also { failed -> _status.value = failed }
+    }
+
+    private fun failedInitializationStatus(failure: Throwable): AdManagerStatus.Failed =
+        AdManagerStatus.Failed(
+            error = AdError.message(failure.message ?: "Google Mobile Ads initialization failed."),
+            retryable = true
+        )
+
+    protected fun adRequestBlockedError(): AdError? = when {
+        !_admission.value.permitsRequests -> AdError.consentRequired()
+        _status.value != AdManagerStatus.Ready -> AdError.sdkNotReady()
+        else -> null
+    }
+
+    /**
+     * Drops cached inventory across every registered controller after consent is
+     * revoked. Live full-screen presentations are deliberately NOT torn down: the
+     * ad is already owned by SDK callbacks, and destroying it mid-presentation is
+     * what caused the presentation-ownership defects fixed earlier (see the
+     * cancellation handling in FullScreenSlotCore.show()).
+     *
+     * Banner and native views may briefly render a destroyed SDK object after this
+     * runs; view-state coherence there is owned by BannerCore/NativeAdCoordinatorCore
+     * and is not addressed here.
+     */
+    private fun purgeOnRevocation() {
+        val (bannersSnapshot, slotsSnapshot) = registryLock.withLock {
+            Pair(banners.values.toList(), slots.values.toList())
+        }
+        bannersSnapshot.forEach { it.clear() }
+        slotsSnapshot.forEach { it.clear() }
+        onNativeConsentRevoked()
+        AdLogger.i(
+            "$platformTag revocation purge complete. banners=${bannersSnapshot.size} " +
+                "fullScreen=${slotsSnapshot.size} nativeSessions=${nativeAds.state.value.activeSessions}"
+        )
+    }
+}

--- a/admob-cmp-core/src/iosMain/kotlin/dev/avinya/ads/IosGoogleAdManager.kt
+++ b/admob-cmp-core/src/iosMain/kotlin/dev/avinya/ads/IosGoogleAdManager.kt
@@ -9,50 +9,21 @@ import GoogleMobileAds.GADCurrentOrientationInlineAdaptiveBannerAdSizeWithWidth
 import GoogleMobileAds.GADInlineAdaptiveBannerAdSizeWithWidthAndMaxHeight
 import GoogleMobileAds.GADLargeAnchoredAdaptiveBannerAdSizeWithWidth
 import GoogleMobileAds.GADMobileAds
-import dev.avinya.ads.internal.AdRequestAdmission
-import dev.avinya.ads.internal.FullScreenPresentationArbiter
-import dev.avinya.ads.internal.deriveAdmission
-import dev.avinya.ads.internal.ConsentSessionState
-import dev.avinya.ads.internal.ownedSnapshot
+import dev.avinya.ads.internal.InitializationTimeouts
 import dev.avinya.ads.internal.NativeAdManagerImpl
+import dev.avinya.ads.internal.awaitNativeCallback
 import dev.avinya.ads.internal.emitOrLogDrop
 import dev.avinya.ads.nativead.IosNativeAdPlatform
 import dev.avinya.ads.nativead.NativeAdManager
 import dev.avinya.ads.nativead.NativeAdMemoryPolicy
-import kotlin.coroutines.cancellation.CancellationException
-import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.CoroutineStart
-import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.NonCancellable
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.async
-import kotlinx.coroutines.currentCoroutineContext
-import kotlinx.coroutines.ensureActive
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlin.coroutines.resume
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.cinterop.CValue
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.readValue
 import platform.CoreGraphics.CGSizeMake
-import platform.Foundation.NSRecursiveLock
-import dev.avinya.ads.internal.AppliedConfigurationDecision
-import dev.avinya.ads.internal.InitializationTimeouts
-import dev.avinya.ads.internal.appliedConfigurationDecision
-import dev.avinya.ads.internal.awaitNativeCallback
-import dev.avinya.ads.internal.dispatchAfterInitializeHooks
-
-private data class AdSlotKey(val placementId: String, val format: AdFormat)
 
 private object IosAdManagerHolder {
     val instance: IosGoogleAdManager = IosGoogleAdManager()
@@ -63,57 +34,22 @@ public object IosAdMob {
     public val manager: AdManager get() = IosAdManagerHolder.instance
 }
 
-internal class IosGoogleAdManager : AdManager, FullScreenPresenceAware {
-    private val _status = MutableStateFlow<AdManagerStatus>(AdManagerStatus.Idle)
-    private val _events = MutableSharedFlow<AdEvent>(extraBufferCapacity = 128)
+internal class IosGoogleAdManager : GoogleAdManagerBase() {
+    override val platformTag: String = "iOS"
 
-    // Guards the controller registries + collision map. Android uses synchronized(registryLock);
-    // an NSRecursiveLock is the iOS equivalent so concurrent factory calls can't create two
-    // controllers for the same placement or corrupt the maps.
-    private val registryLock = NSRecursiveLock()
-    private inline fun <T> registry(block: () -> T): T {
-        registryLock.lock()
-        try {
-            return block()
-        } finally {
-            registryLock.unlock()
-        }
-    }
+    // iOS's equivalent of Android's nativeInitializationScope is already Dispatchers.Main, not
+    // .immediate — see the KDoc on GoogleAdManagerBase.nativeInitializationDispatcher for why
+    // this is preserved rather than unified.
+    override val nativeInitializationDispatcher: CoroutineDispatcher = Dispatchers.Main
 
-    // Process-wide full-screen presentation count + derived signal (see FullScreenPresenceAware).
-    // Observational only — admission is decided by fullScreenArbiter below. Updated from
-    // FullScreenSlotCore via onPresentationChanged.
-    private val presenceLock = NSRecursiveLock()
-    private var presenceCount = 0
-    private val _isFullScreenPresenting = MutableStateFlow(false)
-    override val isFullScreenPresenting: StateFlow<Boolean> = _isFullScreenPresenting
-
-    // Process-wide admission gate — see the Android twin. Shared by every full-screen slot
-    // this manager creates and probed by AppOpenAdCoordinator.
-    override val fullScreenArbiter: FullScreenPresentationArbiter = FullScreenPresentationArbiter()
-    private fun onPresentationChanged(delta: Int) {
-        presenceLock.lock()
-        try {
-            presenceCount = (presenceCount + delta).coerceAtLeast(0)
-            _isFullScreenPresenting.value = presenceCount > 0
-        } finally {
-            presenceLock.unlock()
-        }
-    }
-
-    override val status: StateFlow<AdManagerStatus> = _status
-    override val events: SharedFlow<AdEvent> = _events
-    private val consentSession = ConsentSessionState()
     override val consent: ConsentController = IosConsentController(resume@{ config ->
-        val mode = consentSession.modeForPrivacyOptionsResume() ?: return@resume
+        val mode = privacyOptionsResumeMode() ?: return@resume
         initialize(config, mode)
     })
     private val iosDiagnostics = IosAdDiagnostics()
     override val diagnostics: AdDiagnostics = iosDiagnostics
     override val tracking: AdTrackingController = IosTrackingController
 
-    private val banners = mutableMapOf<String, BannerAdController>()
-    private val slots = mutableMapOf<AdSlotKey, FullScreenAdController>()
     private val nativeManager = NativeAdManagerImpl(
         policy = null,
         platform = IosNativeAdPlatform(),
@@ -122,505 +58,95 @@ internal class IosGoogleAdManager : AdManager, FullScreenPresenceAware {
         // tryEmit and discarded the Boolean -- the exact pattern emitOrLogDrop was introduced to
         // remove -- so a dropped native event was silent, precisely where batching makes bursts
         // most likely.
-        eventSink = { _events.emitOrLogDrop(it, "NativeAds") },
+        eventSink = { mutableEvents.emitOrLogDrop(it, "NativeAds") },
     )
     override val nativeAds: NativeAdManager = nativeManager
 
-    /** Binds the deferred native facade only after this config has initialized GMA. */
-    internal fun configureNativeAdsAfterAcceptedInitialization(config: AdConfig) {
+    init {
+        // Must run after `consent` above is constructed — see GoogleAdManagerBase.startAdmissionTracking.
+        startAdmissionTracking()
+    }
+
+    internal override fun configureNativeAdsAfterAcceptedInitialization(config: AdConfig) {
         nativeManager.configure(config.nativeAdMemoryPolicy)
     }
 
-    // Detects placement-id collisions: the same id used with a different ad unit /
-    // format / config silently reusing the first controller is a programming error.
-    private val registeredPlacements = mutableMapOf<String, AdPlacement>()
+    override fun configuredNativePolicyOrNull(): NativeAdMemoryPolicy? = nativeManager.configuredPolicyOrNull()
 
-    private fun checkPlacementCollision(placement: AdPlacement) {
-        val existing = registeredPlacements.getOrPut(placement.id) { placement }
-        check(existing == placement) {
-            "AdPlacement id '${placement.id}' is already registered with different configuration " +
-                "(existing=$existing, requested=$placement). Placement ids must be unique."
-        }
-    }
-    private data class InitializationAttempt(
-        val identity: AdInitializationConfigIdentity,
-        val consentMode: ConsentMode,
-        val completion: CompletableDeferred<AdManagerStatus>
-    )
-    private sealed interface NativeInitializationResult {
-        data object Applied : NativeInitializationResult
-        data class Failed(val failure: Throwable) : NativeInitializationResult
-    }
-    private data class NativeInitialization(
-        val generation: Long,
-        val identity: AdInitializationConfigIdentity,
-        val completion: Deferred<NativeInitializationResult>
-    )
-
-    // Guards registration of the one in-flight consent -> GMA sequence. The
-    // narrower SDK mutex protects the native-applied identity and terminal state.
-    private val initializationStateMutex = Mutex()
-    private val mobileAdsInitializationMutex = Mutex()
-    private val nativeInitializationScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
-    private var pendingInitialization: InitializationAttempt? = null
-    private var nativeInitialization: NativeInitialization? = null
-    private var nativeInitializationGeneration = 0L
-
-    // Live admission state — see the Android twin. Replaces the sticky
-    // consentGateSatisfied latch so revocation immediately closes the gate.
-    private val _admission = MutableStateFlow(AdRequestAdmission.NotGathered)
-
-    // iOS nativeInitializationScope is already Dispatchers.Main; this scope is kept
-    // separate anyway so the collector's lifetime is independent of initialization.
-    private val admissionScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
-
-    init {
-        admissionScope.launch {
-            consent.canRequestAds.collectLatest { canRequest ->
-                val next = consentSession.admission(canRequest)
-                val previous = _admission.value
-                if (previous == next) return@collectLatest
-                _admission.value = next
-                if (previous == AdRequestAdmission.Allowed && next == AdRequestAdmission.Revoked) {
-                    AdLogger.w("iOS consent revoked. Closing ad request gate and purging cached inventory.")
-                    purgeOnRevocation()
-                }
-            }
-        }
+    override fun onNativeConsentRevoked() {
+        nativeManager.onConsentRevoked()
     }
 
-    private var appliedConfigIdentity: AdInitializationConfigIdentity? = null
-    private var appliedTerminalStatus: AdManagerStatus? = null
+    override fun appId(config: AdConfig): String = config.iosAppId
 
-    override suspend fun initialize(
+    override fun captureDiagnosticsSnapshotOnMain() {
+        iosDiagnostics.captureSnapshotOnMain()
+    }
+
+    override suspend fun initializeMobileAdsNative(
         config: AdConfig,
-        consentMode: ConsentMode
-    ): AdManagerStatus {
-        val ownedConfig = config.ownedSnapshot()
-        val requestedIdentity = ownedConfig.initializationIdentity(ownedConfig.iosAppId)
-        while (true) {
-            var leadsAttempt = false
-            var nativeCompletion: Deferred<NativeInitializationResult>? = null
-            val attempt = initializationStateMutex.withLock {
-                pendingInitialization?.let { return@withLock it }
-                nativeCompletion = mobileAdsInitializationMutex.withLock {
-                    nativeInitialization?.completion
-                }
-                if (nativeCompletion != null) return@withLock null
-                appliedOutcome(requestedIdentity, ownedConfig.nativeAdMemoryPolicy)?.let { return it }
-                InitializationAttempt(
-                    identity = requestedIdentity,
-                    consentMode = consentMode,
-                    completion = CompletableDeferred()
-                ).also {
-                    pendingInitialization = it
-                    leadsAttempt = true
-                }
-            }
-
-            val completionToAwait = nativeCompletion
-            if (completionToAwait != null) {
-                // Await outside admission so callers remain cancellable and no
-                // coordinator mutex is held while the native reservation settles.
-                completionToAwait.await()
-                continue
-            }
-            val admittedAttempt = checkNotNull(attempt)
-            if (leadsAttempt) {
-                return runInitializationAttempt(admittedAttempt, ownedConfig, consentMode)
-            }
-
-            val equivalentAttempt =
-                admittedAttempt.identity == requestedIdentity && admittedAttempt.consentMode == consentMode
-            val result = try {
-                admittedAttempt.completion.await()
-            } catch (leaderCancellation: CancellationException) {
-                currentCoroutineContext().ensureActive()
-                if (equivalentAttempt) throw leaderCancellation
-                continue
-            }
-            if (equivalentAttempt) return result
-            if (result == AdManagerStatus.Ready) {
-                appliedOutcome(requestedIdentity, config.nativeAdMemoryPolicy)?.let { return it }
-            }
-            // A distinct request waited for the process-wide slot but the leader
-            // did not initialize GMA. Register a new attempt for its own semantics.
-        }
-    }
-
-    private suspend fun runInitializationAttempt(
-        attempt: InitializationAttempt,
-        config: AdConfig,
-        consentMode: ConsentMode
-    ): AdManagerStatus {
-        AdLogger.i("iOS initialize requested. consentMode=$consentMode")
-        config.testModeWarningOrNull()?.let(AdLogger::w)
-        val previousStatus = _status.value
-        _status.value = AdManagerStatus.Initializing
-
-        return try {
-            when (awaitAbandonedNativeInitialization()) {
-                NativeInitializationResult.Applied -> {
-                    val result = appliedOutcome(attempt.identity, config.nativeAdMemoryPolicy) ?: _status.value
-                    completeAttempt(attempt, result)
-                    return result
-                }
-                is NativeInitializationResult.Failed -> {
-                    appliedOutcome(attempt.identity, config.nativeAdMemoryPolicy)?.let { result ->
-                        completeAttempt(attempt, result)
-                        return result
-                    }
-                }
-                null -> Unit
-            }
-            // UMP guidance: request a consent info update on every app launch; do not
-            // rely on cached state. Once this manager reaches Ready, equivalent calls
-            // are handled above and must not regress status or rerun consent, hooks,
-            // or the process-wide GMA singleton.
-            when (consentMode) {
-                ConsentMode.GatherBeforeInitialize -> consent.gatherConsent(config)
-                ConsentMode.InitializeOnlyIfAlreadyAllowed -> consent.requestConsentInfoUpdate(config)
-                ConsentMode.SkipConsent -> Unit
-            }
-            val effectiveCanRequest = withContext(Dispatchers.Main.immediate) {
-                consentSession.recordCompletedGate(consentMode)
-                val current = if (consentMode == ConsentMode.SkipConsent) true else consent.canRequestAds.value
-                val newAdmission = consentSession.admission(current)
-                _admission.value = newAdmission
-                current
-            }
-            AdLogger.i("iOS consent gate complete. canRequestAds=$effectiveCanRequest mode=$consentMode")
-            if (!effectiveCanRequest) {
-                AdLogger.w("iOS initialize deferred because consent does not allow ad requests yet.")
-                val result = AdManagerStatus.ConsentRequired.also { _status.value = it }
-                completeAttempt(attempt, result)
-                return result
-            }
-            initializeMobileAds(config).also { completeAttempt(attempt, it) }
-        } catch (cancellation: CancellationException) {
-            cancelAttempt(attempt, cancellation, previousStatus)
-            throw cancellation
-        } catch (failure: Throwable) {
-            initializationFailed(failure).also { completeAttempt(attempt, it) }
-        }
-    }
-
-    private suspend fun completeAttempt(
-        attempt: InitializationAttempt,
-        result: AdManagerStatus
-    ) = withContext(NonCancellable) {
-        initializationStateMutex.withLock {
-            if (pendingInitialization === attempt) pendingInitialization = null
-        }
-        attempt.completion.complete(result)
-    }
-
-    private suspend fun cancelAttempt(
-        attempt: InitializationAttempt,
-        cancellation: CancellationException,
-        previousStatus: AdManagerStatus
-    ) = withContext(NonCancellable) {
-        _status.value = appliedTerminalStatus() ?: previousStatus
-        initializationStateMutex.withLock {
-            if (pendingInitialization === attempt) pendingInitialization = null
-        }
-        attempt.completion.completeExceptionally(cancellation)
-    }
-
-    private suspend fun appliedOutcome(
         requestedIdentity: AdInitializationConfigIdentity,
-        requestedNativeAdMemoryPolicy: NativeAdMemoryPolicy,
-    ): AdManagerStatus? = mobileAdsInitializationMutex.withLock {
-        val decision = appliedConfigurationDecision(
-            appliedIdentity = appliedConfigIdentity,
-            requestedIdentity = requestedIdentity,
-            configuredNativePolicy = nativeManager.configuredPolicyOrNull(),
-            requestedNativePolicy = requestedNativeAdMemoryPolicy,
-            appliedTerminalStatus = appliedTerminalStatus,
-            currentStatus = _status.value,
-        )
-        when (decision) {
-            is AppliedConfigurationDecision.NotApplied -> null
-            is AppliedConfigurationDecision.Accepted ->
-                decision.publish?.let(::publishAppliedTerminalLocked)
-            is AppliedConfigurationDecision.Conflict -> {
-                AdLogger.w("iOS MobileAds configuration conflict. ${decision.reason}")
-                // Publish the TRUE status, return the rejection. Publishing the rejection would
-                // make adRequestBlockedError() block every ad request process-wide, breaking the
-                // caller whose configuration was actually accepted.
-                publishAppliedTerminalLocked(decision.publish)
-                decision.rejection
-            }
+    ) {
+        GADMobileAds.sharedInstance.requestConfiguration.let { requestConfig ->
+            requestedIdentity.globalRequestConfiguration.applyTo(requestConfig)
         }
-    }
-
-    private suspend fun appliedTerminalStatus(): AdManagerStatus? =
-        mobileAdsInitializationMutex.withLock { appliedTerminalStatus }
-
-    private suspend fun awaitAbandonedNativeInitialization(): NativeInitializationResult? {
-        val operation = mobileAdsInitializationMutex.withLock { nativeInitialization } ?: return null
-        return operation.completion.await()
-    }
-
-    private suspend fun initializeMobileAds(config: AdConfig): AdManagerStatus {
-        val requestedIdentity = config.initializationIdentity(config.iosAppId)
-        appliedOutcome(requestedIdentity, config.nativeAdMemoryPolicy)?.let { return it }
-
-        var operation = mobileAdsInitializationMutex.withLock { nativeInitialization }
-        if (operation == null) {
-            withContext(Dispatchers.Main.immediate) {
-                config.dispatchInitializationHooks(AdInitializationPhase.BeforeMobileAdsInitialize)
-            }
-            operation = startNativeInitialization(config, requestedIdentity)
-        }
-
-        val previousStatus = _status.value
-        _status.value = AdManagerStatus.Initializing
-        return try {
-            when (val nativeResult = operation.completion.await()) {
-                is NativeInitializationResult.Failed -> return initializationFailed(nativeResult.failure)
-                NativeInitializationResult.Applied -> Unit
-            }
-            AdLogger.i("iOS MobileAds initialization succeeded.")
-            publishAppliedTerminal(previousStatus)
-        } catch (cancellation: CancellationException) {
-            withContext(NonCancellable) { publishAppliedTerminal(previousStatus) }
-            throw cancellation
-        } catch (failure: Throwable) {
-            recordAppliedFailure(requestedIdentity, failure)
-        }
-    }
-
-    private suspend fun startNativeInitialization(
-        config: AdConfig,
-        requestedIdentity: AdInitializationConfigIdentity
-    ): NativeInitialization = mobileAdsInitializationMutex.withLock {
-        nativeInitialization?.let { return@withLock it }
-        appliedConfigIdentity?.let {
-            return@withLock completedNativeInitialization(it)
-        }
-
-        val generation = ++nativeInitializationGeneration
-        // Runs on nativeInitializationScope (a detached SupervisorJob scope), not on any
-        // individual caller's coroutine, so cancelling one initialize() caller can never
-        // interrupt this operation — every caller (leader and followers) only awaits its
-        // result. THAT detachment is what makes AfterMobileAdsInitialize fire exactly once
-        // whenever native init succeeds; an earlier comment here credited the hook's position
-        // *before* publication, which was wrong and cost correctness elsewhere.
-        //
-        // Native acceptance MUST be committed BEFORE the hook runs. Commit it after, and a
-        // throwing publisher hook leaves appliedConfigIdentity null while GMA is already
-        // initialized, so a retry with a different app ID sails past appliedOutcome() and
-        // tries to reconfigure an immutable process singleton. The tradeoff is that a
-        // concurrent same-identity initialize() may observe Ready while the hook is still
-        // running -- strictly better than desynchronizing the wrapper from native reality.
-        val completion = nativeInitializationScope.async(start = CoroutineStart.LAZY) {
-            val result = try {
-                GADMobileAds.sharedInstance.requestConfiguration.let { requestConfig ->
-                    requestedIdentity.globalRequestConfiguration.applyTo(requestConfig)
-                }
-                // Bounded: GMA can accept start() and never invoke the handler, which used to
-                // leave initialize() suspended forever. A timeout is NOT a CancellationException
-                // (see awaitNativeCallback), so it reaches the catch below as a real failure and
-                // leaves the identity uncommitted -- making a retry the correct next step.
-                awaitNativeCallback(
-                    operation = "GADMobileAds.start",
-                    timeout = InitializationTimeouts.nativeInitialize
-                ) {
-                    suspendCancellableCoroutine<Unit> { continuation ->
-                        GADMobileAds.sharedInstance.startWithCompletionHandler { status ->
-                            val adapterStates = status?.adapterStatusesByClassName
-                            if (adapterStates != null) {
-                                adapterStates.forEach { (name, _) ->
-                                    AdLogger.d("iOS adapter '${name}'")
-                                }
-                            }
-                            if (continuation.isActive) continuation.resume(Unit)
+        // MUST stay bounded: GMA can accept start() and never invoke the handler, which would
+        // leave initialize() suspended forever otherwise. A timeout is NOT a
+        // CancellationException (see awaitNativeCallback), so it reaches the catch below as a
+        // real failure and leaves the identity uncommitted -- making a retry the correct next
+        // step.
+        awaitNativeCallback(
+            operation = "GADMobileAds.start",
+            timeout = InitializationTimeouts.nativeInitialize
+        ) {
+            suspendCancellableCoroutine<Unit> { continuation ->
+                GADMobileAds.sharedInstance.startWithCompletionHandler { status ->
+                    val adapterStates = status?.adapterStatusesByClassName
+                    if (adapterStates != null) {
+                        adapterStates.forEach { (name, _) ->
+                            AdLogger.d("iOS adapter '${name}'")
                         }
                     }
-                }
-                config.globalRequestConfiguration.publisherFirstPartyIdEnabled?.let {
-                    AdLogger.d("iOS publisherFirstPartyIdEnabled is Ad Manager only, skipping")
-                }
-                config.globalRequestConfiguration.appMuted?.let {
-                    GADMobileAds.sharedInstance.applicationMuted = it
-                }
-                config.globalRequestConfiguration.appVolume?.let {
-                    GADMobileAds.sharedInstance.applicationVolume = it.coerceIn(0f, 1f)
-                }
-                // Already on nativeInitializationScope (Dispatchers.Main). Captured after
-                // startWithCompletionHandler returns so adapter statuses are populated,
-                // and before the After hook so a publisher hook can read them.
-                iosDiagnostics.captureSnapshotOnMain()
-                mobileAdsInitializationMutex.withLock {
-                    // Native GMA is initialized at this point and can never be reconfigured, so
-                    // the identity commit below must be unconditional. configureNativeAds can
-                    // throw -- NativeAdManagerImpl.configure has a check(existing == null) --
-                    // which is the same trap as a throwing hook, one step earlier.
-                    try {
-                        configureNativeAdsAfterAcceptedInitialization(config)
-                    } catch (t: Throwable) {
-                        AdLogger.e(
-                            "Failed to bind the native ad memory policy after iOS MobileAds " +
-                                "initialization. GMA stays initialized and Ready; native ad " +
-                                "capacity keeps its previously configured policy.",
-                            t
-                        )
-                    }
-                    appliedConfigIdentity = requestedIdentity
-                    appliedTerminalStatus = AdManagerStatus.Ready
-                }
-                // AFTER the commit, and isolated: a publisher hook is host code, so its failure is
-                // reported but must never make the native singleton look unapplied.
-                dispatchAfterInitializeHooks(config)
-                NativeInitializationResult.Applied
-            } catch (failure: Throwable) {
-                NativeInitializationResult.Failed(failure)
-            }
-            withContext(NonCancellable) {
-                mobileAdsInitializationMutex.withLock {
-                    if (nativeInitialization?.generation == generation) nativeInitialization = null
-                    if (result is NativeInitializationResult.Failed && appliedConfigIdentity == requestedIdentity) {
-                        val failed = failedInitializationStatus(result.failure)
-                        appliedTerminalStatus = failed
-                        publishAppliedTerminalLocked(failed)
-                    }
+                    if (continuation.isActive) continuation.resume(Unit)
                 }
             }
-            result
         }
-        NativeInitialization(generation, requestedIdentity, completion).also {
-            nativeInitialization = it
-            completion.start()
+        config.globalRequestConfiguration.publisherFirstPartyIdEnabled?.let {
+            AdLogger.d("iOS publisherFirstPartyIdEnabled is Ad Manager only, skipping")
         }
-    }
-
-    private fun completedNativeInitialization(
-        identity: AdInitializationConfigIdentity
-    ): NativeInitialization = NativeInitialization(
-        generation = nativeInitializationGeneration,
-        identity = identity,
-        completion = CompletableDeferred(NativeInitializationResult.Applied)
-    )
-
-    private suspend fun publishAppliedTerminal(previousStatus: AdManagerStatus): AdManagerStatus =
-        mobileAdsInitializationMutex.withLock {
-            publishAppliedTerminalLocked(appliedTerminalStatus ?: previousStatus)
+        config.globalRequestConfiguration.appMuted?.let {
+            GADMobileAds.sharedInstance.applicationMuted = it
         }
-
-    private fun publishAppliedTerminalLocked(terminal: AdManagerStatus): AdManagerStatus {
-        _status.value = terminal
-        return terminal
-    }
-
-    private suspend fun recordAppliedFailure(
-        requestedIdentity: AdInitializationConfigIdentity,
-        failure: Throwable
-    ): AdManagerStatus {
-        AdLogger.e("iOS MobileAds initialization failed.", failure)
-        val failed = failedInitializationStatus(failure)
-        return withContext(NonCancellable) {
-            mobileAdsInitializationMutex.withLock {
-                if (appliedConfigIdentity == requestedIdentity) {
-                    appliedTerminalStatus = failed
-                    publishAppliedTerminalLocked(failed)
-                }
-            }
-            failed
+        config.globalRequestConfiguration.appVolume?.let {
+            GADMobileAds.sharedInstance.applicationVolume = it.coerceIn(0f, 1f)
         }
     }
 
-    private fun initializationFailed(failure: Throwable): AdManagerStatus {
-        AdLogger.e("iOS MobileAds initialization failed.", failure)
-        return failedInitializationStatus(failure).also { failed -> _status.value = failed }
-    }
-
-    private fun failedInitializationStatus(failure: Throwable): AdManagerStatus.Failed =
-        AdManagerStatus.Failed(
-            error = AdError.message(failure.message ?: "Google Mobile Ads initialization failed."),
-            retryable = true
-        )
-
-    private fun adRequestBlockedError(): AdError? = when {
-        !_admission.value.permitsRequests -> AdError.consentRequired()
-        _status.value != AdManagerStatus.Ready -> AdError.sdkNotReady()
-        else -> null
-    }
-
-    /**
-     * Drops cached inventory across every registered controller after consent is
-     * revoked. Live full-screen presentations are deliberately NOT torn down — the
-     * ad is already owned by SDK callbacks. See the Android twin for the full
-     * rationale.
-     */
-    private fun purgeOnRevocation() {
-        var bannersSnapshot: List<BannerAdController> = emptyList()
-        var slotsSnapshot: List<FullScreenAdController> = emptyList()
-        registry {
-            bannersSnapshot = banners.values.toList()
-            slotsSnapshot = slots.values.toList()
+    override fun banner(placement: AdPlacement): BannerAdController =
+        registerBanner(placement) { owned ->
+            AdLogger.d("iOS banner controller created. placement=${owned.id}")
+            IosBannerAdController(owned, mutableEvents, ::adRequestBlockedError)
         }
-        bannersSnapshot.forEach { it.clear() }
-        slotsSnapshot.forEach { it.clear() }
-        nativeManager.onConsentRevoked()
-        AdLogger.i(
-            "iOS revocation purge complete. banners=${bannersSnapshot.size} " +
-                "fullScreen=${slotsSnapshot.size} nativeSessions=${nativeAds.state.value.activeSessions}"
-        )
-    }
 
-    override fun banner(placement: AdPlacement): BannerAdController = registry {
-        val ownedPlacement = placement.ownedSnapshot()
-        require(ownedPlacement.format == AdFormat.Banner) {
-            "AdPlacement '${ownedPlacement.id}' has format ${ownedPlacement.format} but was passed to a Banner factory. " +
-                "The factory function and placement.format must agree."
-        }
-        checkPlacementCollision(ownedPlacement)
-        banners.getOrPut(ownedPlacement.id) {
-            AdLogger.d("iOS banner controller created. placement=${ownedPlacement.id}")
-            IosBannerAdController(ownedPlacement, _events, ::adRequestBlockedError)
-        }
-    }
+    override fun interstitial(placement: AdPlacement): InterstitialAdController =
+        registerFullScreenSlot(placement, AdFormat.Interstitial) {
+            IosInterstitialSlot(it, mutableEvents, ::adRequestBlockedError, ::onPresentationChanged, fullScreenArbiter)
+        } as InterstitialAdController
 
-    override fun interstitial(placement: AdPlacement): InterstitialAdController = registry {
-        val ownedPlacement = placement.ownedSnapshot()
-        require(ownedPlacement.format == AdFormat.Interstitial) {
-            "AdPlacement '${ownedPlacement.id}' has format ${ownedPlacement.format} but was passed to an Interstitial factory. " +
-                "The factory function and placement.format must agree."
-        }
-        checkPlacementCollision(ownedPlacement)
-        slots.getOrPut(AdSlotKey(ownedPlacement.id, ownedPlacement.format)) { IosInterstitialSlot(ownedPlacement, _events, ::adRequestBlockedError, ::onPresentationChanged, fullScreenArbiter) } as InterstitialAdController
-    }
+    override fun rewarded(placement: AdPlacement): RewardedAdController =
+        registerFullScreenSlot(placement, AdFormat.Rewarded) {
+            IosRewardedSlot(it, mutableEvents, ::adRequestBlockedError, ::onPresentationChanged, fullScreenArbiter)
+        } as RewardedAdController
 
-    override fun rewarded(placement: AdPlacement): RewardedAdController = registry {
-        val ownedPlacement = placement.ownedSnapshot()
-        require(ownedPlacement.format == AdFormat.Rewarded) {
-            "AdPlacement '${ownedPlacement.id}' has format ${ownedPlacement.format} but was passed to a Rewarded factory. " +
-                "The factory function and placement.format must agree."
-        }
-        checkPlacementCollision(ownedPlacement)
-        slots.getOrPut(AdSlotKey(ownedPlacement.id, ownedPlacement.format)) { IosRewardedSlot(ownedPlacement, _events, ::adRequestBlockedError, ::onPresentationChanged, fullScreenArbiter) } as RewardedAdController
-    }
+    override fun rewardedInterstitial(placement: AdPlacement): RewardedInterstitialAdController =
+        registerFullScreenSlot(placement, AdFormat.RewardedInterstitial) {
+            IosRewardedInterstitialSlot(it, mutableEvents, ::adRequestBlockedError, ::onPresentationChanged, fullScreenArbiter)
+        } as RewardedInterstitialAdController
 
-    override fun rewardedInterstitial(placement: AdPlacement): RewardedInterstitialAdController = registry {
-        val ownedPlacement = placement.ownedSnapshot()
-        require(ownedPlacement.format == AdFormat.RewardedInterstitial) {
-            "AdPlacement '${ownedPlacement.id}' has format ${ownedPlacement.format} but was passed to a RewardedInterstitial factory. " +
-                "The factory function and placement.format must agree."
-        }
-        checkPlacementCollision(ownedPlacement)
-        slots.getOrPut(AdSlotKey(ownedPlacement.id, ownedPlacement.format)) { IosRewardedInterstitialSlot(ownedPlacement, _events, ::adRequestBlockedError, ::onPresentationChanged, fullScreenArbiter) } as RewardedInterstitialAdController
-    }
-
-    override fun appOpen(placement: AdPlacement): AppOpenAdController = registry {
-        val ownedPlacement = placement.ownedSnapshot()
-        require(ownedPlacement.format == AdFormat.AppOpen) {
-            "AdPlacement '${ownedPlacement.id}' has format ${ownedPlacement.format} but was passed to an AppOpen factory. " +
-                "The factory function and placement.format must agree."
-        }
-        checkPlacementCollision(ownedPlacement)
-        slots.getOrPut(AdSlotKey(ownedPlacement.id, ownedPlacement.format)) { IosAppOpenSlot(ownedPlacement, _events, ::adRequestBlockedError, ::onPresentationChanged, fullScreenArbiter) } as AppOpenAdController
-    }
+    override fun appOpen(placement: AdPlacement): AppOpenAdController =
+        registerFullScreenSlot(placement, AdFormat.AppOpen) {
+            IosAppOpenSlot(it, mutableEvents, ::adRequestBlockedError, ::onPresentationChanged, fullScreenArbiter)
+        } as AppOpenAdController
 }
 
 internal fun AdSizePolicy.toIOSAdSize(widthDp: Int): CValue<GADAdSize> = when (this) {


### PR DESCRIPTION
## M1 from the SDK review: shared init orchestration

`AndroidGoogleAdManager` and `IosGoogleAdManager` were two independent
implementations of the same policy — the `initialize()` attempt-coalescing
loop, the applied-configuration decision, native-init generation tracking,
terminal status publication, revocation purging, and placement registration
— differing only in log-message text and the actual GMA/GAD SDK calls. Every
fix to that policy had to be made twice.

### What changed

Extracts `GoogleAdManagerBase` (commonMain, `internal`). Both managers are
now `internal class Android/IosGoogleAdManager : GoogleAdManagerBase()`,
implementing 7 hooks each (`platformTag`, `nativeInitializationDispatcher`,
`appId`, `initializeMobileAdsNative`, `captureDiagnosticsSnapshotOnMain`,
`configureNativeAdsAfterAcceptedInitialization`, `configuredNativePolicyOrNull`,
`onNativeConsentRevoked`) instead of the whole ~600-line pipeline.

`registerBanner`/`registerFullScreenSlot` in the base collapse what was 5
near-identical validate+collision-check+getOrPut bodies per platform (10
total) into 2 shared implementations.

`registryLock`/`presenceLock` now reuse the pre-existing `FullScreenStateLock`
(already used by `NativeAdManagerImpl`) instead of each platform hand-rolling
`synchronized(Any())` / `NSRecursiveLock`.

### A real hazard, designed around rather than hit at runtime

The original `init { admissionScope.launch { consent... } }` block can't
move into the base class as-is: `consent` is an abstract member each
subclass overrides with an eagerly-constructed property, and Kotlin runs a
base class's own init-time code strictly before a derived class's property
initializers. Exposed as `protected fun startAdmissionTracking()` instead,
called explicitly from each subclass's own `init {}` after its own `consent`
is constructed.

### Verified, not asserted

- Both platforms compile clean.
- `:admob-cmp-core:allTests` passes unchanged on Android host tests and
  `iosSimulatorArm64Test` — including the concurrency-sensitive
  attempt-coalescing, presence-arbiter, and revocation-purge paths.
- detekt clean, zero new baseline entries.
- `checkKotlinAbi` — **zero dump changes**. Both classes are `internal` and
  were already absent from `admob-cmp-core.klib.api`, so this refactor is
  provably ABI-neutral.
- Downstream modules (`admob-cmp`, `admob-cmp-compose`, `showcase`) still
  compile against the refactored core.
- Full `./scripts/release-readiness.sh` → `READINESS: PASS`, all 9 sections,
  nothing skipped.

Net: 1262 → 920 lines even before accounting for the base class's fuller
KDoc than either terse original carried.

🤖 Generated with [Claude Code](https://claude.com/claude-code)