### PR TITLE
refactor: collapse full-screen presentation duplication (M2)

### DIFF
--- a/admob-cmp-core/src/androidMain/kotlin/dev/avinya/ads/AndroidFullScreenSlots.kt
+++ b/admob-cmp-core/src/androidMain/kotlin/dev/avinya/ads/AndroidFullScreenSlots.kt
@@ -135,38 +135,25 @@ internal class AndroidInterstitialSlot(
         options: FullScreenAdOptions,
         presentation: FullScreenPresentationHandle,
         rewardDelivery: RewardDelivery?
-    ): AdShowResult = withContext(Dispatchers.Main.immediate) {
-        val activity = activityProvider()
-            ?: return@withContext AdShowResult.Failed(AdError.message("No current Android Activity."))
-        suspendCancellableCoroutine<AdShowResult> { continuation ->
-            continuation.invokeOnCancellation { presentation.closeIfCoreOwned() }
-            if (!continuation.isActive) return@suspendCancellableCoroutine
-            loaded.setImmersiveMode(options.immersiveMode)
+    ): AdShowResult {
+        val activity = withContext(Dispatchers.Main.immediate) { activityProvider() }
+            ?: return AdShowResult.Failed(AdError.message("No current Android Activity."))
+        return presentSimpleFullScreenAd(
+            loaded,
+            presentation,
+            beforeHandOff = { loaded.setImmersiveMode(options.immersiveMode) }
+        ) { callback ->
             loaded.adEventCallback = object : InterstitialAdEventCallback {
-                override fun onAdShowedFullScreenContent() = emit(AdEvent.OpenedFullScreen(placement.id))
-                override fun onAdImpression() = emit(AdEvent.Impression(placement.id))
-                override fun onAdClicked() = emit(AdEvent.Clicked(placement.id))
-                override fun onAdPaid(value: com.google.android.libraries.ads.mobile.sdk.common.AdValue) {
-                    emit(AdEvent.Paid(placement.id, PaidEvent(placement.id, value.toCommon(), loaded.getResponseInfo().toCommon())))
-                }
-                override fun onAdDismissedFullScreenContent() {
-                    if (presentation.close(wasShown = true)) {
-                        emit(AdEvent.ClosedFullScreen(placement.id))
-                        if (continuation.isActive) continuation.resume(AdShowResult.Shown)
-                    }
-                }
-                override fun onAdFailedToShowFullScreenContent(error: FullScreenContentError) {
-                    val adError = error.toAdError()
-                    if (presentation.close(wasShown = false)) {
-                        emit(AdEvent.ShowFailed(placement.id, adError))
-                        if (continuation.isActive) continuation.resume(AdShowResult.Failed(adError))
-                    }
-                }
+                override fun onAdShowedFullScreenContent() = callback.onShowed()
+                override fun onAdImpression() = callback.onImpression()
+                override fun onAdClicked() = callback.onClicked()
+                override fun onAdPaid(value: com.google.android.libraries.ads.mobile.sdk.common.AdValue) = callback.onPaid(value)
+                override fun onAdDismissedFullScreenContent() = callback.onDismissed()
+                override fun onAdFailedToShowFullScreenContent(error: FullScreenContentError) = callback.onFailedToShow(error)
             }
-            if (presentation.tryHandOffToCallbacks()) loaded.show(activity)
+            loaded.show(activity)
         }
     }
-
 
     override fun onAdLoaded(ad: InterstitialAd, requestOptions: AdRequestOptions) {
         (requestOptions.placementId ?: placement.requestOptions.placementId)?.let { ad.placementId = it }
@@ -338,37 +325,21 @@ internal class AndroidAppOpenSlot(
         options: FullScreenAdOptions,
         presentation: FullScreenPresentationHandle,
         rewardDelivery: RewardDelivery?
-    ): AdShowResult = withContext(Dispatchers.Main.immediate) {
-        val activity = activityProvider()
-            ?: return@withContext AdShowResult.Failed(AdError.message("No current Android Activity."))
-        suspendCancellableCoroutine<AdShowResult> { continuation ->
-            continuation.invokeOnCancellation { presentation.closeIfCoreOwned() }
-            if (!continuation.isActive) return@suspendCancellableCoroutine
+    ): AdShowResult {
+        val activity = withContext(Dispatchers.Main.immediate) { activityProvider() }
+            ?: return AdShowResult.Failed(AdError.message("No current Android Activity."))
+        return presentSimpleFullScreenAd(loaded, presentation) { callback ->
             loaded.adEventCallback = object : AppOpenAdEventCallback {
-                override fun onAdShowedFullScreenContent() = emit(AdEvent.OpenedFullScreen(placement.id))
-                override fun onAdImpression() = emit(AdEvent.Impression(placement.id))
-                override fun onAdClicked() = emit(AdEvent.Clicked(placement.id))
-                override fun onAdPaid(value: com.google.android.libraries.ads.mobile.sdk.common.AdValue) {
-                    emit(AdEvent.Paid(placement.id, PaidEvent(placement.id, value.toCommon(), loaded.getResponseInfo().toCommon())))
-                }
-                override fun onAdDismissedFullScreenContent() {
-                    if (presentation.close(wasShown = true)) {
-                        emit(AdEvent.ClosedFullScreen(placement.id))
-                        if (continuation.isActive) continuation.resume(AdShowResult.Shown)
-                    }
-                }
-                override fun onAdFailedToShowFullScreenContent(error: FullScreenContentError) {
-                    val adError = error.toAdError()
-                    if (presentation.close(wasShown = false)) {
-                        emit(AdEvent.ShowFailed(placement.id, adError))
-                        if (continuation.isActive) continuation.resume(AdShowResult.Failed(adError))
-                    }
-                }
+                override fun onAdShowedFullScreenContent() = callback.onShowed()
+                override fun onAdImpression() = callback.onImpression()
+                override fun onAdClicked() = callback.onClicked()
+                override fun onAdPaid(value: com.google.android.libraries.ads.mobile.sdk.common.AdValue) = callback.onPaid(value)
+                override fun onAdDismissedFullScreenContent() = callback.onDismissed()
+                override fun onAdFailedToShowFullScreenContent(error: FullScreenContentError) = callback.onFailedToShow(error)
             }
-            if (presentation.tryHandOffToCallbacks()) loaded.show(activity)
+            loaded.show(activity)
         }
     }
-
 
     override fun onAdLoaded(ad: AppOpenAd, requestOptions: AdRequestOptions) {
         (requestOptions.placementId ?: placement.requestOptions.placementId)?.let { ad.placementId = it }
@@ -379,6 +350,72 @@ internal class AndroidAppOpenSlot(
     override fun getResponseInfo(ad: AppOpenAd): AdResponseInfo? = ad.getResponseInfo().toCommon()
 
     override fun canPresent(): AdError? = if (activityProvider() != null) null else AdError.message("No current Android Activity.")
+}
+
+/**
+ * Callback bodies shared by every non-rewarded full-screen format (Interstitial, AppOpen).
+ * `InterstitialAdEventCallback`/`AppOpenAdEventCallback` are separate SAM interfaces with no
+ * common supertype, so each slot still builds its own — by forwarding every method to the
+ * matching lambda here — the same way [showRewarded] below already forwards
+ * `RewardedInterstitialAdEventCallback` to a `RewardedAdEventCallback`-shaped object.
+ */
+private class SimpleFullScreenCallback(
+    val onShowed: () -> Unit,
+    val onImpression: () -> Unit,
+    val onClicked: () -> Unit,
+    val onPaid: (com.google.android.libraries.ads.mobile.sdk.common.AdValue) -> Unit,
+    val onDismissed: () -> Unit,
+    val onFailedToShow: (FullScreenContentError) -> Unit,
+)
+
+/**
+ * Shared continuation ceremony for presenting a loaded non-rewarded full-screen ad. Every
+ * `presentAd` override for Interstitial/AppOpen is this function plus exactly the platform call
+ * that's genuinely different per format: build the SAM callback (forwarding to
+ * [SimpleFullScreenCallback]) and call `loaded.show(activity)`.
+ *
+ * The hand-off invariant lives here now, in one place: [installCallbackAndShow] — which sets the
+ * SDK callback and calls `show` — runs only AFTER
+ * [FullScreenPresentationHandle.tryHandOffToCallbacks] succeeds. If it returns false
+ * (cancellation raced in first), the SDK show must never happen.
+ */
+private suspend fun <T : Ad> FullScreenSlotCore<T>.presentSimpleFullScreenAd(
+    loaded: T,
+    presentation: FullScreenPresentationHandle,
+    beforeHandOff: () -> Unit = {},
+    installCallbackAndShow: (SimpleFullScreenCallback) -> Unit,
+): AdShowResult = withContext(Dispatchers.Main.immediate) {
+    suspendCancellableCoroutine<AdShowResult> { continuation ->
+        continuation.invokeOnCancellation { presentation.closeIfCoreOwned() }
+        if (!continuation.isActive) return@suspendCancellableCoroutine
+        beforeHandOff()
+        val callback = SimpleFullScreenCallback(
+            onShowed = { emit(AdEvent.OpenedFullScreen(placement.id)) },
+            onImpression = { emit(AdEvent.Impression(placement.id)) },
+            onClicked = { emit(AdEvent.Clicked(placement.id)) },
+            onPaid = { value ->
+                emit(AdEvent.Paid(placement.id, PaidEvent(placement.id, value.toCommon(), loaded.getResponseInfo().toCommon())))
+            },
+            onDismissed = {
+                if (presentation.close(wasShown = true)) {
+                    emit(AdEvent.ClosedFullScreen(placement.id))
+                    if (continuation.isActive) continuation.resume(AdShowResult.Shown)
+                }
+            },
+            onFailedToShow = { error ->
+                val adError = error.toAdError()
+                if (presentation.close(wasShown = false)) {
+                    emit(AdEvent.ShowFailed(placement.id, adError))
+                    if (continuation.isActive) continuation.resume(AdShowResult.Failed(adError))
+                }
+            }
+        )
+        // Hand off before installing the callback: if cancellation already closed the handle
+        // (raced in via invokeOnCancellation between the isActive check above and here), there
+        // will be no terminal SDK callback to release this ad — installing regardless would show
+        // an ad nobody is tracking anymore.
+        if (presentation.tryHandOffToCallbacks()) installCallbackAndShow(callback)
+    }
 }
 
 private suspend fun <T : Ad> FullScreenSlotCore<T>.showRewarded(

--- a/admob-cmp-core/src/iosMain/kotlin/dev/avinya/ads/IosFullScreenSlots.kt
+++ b/admob-cmp-core/src/iosMain/kotlin/dev/avinya/ads/IosFullScreenSlots.kt
@@ -27,6 +27,7 @@ import kotlin.native.ref.WeakReference
 import platform.Foundation.NSError
 import platform.Foundation.NSRecursiveLock
 import platform.Foundation.NSThread
+import platform.UIKit.UIViewController
 import platform.darwin.NSObject
 import platform.darwin.dispatch_async
 import platform.darwin.dispatch_get_main_queue
@@ -106,45 +107,9 @@ internal class IosInterstitialSlot(
         options: FullScreenAdOptions,
         presentation: FullScreenPresentationHandle,
         rewardDelivery: RewardDelivery?
-    ): AdShowResult = withContext(Dispatchers.Main.immediate) {
-        val rootVC = topViewController()
-            ?: return@withContext AdShowResult.Failed(AdError.message("No root view controller."))
-        suspendCancellableCoroutine<AdShowResult> { continuation ->
-            // Cancellation closes only while the core still owns presentation. Once hand-off
-            // wins, this delegate stays retained until the SDK terminal callback closes it.
-            continuation.invokeOnCancellation { presentation.closeIfCoreOwned() }
-            if (!continuation.isActive) return@suspendCancellableCoroutine
-            val delegate = FullScreenDelegate(
-                onOpened = { emit(AdEvent.OpenedFullScreen(placement.id)) },
-                onClosed = {
-                    delegates.terminal(loaded) {
-                        if (presentation.close(wasShown = true)) {
-                            emit(AdEvent.ClosedFullScreen(placement.id))
-                            if (continuation.isActive) continuation.resume(AdShowResult.Shown)
-                        }
-                    }
-                },
-                onFailedToShow = { error ->
-                    delegates.terminal(loaded) {
-                        if (presentation.close(wasShown = false)) {
-                            emit(AdEvent.ShowFailed(placement.id, error))
-                            if (continuation.isActive) continuation.resume(AdShowResult.Failed(error))
-                        }
-                    }
-                },
-                onImpression = { emit(AdEvent.Impression(placement.id)) },
-                onClicked = { emit(AdEvent.Clicked(placement.id)) }
-            )
-            // Hand off before retaining: if cancellation already closed the handle (raced in
-            // via invokeOnCancellation between the isActive check above and here), there will
-            // be no terminal SDK callback to release this delegate — retaining it regardless
-            // would leak the entry in the delegate store until the slot is next reused.
-            if (presentation.tryHandOffToCallbacks()) {
-                delegates.retain(loaded, delegate)
-                loaded.fullScreenContentDelegate = delegate
-                loaded.presentFromRootViewController(rootVC)
-            }
-        }
+    ): AdShowResult = presentFullScreenAd(loaded, presentation, delegates) { rootVC, delegate ->
+        loaded.fullScreenContentDelegate = delegate
+        loaded.presentFromRootViewController(rootVC)
     }
 
     override fun destroyAd(ad: GADInterstitialAd) {
@@ -209,53 +174,24 @@ internal class IosRewardedSlot(
         options: FullScreenAdOptions,
         presentation: FullScreenPresentationHandle,
         rewardDelivery: RewardDelivery?
-    ): AdShowResult = withContext(Dispatchers.Main.immediate) {
-        val rootVC = topViewController()
-            ?: return@withContext AdShowResult.Failed(AdError.message("No root view controller."))
-        options.serverSideVerification?.let { loaded.serverSideVerificationOptions = options.serverSideVerificationOptions() }
-        suspendCancellableCoroutine<AdShowResult> { continuation ->
-            // Cancellation closes only while the core still owns presentation. Once hand-off
-            // wins, this delegate stays retained until the SDK terminal callback closes it.
-            continuation.invokeOnCancellation { presentation.closeIfCoreOwned() }
-            if (!continuation.isActive) return@suspendCancellableCoroutine
-            val delegate = FullScreenDelegate(
-                onOpened = { emit(AdEvent.OpenedFullScreen(placement.id)) },
-                onClosed = {
-                    delegates.terminal(loaded) {
-                        if (presentation.close(wasShown = true)) {
-                            emit(AdEvent.ClosedFullScreen(placement.id))
-                            if (continuation.isActive) continuation.resume(AdShowResult.Shown)
-                        }
-                    }
-                },
-                onFailedToShow = { error ->
-                    delegates.terminal(loaded) {
-                        if (presentation.close(wasShown = false)) {
-                            emit(AdEvent.ShowFailed(placement.id, error))
-                            if (continuation.isActive) continuation.resume(AdShowResult.Failed(error))
-                        }
-                    }
-                },
-                onImpression = { emit(AdEvent.Impression(placement.id)) },
-                onClicked = { emit(AdEvent.Clicked(placement.id)) }
-            )
-            // Hand off before retaining: if cancellation already closed the handle (raced in
-            // via invokeOnCancellation between the isActive check above and here), there will
-            // be no terminal SDK callback to release this delegate — retaining it regardless
-            // would leak the entry in the delegate store until the slot is next reused.
-            if (presentation.tryHandOffToCallbacks()) {
-                delegates.retain(loaded, delegate)
-                loaded.fullScreenContentDelegate = delegate
-                val weakLoaded = WeakReference(loaded)
-                loaded.presentFromRootViewController(rootVC) {
-                    val adReward = weakLoaded.value?.adReward
-                    if (adReward != null) {
-                        // amount is an NSDecimalNumber and may be fractional (the exact-decimal
-                        // pattern used for paid values applies here too, so a mediated
-                        // 0.5/2.5 reward is preserved exactly rather than rounded to 1/3).
-                        val earned = AdReward(adReward.amount.toValueMicros(), adReward.type)
-                        rewardDelivery?.deliver(earned)
-                    }
+    ): AdShowResult {
+        // On Main, unconditionally, before the rootVC check — matches presentFullScreenAd's own
+        // dispatch so this always runs on the SDK's expected thread regardless of whether
+        // presentation ultimately succeeds.
+        withContext(Dispatchers.Main.immediate) {
+            options.serverSideVerification?.let { loaded.serverSideVerificationOptions = options.serverSideVerificationOptions() }
+        }
+        return presentFullScreenAd(loaded, presentation, delegates) { rootVC, delegate ->
+            loaded.fullScreenContentDelegate = delegate
+            val weakLoaded = WeakReference(loaded)
+            loaded.presentFromRootViewController(rootVC) {
+                val adReward = weakLoaded.value?.adReward
+                if (adReward != null) {
+                    // amount is an NSDecimalNumber and may be fractional (the exact-decimal
+                    // pattern used for paid values applies here too, so a mediated
+                    // 0.5/2.5 reward is preserved exactly rather than rounded to 1/3).
+                    val earned = AdReward(adReward.amount.toValueMicros(), adReward.type)
+                    rewardDelivery?.deliver(earned)
                 }
             }
         }
@@ -323,53 +259,24 @@ internal class IosRewardedInterstitialSlot(
         options: FullScreenAdOptions,
         presentation: FullScreenPresentationHandle,
         rewardDelivery: RewardDelivery?
-    ): AdShowResult = withContext(Dispatchers.Main.immediate) {
-        val rootVC = topViewController()
-            ?: return@withContext AdShowResult.Failed(AdError.message("No root view controller."))
-        options.serverSideVerification?.let { loaded.serverSideVerificationOptions = options.serverSideVerificationOptions() }
-        suspendCancellableCoroutine<AdShowResult> { continuation ->
-            // Cancellation closes only while the core still owns presentation. Once hand-off
-            // wins, this delegate stays retained until the SDK terminal callback closes it.
-            continuation.invokeOnCancellation { presentation.closeIfCoreOwned() }
-            if (!continuation.isActive) return@suspendCancellableCoroutine
-            val delegate = FullScreenDelegate(
-                onOpened = { emit(AdEvent.OpenedFullScreen(placement.id)) },
-                onClosed = {
-                    delegates.terminal(loaded) {
-                        if (presentation.close(wasShown = true)) {
-                            emit(AdEvent.ClosedFullScreen(placement.id))
-                            if (continuation.isActive) continuation.resume(AdShowResult.Shown)
-                        }
-                    }
-                },
-                onFailedToShow = { error ->
-                    delegates.terminal(loaded) {
-                        if (presentation.close(wasShown = false)) {
-                            emit(AdEvent.ShowFailed(placement.id, error))
-                            if (continuation.isActive) continuation.resume(AdShowResult.Failed(error))
-                        }
-                    }
-                },
-                onImpression = { emit(AdEvent.Impression(placement.id)) },
-                onClicked = { emit(AdEvent.Clicked(placement.id)) }
-            )
-            // Hand off before retaining: if cancellation already closed the handle (raced in
-            // via invokeOnCancellation between the isActive check above and here), there will
-            // be no terminal SDK callback to release this delegate — retaining it regardless
-            // would leak the entry in the delegate store until the slot is next reused.
-            if (presentation.tryHandOffToCallbacks()) {
-                delegates.retain(loaded, delegate)
-                loaded.fullScreenContentDelegate = delegate
-                val weakLoaded = WeakReference(loaded)
-                loaded.presentFromRootViewController(rootVC) {
-                    val adReward = weakLoaded.value?.adReward
-                    if (adReward != null) {
-                        // amount is an NSDecimalNumber and may be fractional (the exact-decimal
-                        // pattern used for paid values applies here too, so a mediated
-                        // 0.5/2.5 reward is preserved exactly rather than rounded to 1/3).
-                        val earned = AdReward(adReward.amount.toValueMicros(), adReward.type)
-                        rewardDelivery?.deliver(earned)
-                    }
+    ): AdShowResult {
+        // On Main, unconditionally, before the rootVC check — matches presentFullScreenAd's own
+        // dispatch so this always runs on the SDK's expected thread regardless of whether
+        // presentation ultimately succeeds.
+        withContext(Dispatchers.Main.immediate) {
+            options.serverSideVerification?.let { loaded.serverSideVerificationOptions = options.serverSideVerificationOptions() }
+        }
+        return presentFullScreenAd(loaded, presentation, delegates) { rootVC, delegate ->
+            loaded.fullScreenContentDelegate = delegate
+            val weakLoaded = WeakReference(loaded)
+            loaded.presentFromRootViewController(rootVC) {
+                val adReward = weakLoaded.value?.adReward
+                if (adReward != null) {
+                    // amount is an NSDecimalNumber and may be fractional (the exact-decimal
+                    // pattern used for paid values applies here too, so a mediated
+                    // 0.5/2.5 reward is preserved exactly rather than rounded to 1/3).
+                    val earned = AdReward(adReward.amount.toValueMicros(), adReward.type)
+                    rewardDelivery?.deliver(earned)
                 }
             }
         }
@@ -432,45 +339,9 @@ internal class IosAppOpenSlot(
         options: FullScreenAdOptions,
         presentation: FullScreenPresentationHandle,
         rewardDelivery: RewardDelivery?
-    ): AdShowResult = withContext(Dispatchers.Main.immediate) {
-        val rootVC = topViewController()
-            ?: return@withContext AdShowResult.Failed(AdError.message("No root view controller."))
-        suspendCancellableCoroutine<AdShowResult> { continuation ->
-            // Cancellation closes only while the core still owns presentation. Once hand-off
-            // wins, this delegate stays retained until the SDK terminal callback closes it.
-            continuation.invokeOnCancellation { presentation.closeIfCoreOwned() }
-            if (!continuation.isActive) return@suspendCancellableCoroutine
-            val delegate = FullScreenDelegate(
-                onOpened = { emit(AdEvent.OpenedFullScreen(placement.id)) },
-                onClosed = {
-                    delegates.terminal(loaded) {
-                        if (presentation.close(wasShown = true)) {
-                            emit(AdEvent.ClosedFullScreen(placement.id))
-                            if (continuation.isActive) continuation.resume(AdShowResult.Shown)
-                        }
-                    }
-                },
-                onFailedToShow = { error ->
-                    delegates.terminal(loaded) {
-                        if (presentation.close(wasShown = false)) {
-                            emit(AdEvent.ShowFailed(placement.id, error))
-                            if (continuation.isActive) continuation.resume(AdShowResult.Failed(error))
-                        }
-                    }
-                },
-                onImpression = { emit(AdEvent.Impression(placement.id)) },
-                onClicked = { emit(AdEvent.Clicked(placement.id)) }
-            )
-            // Hand off before retaining: if cancellation already closed the handle (raced in
-            // via invokeOnCancellation between the isActive check above and here), there will
-            // be no terminal SDK callback to release this delegate — retaining it regardless
-            // would leak the entry in the delegate store until the slot is next reused.
-            if (presentation.tryHandOffToCallbacks()) {
-                delegates.retain(loaded, delegate)
-                loaded.fullScreenContentDelegate = delegate
-                loaded.presentFromRootViewController(rootVC)
-            }
-        }
+    ): AdShowResult = presentFullScreenAd(loaded, presentation, delegates) { rootVC, delegate ->
+        loaded.fullScreenContentDelegate = delegate
+        loaded.presentFromRootViewController(rootVC)
     }
 
     override fun destroyAd(ad: GADAppOpenAd) {
@@ -480,6 +351,66 @@ internal class IosAppOpenSlot(
     override fun getResponseInfo(ad: GADAppOpenAd): AdResponseInfo? = ad.responseInfo?.toCommon()
 
     override fun canPresent(): AdError? = if (topViewController() != null) null else AdError.message("No root view controller.")
+}
+
+/**
+ * Shared continuation+delegate ceremony for presenting a loaded full-screen ad. Every
+ * `presentAd` override in this file is this function plus exactly one platform call:
+ * `loaded.fullScreenContentDelegate = delegate; loaded.presentFromRootViewController(rootVC)`,
+ * with a reward trailing closure on the two rewarded formats. [installDelegateAndPresent] is
+ * that one call — the four GAD ad types share no common Kotlin interface for their instance
+ * members (`fullScreenContentDelegate`, `presentFromRootViewController`, ...), which is why it
+ * can't be pulled in here too.
+ *
+ * The hand-off invariant lives here now, in exactly one place: retain the delegate — via
+ * [delegates] — only AFTER [FullScreenPresentationHandle.tryHandOffToCallbacks] succeeds. If it
+ * returns false (cancellation raced in first), [installDelegateAndPresent] must never run —
+ * the SDK show never happens, and nothing would ever call `destroyAd` to release a delegate
+ * retained before that check.
+ */
+internal suspend fun <AdT : Any> FullScreenSlotCore<AdT>.presentFullScreenAd(
+    loaded: AdT,
+    presentation: FullScreenPresentationHandle,
+    delegates: FullScreenDelegateStore<AdT>,
+    installDelegateAndPresent: (rootVC: UIViewController, delegate: FullScreenDelegate) -> Unit,
+): AdShowResult = withContext(Dispatchers.Main.immediate) {
+    val rootVC = topViewController()
+        ?: return@withContext AdShowResult.Failed(AdError.message("No root view controller."))
+    suspendCancellableCoroutine<AdShowResult> { continuation ->
+        // Cancellation closes only while the core still owns presentation. Once hand-off
+        // wins, this delegate stays retained until the SDK terminal callback closes it.
+        continuation.invokeOnCancellation { presentation.closeIfCoreOwned() }
+        if (!continuation.isActive) return@suspendCancellableCoroutine
+        val delegate = FullScreenDelegate(
+            onOpened = { emit(AdEvent.OpenedFullScreen(placement.id)) },
+            onClosed = {
+                delegates.terminal(loaded) {
+                    if (presentation.close(wasShown = true)) {
+                        emit(AdEvent.ClosedFullScreen(placement.id))
+                        if (continuation.isActive) continuation.resume(AdShowResult.Shown)
+                    }
+                }
+            },
+            onFailedToShow = { error ->
+                delegates.terminal(loaded) {
+                    if (presentation.close(wasShown = false)) {
+                        emit(AdEvent.ShowFailed(placement.id, error))
+                        if (continuation.isActive) continuation.resume(AdShowResult.Failed(error))
+                    }
+                }
+            },
+            onImpression = { emit(AdEvent.Impression(placement.id)) },
+            onClicked = { emit(AdEvent.Clicked(placement.id)) }
+        )
+        // Hand off before retaining: if cancellation already closed the handle (raced in
+        // via invokeOnCancellation between the isActive check above and here), there will
+        // be no terminal SDK callback to release this delegate — retaining it regardless
+        // would leak the entry in the delegate store until the slot is next reused.
+        if (presentation.tryHandOffToCallbacks()) {
+            delegates.retain(loaded, delegate)
+            installDelegateAndPresent(rootVC, delegate)
+        }
+    }
 }
 
 internal class FullScreenDelegate(


### PR DESCRIPTION
## M2 from the SDK review: full-screen slot duplication

### iOS (4x → 1)

`IosInterstitialSlot`, `IosRewardedSlot`, `IosRewardedInterstitialSlot`, and
`IosAppOpenSlot` each repeated the identical continuation/delegate ceremony
in `presentAd`. The hand-off invariant — retain the delegate only **after**
`tryHandOffToCallbacks()` succeeds — lived in four places.

The four GAD ad types share no common Kotlin interface for their instance
members, so the load entrypoint stays per-slot as the review anticipated.
The ceremony around it doesn't: extracted as
`FullScreenSlotCore<AdT>.presentFullScreenAd(...)`, an internal generic
extension function. Each slot's `presentAd` is now just the one line
that's genuinely different per format.

Caught before it shipped: my first draft moved the two rewarded slots'
`serverSideVerificationOptions` assignment into the new shared function's
trailing lambda, which only runs on hand-off success. The original ran it
unconditionally on Main, before the rootVC check. Restored explicitly
rather than silently changing when that side effect happens.

### Android (2x → 1, the two formats `showRewarded` didn't already cover)

`showRewarded` already unified `RewardedAd`/`RewardedInterstitialAd`, but
`AndroidInterstitialSlot` and `AndroidAppOpenSlot` still duplicated their
own ~30-line `presentAd` against each other. Same pattern:
`FullScreenSlotCore<T>.presentSimpleFullScreenAd` (`T : Ad`) plus a
`SimpleFullScreenCallback` holder, mirroring how `showRewarded` already
forwards `RewardedInterstitialAdEventCallback`.

Two exact-ordering details preserved rather than quietly resolved either
way: `activityProvider()` ran on `Dispatchers.Main.immediate` before the
coroutine even starts (kept as an explicit `withContext` at the call site,
not demoted to whatever thread `presentAd` is invoked from), and
Interstitial's `setImmersiveMode` ran unconditionally regardless of whether
hand-off later succeeds (now a `beforeHandOff` hook in the same position).

### Verified, not asserted

- Both platforms compile clean (only pre-existing warnings, line-shifted).
- `:admob-cmp-core:allTests` passes unchanged on Android host tests and
  `iosSimulatorArm64Test`, including the presence-arbiter fault-injection
  tests that exercise the exact hand-off race both refactors touch.
- detekt clean on both (one new `MaxLineLength` caught and fixed, not
  baselined).
- `checkKotlinAbi` — **zero dump changes** on both platforms.
- Downstream modules (`admob-cmp`, `admob-cmp-compose`, `showcase`) still
  compile.
- Full `./scripts/release-readiness.sh` → `READINESS: PASS`, all 9
  sections, nothing skipped.

iOS: 483 lines, down from 553. Android: 513 lines, up from 477 — the
shared function's KDoc plus two SAM-forwarding blocks cost more raw lines
than the inline object expressions they replace. The win in both cases is
that the safety-critical logic (hand-off ordering, `presentation.close()`,
event emission) now exists in exactly one place per platform instead of
two or four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)