### PR TITLE
fix(core, compose): harden SDK runtime paths — consent, app ID verification, log sinks, layout diagnostics

### DIFF
--- a/admob-cmp-compose/build.gradle.kts
+++ b/admob-cmp-compose/build.gradle.kts
@@ -75,6 +75,9 @@ kotlin {
             implementation(libs.kotlin.test)
             implementation(libs.kotlinx.coroutines.test)
         }
+        getByName("androidHostTest").dependencies {
+            implementation(libs.mockito.core)
+        }
     }
 }
 

--- a/admob-cmp-compose/src/androidHostTest/kotlin/dev/avinya/ads/nativead/rendering/AndroidNativeAdRendererLoggingTest.kt
+++ b/admob-cmp-compose/src/androidHostTest/kotlin/dev/avinya/ads/nativead/rendering/AndroidNativeAdRendererLoggingTest.kt
@@ -1,0 +1,65 @@
+package dev.avinya.ads.nativead.rendering
+
+import android.content.Context
+import android.content.res.Resources
+import android.graphics.Typeface
+import android.util.DisplayMetrics
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAd
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdView
+import dev.avinya.ads.AdLogSink
+import dev.avinya.ads.AdLogger
+import dev.avinya.ads.nativead.layout.AdFontFamily
+import dev.avinya.ads.nativead.layout.AdLayout
+import dev.avinya.ads.nativead.layout.AdStaticText
+import dev.avinya.ads.nativead.layout.AdTextStyle
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+
+class AndroidNativeAdRendererLoggingTest {
+    private val originalSink = AdLogger.sink
+
+    @AfterTest
+    fun tearDown() {
+        AdLogger.sink = originalSink
+    }
+
+    @Test
+    fun `render logging does not expose static layout text or the full identity`() {
+        val messages = mutableListOf<String>()
+        AdLogger.sink = AdLogSink { _, _, message, _ -> messages += message }
+        val sensitiveStaticText = "account-owner-email@example.test"
+        val composeFontFamily = FontFamily.SansSerif
+        val layout = AdLayout(
+            root = AdStaticText(
+                text = sensitiveStaticText,
+                style = AdTextStyle(fontFamily = AdFontFamily.FromCompose(composeFontFamily)),
+            ),
+        )
+        val context = mock(Context::class.java)
+        val resources = mock(Resources::class.java)
+        `when`(context.resources).thenReturn(resources)
+        `when`(resources.displayMetrics).thenReturn(DisplayMetrics().apply { density = 1f })
+        val nativeAdView = mock(NativeAdView::class.java)
+        val renderer = AndroidNativeAdLayoutRenderer(
+            context = context,
+            nativeAd = mock(NativeAd::class.java),
+            resolvedComposeFonts = ResolvedComposeFonts(
+                mapOf(
+                    ComposeFontRequest(composeFontFamily, FontWeight.Normal) to
+                        mock(Typeface::class.java),
+                ),
+            ),
+            existingRoot = nativeAdView,
+        )
+
+        renderer.render(layout)
+
+        assertTrue(messages.none { sensitiveStaticText in it })
+        assertTrue(messages.none { layout.identity in it })
+    }
+}

--- a/admob-cmp-compose/src/androidMain/kotlin/dev/avinya/ads/nativead/rendering/AndroidNativeAdLayoutRenderer.kt
+++ b/admob-cmp-compose/src/androidMain/kotlin/dev/avinya/ads/nativead/rendering/AndroidNativeAdLayoutRenderer.kt
@@ -43,7 +43,9 @@ internal class AndroidNativeAdLayoutRenderer(
         (existingRoot ?: NativeAdView(context)).also { renderInto(it, layout) }
 
     fun renderInto(nativeAdView: NativeAdView, layout: AdLayout): NativeAdView {
-        AdLogger.d("Android native renderer renderInto. layout=${layout.identity}")
+        // AdLayout.identity can contain AdStaticText.text. Keep render diagnostics free of
+        // consumer- or user-derived layout content.
+        AdLogger.d("Android native renderer renderInto.")
         nativeAdView.removeAllViews()
         nativeAdView.clipChildren = true
         nativeAdView.clipToPadding = true
@@ -205,48 +207,7 @@ internal class AndroidNativeAdLayoutRenderer(
                 applyViewStyle(this, node.modifier, backgroundArgb)
                 renderedMediaView = this
             }
-            // A `TextView`, deliberately not a `Button`.
-            //
-            // `Button(context)` resolves the *device theme's* `buttonStyle`, which carries an
-            // `android:minHeight`/`minWidth`. Those are `TextView`-level minimums, so
-            // `applyViewStyle`'s `view.minimumHeight = 0` does not clear them — the call-to-action's
-            // height was therefore decided by the OEM's button style, differing from iOS and from
-            // one Android vendor to the next. A bare `TextView` with an explicit style attribute of
-            // zero inherits nothing, so the size is exactly text plus the resolved insets, which is
-            // the same arithmetic the iOS renderer performs.
-            is AdAssetNode.CallToAction -> TextView(context, null, 0, 0).apply {
-                text = resolveCallToActionText(nativeAd.callToAction.orEmpty(), node.style.textCase)
-                isAllCaps = false
-                maxLines = 1
-                ellipsize = TextUtils.TruncateAt.END
-                disableDirectInteractionForNativeAdAsset()
-                setTextColor(node.style.textStyle.colorArgb.toAndroidColor())
-                textSize = node.style.textStyle.fontSizeSp
-                typeface = node.style.textStyle.fontFamily.toTypeface(
-                    node.style.textStyle.fontWeight,
-                    resolvedComposeFonts,
-                )
-                gravity = Gravity.CENTER
-                // Handing the resolved radius back through the modifier keeps one code path
-                // painting the surface, so a node that sets its own background, border or corner
-                // radius overrides the style instead of fighting it.
-                val backgroundArgb = resolveNativeAdDrawableBackgroundArgb(node.modifier, node.style.backgroundArgb)
-                applyViewStyle(
-                    view = this,
-                    modifier = node.modifier.withoutPadding()
-                        .copy(cornerRadiusDp = resolveCallToActionCornerRadiusDp(node.modifier, node.style)),
-                    backgroundArgb = backgroundArgb,
-                )
-                val insets = resolveCallToActionContentInsets(node.modifier, node.style)
-                setPadding(
-                    dp(insets.startDp),
-                    dp(insets.topDp),
-                    dp(insets.endDp),
-                    dp(insets.bottomDp),
-                )
-                applyMissingVisibility(nativeAd.callToAction?.takeIf { it.isNotBlank() }, node.visibilityPolicy)
-                nativeAdView.callToActionView = this
-            }
+            is AdAssetNode.CallToAction -> buildCallToAction(node, nativeAdView)
             // A real `AdChoicesView`, registered with the ad view.
             //
             // Must be a real `AdChoicesView` assigned to `NativeAdView.adChoicesView` — not a
@@ -267,6 +228,72 @@ internal class AndroidNativeAdLayoutRenderer(
                 gravity = Gravity.CENTER
                 applyViewStyle(this, node.modifier)
             }
+        }
+    }
+
+    /**
+     * Builds a centred, wrap-content label inside a painted full-width container — the shape the
+     * iOS renderer builds in `renderCallToAction` (a `UILabel` inside an inset container).
+     *
+     * The label is a bare `TextView` with a zero style attribute, not a `Button`:
+     * `Button(context)` resolves the device theme's `buttonStyle`, whose
+     * `android:minHeight`/`minWidth` are `TextView`-level minimums that `applyViewStyle`'s
+     * `view.minimumHeight = 0` cannot clear, so the height would be decided by the OEM rather than
+     * by the resolved insets.
+     *
+     * The label is sized to its text, not stretched to the container. A full-width `TextView` that
+     * centres its own text registers a pre-draw listener that can scroll the text horizontally
+     * during Compose `AndroidView`'s transient zero-width pass, leaving it drawn flush left. A
+     * wrap-content label's viewport always equals its line width, so that scroll is always zero;
+     * the container's gravity does the centring instead.
+     */
+    private fun buildCallToAction(
+        node: AdAssetNode.CallToAction,
+        nativeAdView: NativeAdView,
+    ): FrameLayout {
+        val label = TextView(context, null, 0, 0).apply {
+            text = resolveCallToActionText(nativeAd.callToAction.orEmpty(), node.style.textCase)
+            isAllCaps = false
+            maxLines = 1
+            ellipsize = TextUtils.TruncateAt.END
+            setTextColor(node.style.textStyle.colorArgb.toAndroidColor())
+            textSize = node.style.textStyle.fontSizeSp
+            typeface = node.style.textStyle.fontFamily.toTypeface(
+                node.style.textStyle.fontWeight,
+                resolvedComposeFonts,
+            )
+        }
+        return FrameLayout(context).apply {
+            clipChildren = true
+            clipToPadding = true
+            disableDirectInteractionForNativeAdAsset()
+            // Handing the resolved radius back through the modifier keeps one code path painting
+            // the surface, so a node that sets its own background, border or corner radius
+            // overrides the style instead of fighting it.
+            val backgroundArgb = resolveNativeAdDrawableBackgroundArgb(node.modifier, node.style.backgroundArgb)
+            applyViewStyle(
+                view = this,
+                modifier = node.modifier.withoutPadding()
+                    .copy(cornerRadiusDp = resolveCallToActionCornerRadiusDp(node.modifier, node.style)),
+                backgroundArgb = backgroundArgb,
+            )
+            val insets = resolveCallToActionContentInsets(node.modifier, node.style)
+            setPadding(
+                dp(insets.startDp),
+                dp(insets.topDp),
+                dp(insets.endDp),
+                dp(insets.bottomDp),
+            )
+            addView(
+                label,
+                FrameLayout.LayoutParams(
+                    ViewGroup.LayoutParams.WRAP_CONTENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT,
+                    Gravity.CENTER,
+                ),
+            )
+            applyMissingVisibility(nativeAd.callToAction?.takeIf { it.isNotBlank() }, node.visibilityPolicy)
+            nativeAdView.callToActionView = this
         }
     }
 
@@ -411,7 +438,7 @@ internal class AndroidNativeAdLayoutRenderer(
         }
     }
 
-    private fun TextView.disableDirectInteractionForNativeAdAsset() {
+    private fun View.disableDirectInteractionForNativeAdAsset() {
         isClickable = false
         isFocusable = false
     }

--- a/admob-cmp-compose/src/androidMain/kotlin/dev/avinya/ads/ui/AndroidNativeAdView.kt
+++ b/admob-cmp-compose/src/androidMain/kotlin/dev/avinya/ads/ui/AndroidNativeAdView.kt
@@ -22,6 +22,7 @@ import dev.avinya.ads.nativead.NativeAdSession
 import dev.avinya.ads.nativead.NativeAdSlotState
 import dev.avinya.ads.nativead.acquireAndroidRenderLease
 import dev.avinya.ads.nativead.layout.AdLayout
+import dev.avinya.ads.nativead.layout.logValidationWarningsOnce
 import dev.avinya.ads.nativead.rendering.AndroidNativeAdLayoutRenderer
 import dev.avinya.ads.nativead.rendering.adRootSurface
 import dev.avinya.ads.nativead.rendering.rememberResolvedComposeFonts
@@ -41,6 +42,7 @@ public actual fun NativeAdView(
         NativeAdPlaceholder(modifier, loading)
         return
     }
+    LaunchedEffect(layout.identity) { layout.logValidationWarningsOnce() }
 
     val slotState = session.state.collectAsState().value.slots[slotKey]
     val rendererId = remember(session, slotKey) { "android-native-renderer-${nextAndroidRendererId++}" }

--- a/admob-cmp-compose/src/commonMain/kotlin/dev/avinya/ads/nativead/layout/AdLayoutValidationLogging.kt
+++ b/admob-cmp-compose/src/commonMain/kotlin/dev/avinya/ads/nativead/layout/AdLayoutValidationLogging.kt
@@ -1,0 +1,55 @@
+package dev.avinya.ads.nativead.layout
+
+import dev.avinya.ads.AdLogger
+
+/**
+ * Upper bound on how many distinct layout identities are remembered for
+ * [AdLayout.logValidationWarningsOnce]'s dedup.
+ *
+ * [AdLayout.identity] includes node content such as [AdStaticText.text], so an app that
+ * generates layouts dynamically (locale- or user-data-dependent copy) can produce an unbounded
+ * number of distinct identities over a process lifetime. A plain unbounded set would then grow
+ * for as long as the process runs. FIFO eviction at this bound keeps memory use flat; the
+ * tradeoff is that an evicted identity can log again if it reappears later, which is an
+ * acceptable cost for a diagnostic warning, not a correctness-relevant guarantee.
+ */
+private const val MAX_TRACKED_LAYOUT_IDENTITIES = 64
+
+// Plain, not synchronized: both platform NativeAdView entry points call this only from
+// LaunchedEffect (Compose main-thread effects), never from a background dispatcher or a native
+// callback thread, so no concurrent mutation is possible.
+private val warnedLayoutIdentities = mutableSetOf<String>()
+private val warnedLayoutIdentityOrder = ArrayDeque<String>()
+
+/**
+ * Logs [AdLayout.validation]'s warnings through [AdLogger] once per distinct
+ * [AdLayout.identity] (bounded by [MAX_TRACKED_LAYOUT_IDENTITIES]), the first time this layout
+ * is rendered.
+ *
+ * This is a developer-experience convenience, not a correctness fix: [AdLayoutValidator]
+ * already reports every warning through [AdLayout.validation] regardless of whether this
+ * function is ever called, and its own KDoc leaves reacting to
+ * [AdLayoutValidationReport.warnings] up to the consumer. What this adds is a zero-effort
+ * default -- most apps read no diagnostics at all, so surfacing warnings through [AdLogger]
+ * automatically means a missing ad badge or AdChoices slot is visible in the log without a
+ * developer having to go read `layout.validation` themselves.
+ *
+ * Deliberately NOT called from [AdLayout]'s constructor: `validation` is recomputed on every
+ * construction, including every `copy()`, and both `NativeAdView` implementations rebuild their
+ * [AdLayout] on every recomposition that touches the tree — logging there would repeat on every
+ * recomposition instead of once per distinct layout. The identity dedup is what keeps this to
+ * one log per layout shape, no matter how many times it renders.
+ */
+internal fun AdLayout.logValidationWarningsOnce() {
+    if (validation.warnings.isEmpty()) return
+    if (!warnedLayoutIdentities.add(identity)) return
+    warnedLayoutIdentityOrder.addLast(identity)
+    if (warnedLayoutIdentityOrder.size > MAX_TRACKED_LAYOUT_IDENTITIES) {
+        warnedLayoutIdentities.remove(warnedLayoutIdentityOrder.removeFirst())
+    }
+    validation.warnings.forEach { issue ->
+        // identity may contain AdStaticText.text, including locale- or user-derived content.
+        // Keep it as the internal dedup key, but never copy it into the host's logs.
+        AdLogger.w("Native ad layout: ${issue.message}")
+    }
+}

--- a/admob-cmp-compose/src/commonTest/kotlin/dev/avinya/ads/AdLayoutValidationLoggingTest.kt
+++ b/admob-cmp-compose/src/commonTest/kotlin/dev/avinya/ads/AdLayoutValidationLoggingTest.kt
@@ -1,0 +1,119 @@
+package dev.avinya.ads
+
+import dev.avinya.ads.nativead.layout.AdAssetNode
+import dev.avinya.ads.nativead.layout.AdContainerNode
+import dev.avinya.ads.nativead.layout.AdLayout
+import dev.avinya.ads.nativead.layout.AdModifier
+import dev.avinya.ads.nativead.layout.AdStaticText
+import dev.avinya.ads.nativead.layout.logValidationWarningsOnce
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class AdLayoutValidationLoggingTest {
+
+    private val originalSink = AdLogger.sink
+
+    @AfterTest
+    fun tearDown() {
+        // AdLogger.sink is process-wide; a test that leaves one installed would leak into
+        // unrelated tests run in the same process.
+        AdLogger.sink = originalSink
+    }
+
+    @Test
+    fun `logs each warning once per distinct layout identity even across repeated calls`() {
+        val messages = mutableListOf<String>()
+        AdLogger.sink = AdLogSink { _, _, message, _ -> messages += message }
+        // AdStaticText's text participates in AdLayout.identity, so this marker keeps this
+        // layout's identity from colliding with any other layout built in this test suite.
+        val layout = missingBadgeAndAdChoicesLayout(
+            marker = "logs each warning once per distinct layout identity even across repeated calls",
+        )
+        check(layout.validation.warnings.isNotEmpty()) { "test fixture must produce warnings" }
+
+        layout.logValidationWarningsOnce()
+        layout.logValidationWarningsOnce() // same identity: must not log again
+
+        assertEquals(layout.validation.warnings.size, messages.size)
+        layout.validation.warnings.forEach { warning ->
+            assertTrue(messages.any { it.contains(warning.message) })
+        }
+    }
+
+    @Test
+    fun `warning messages do not expose static layout text or the full identity`() {
+        val messages = mutableListOf<String>()
+        AdLogger.sink = AdLogSink { _, _, message, _ -> messages += message }
+        val sensitiveStaticText = "account-owner-email@example.test"
+        val layout = missingBadgeAndAdChoicesLayout(marker = sensitiveStaticText)
+
+        layout.logValidationWarningsOnce()
+
+        assertTrue(messages.isNotEmpty())
+        assertTrue(messages.none { sensitiveStaticText in it })
+        assertTrue(messages.none { layout.identity in it })
+    }
+
+    @Test
+    fun `does not log when the layout has no warnings`() {
+        val messages = mutableListOf<String>()
+        AdLogger.sink = AdLogSink { _, _, message, _ -> messages += message }
+        val layout = AdLayout(
+            // A Row root, not a Column: AdLayoutValidator's "ad_attribution_not_at_top" check
+            // treats a non-Column root as its own top region, so the badge is found regardless
+            // of child order -- see AdLayoutValidator.kt's topRegion computation.
+            root = AdContainerNode.Row(
+                modifier = AdModifier.empty.copy(backgroundArgb = 0xFF000000L),
+                children = listOf(
+                    AdAssetNode.Headline(),
+                    AdAssetNode.AdBadge(),
+                    AdAssetNode.AdChoices(),
+                    AdStaticText(text = "does not log when the layout has no warnings marker"),
+                ),
+            ),
+        )
+        check(layout.validation.warnings.isEmpty()) { "test fixture must produce no warnings" }
+
+        layout.logValidationWarningsOnce()
+
+        assertTrue(messages.isEmpty())
+    }
+
+    @Test
+    fun `evicts the oldest tracked identity once the bound is exceeded`() {
+        val messages = mutableListOf<String>()
+        AdLogger.sink = AdLogSink { _, _, message, _ -> messages += message }
+
+        // One more than the internal MAX_TRACKED_LAYOUT_IDENTITIES bound (64), so the first
+        // layout's identity is guaranteed to have been evicted by the time the loop finishes --
+        // the dedup set must stay bounded, not grow for the life of the process.
+        val layouts = (1..65).map { index ->
+            missingBadgeAndAdChoicesLayout(marker = "evicts the oldest tracked identity marker $index")
+        }
+        layouts.forEach { it.logValidationWarningsOnce() }
+        val warningsPerLayout = layouts.first().validation.warnings.size
+        check(warningsPerLayout > 0) { "test fixture must produce warnings" }
+        val messagesAfterFirstPass = messages.size
+        assertEquals(65 * warningsPerLayout, messagesAfterFirstPass)
+
+        // Most recently tracked identity: still within the bound, still deduped.
+        layouts.last().logValidationWarningsOnce()
+        assertEquals(messagesAfterFirstPass, messages.size)
+
+        // Oldest identity: evicted to stay within the bound, so it logs again.
+        layouts.first().logValidationWarningsOnce()
+        assertEquals(messagesAfterFirstPass + warningsPerLayout, messages.size)
+    }
+
+    private fun missingBadgeAndAdChoicesLayout(marker: String): AdLayout = AdLayout(
+        root = AdContainerNode.Column(
+            modifier = AdModifier.empty,
+            children = listOf(
+                AdAssetNode.Headline(),
+                AdStaticText(text = marker),
+            ),
+        ),
+    )
+}

--- a/admob-cmp-compose/src/iosMain/kotlin/dev/avinya/ads/ui/IosNativeAdView.kt
+++ b/admob-cmp-compose/src/iosMain/kotlin/dev/avinya/ads/ui/IosNativeAdView.kt
@@ -39,6 +39,7 @@ import dev.avinya.ads.nativead.NativeAdSlotState
 import dev.avinya.ads.nativead.acquireIosNativeAdRenderLease
 import dev.avinya.ads.nativead.layout.AdLayout
 import dev.avinya.ads.nativead.layout.AdLayoutSize
+import dev.avinya.ads.nativead.layout.logValidationWarningsOnce
 import dev.avinya.ads.nativead.rendering.IosNativeAdRenderer
 import dev.avinya.ads.nativead.rendering.adRootSurface
 import dev.avinya.ads.nativead.rendering.rememberResolvedComposeFonts
@@ -70,6 +71,7 @@ public actual fun NativeAdView(
         NativeAdPlaceholder(modifier, loading)
         return
     }
+    LaunchedEffect(layout.identity) { layout.logValidationWarningsOnce() }
 
     val slotState = session.state.collectAsState().value.slots[slotKey]
     val rendererId = remember(session, slotKey) { "ios-native-renderer-${nextIosRendererId++}" }

--- a/admob-cmp-core/src/androidHostTest/kotlin/dev/avinya/ads/AndroidGoogleAdManagerNativePolicyTest.kt
+++ b/admob-cmp-core/src/androidHostTest/kotlin/dev/avinya/ads/AndroidGoogleAdManagerNativePolicyTest.kt
@@ -1,6 +1,10 @@
 package dev.avinya.ads
 
 import android.content.Context
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageManager
+import android.os.Bundle
+import dev.avinya.ads.internal.DeclaredAppId
 import dev.avinya.ads.nativead.NativeAdMemoryPolicy
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
@@ -8,6 +12,7 @@ import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Before
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -41,5 +46,67 @@ class AndroidGoogleAdManagerNativePolicyTest {
         manager.configureNativeAdsAfterAcceptedInitialization(config)
 
         assertEquals(config.nativeAdMemoryPolicy, manager.nativeAds.policy)
+    }
+
+    @Test
+    fun `declaredAppId reads the manifest APPLICATION_ID meta-data as Present`() {
+        val context = mock(Context::class.java)
+        val packageManager = mock(PackageManager::class.java)
+        val metaDataBundle = mock(Bundle::class.java)
+        val applicationInfo = ApplicationInfo().apply { metaData = metaDataBundle }
+        `when`(context.packageManager).thenReturn(packageManager)
+        `when`(context.packageName).thenReturn("dev.avinya.showcase")
+        `when`(packageManager.getApplicationInfo("dev.avinya.showcase", PackageManager.GET_META_DATA))
+            .thenReturn(applicationInfo)
+        `when`(metaDataBundle.getString("com.google.android.gms.ads.APPLICATION_ID"))
+            .thenReturn("ca-app-pub-native-manifest-id")
+
+        val manager = AndroidGoogleAdManager(context) { null }
+
+        assertEquals(DeclaredAppId.Present("ca-app-pub-native-manifest-id"), manager.declaredAppId())
+    }
+
+    @Test
+    fun `declaredAppId reports Missing when the meta-data bundle has no value for the key`() {
+        val context = mock(Context::class.java)
+        val packageManager = mock(PackageManager::class.java)
+        val metaDataBundle = mock(Bundle::class.java)
+        val applicationInfo = ApplicationInfo().apply { metaData = metaDataBundle }
+        `when`(context.packageManager).thenReturn(packageManager)
+        `when`(context.packageName).thenReturn("dev.avinya.showcase")
+        `when`(packageManager.getApplicationInfo("dev.avinya.showcase", PackageManager.GET_META_DATA))
+            .thenReturn(applicationInfo)
+        `when`(metaDataBundle.getString("com.google.android.gms.ads.APPLICATION_ID")).thenReturn(null)
+
+        val manager = AndroidGoogleAdManager(context) { null }
+
+        assertEquals(DeclaredAppId.Missing, manager.declaredAppId())
+    }
+
+    @Test
+    fun `declaredAppId reports Missing when there is no meta-data block at all`() {
+        val context = mock(Context::class.java)
+        val packageManager = mock(PackageManager::class.java)
+        val applicationInfo = ApplicationInfo() // metaData left null: no <meta-data> in the manifest
+        `when`(context.packageManager).thenReturn(packageManager)
+        `when`(context.packageName).thenReturn("dev.avinya.showcase")
+        `when`(packageManager.getApplicationInfo("dev.avinya.showcase", PackageManager.GET_META_DATA))
+            .thenReturn(applicationInfo)
+
+        val manager = AndroidGoogleAdManager(context) { null }
+
+        assertEquals(DeclaredAppId.Missing, manager.declaredAppId())
+    }
+
+    @Test
+    fun `declaredAppId reports Unknown instead of throwing when package manager state is unavailable`() {
+        // A bare mock's packageManager is null, exercising the try/catch fallback in
+        // AndroidGoogleAdManager.declaredAppId -- a read failure must degrade to Unknown (never
+        // a warning), not crash initialize(), and must not be conflated with a confirmed-absent
+        // Missing value.
+        val context = mock(Context::class.java)
+        val manager = AndroidGoogleAdManager(context) { null }
+
+        assertEquals(DeclaredAppId.Unknown, manager.declaredAppId())
     }
 }

--- a/admob-cmp-core/src/androidMain/kotlin/dev/avinya/ads/AndroidConsentController.kt
+++ b/admob-cmp-core/src/androidMain/kotlin/dev/avinya/ads/AndroidConsentController.kt
@@ -7,14 +7,18 @@ import dev.avinya.ads.internal.NativeCallbackTimeoutException
 import dev.avinya.ads.internal.awaitHost
 import dev.avinya.ads.internal.awaitNativeCallback
 import dev.avinya.ads.internal.ownedSnapshot
+import dev.avinya.ads.internal.reconcileThenResumeIfActive
 import com.google.android.ump.ConsentDebugSettings
 import com.google.android.ump.ConsentInformation
 import com.google.android.ump.ConsentRequestParameters
 import com.google.android.ump.UserMessagingPlatform
 import kotlin.coroutines.resume
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 
@@ -29,6 +33,11 @@ internal class AndroidConsentController(
     // Retained so showPrivacyOptions() can resume initialization if the user grants
     // consent from the privacy form after an earlier denial.
     private var lastConfig: AdConfig? = null
+    // Owns the initialize() resume triggered by showPrivacyOptions() below, so a granted
+    // consent decision still reaches initialize() even if the caller that awaited
+    // showPrivacyOptions() was itself cancelled (navigation, rotation) before this runs.
+    // Same shape as GoogleAdManagerBase.admissionScope: process-wide, never cancelled.
+    private val consentScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
 
     override val status: StateFlow<ConsentStatus> = _status
     override val privacyOptionsRequirementStatus: StateFlow<PrivacyOptionsRequirementStatus> = _privacy
@@ -143,33 +152,51 @@ internal class AndroidConsentController(
                     if (formError != null) {
                         AdLogger.w("UMP consent form load/show failed: code=${formError.errorCode} message=${formError.message}")
                     }
-                    if (continuation.isActive) continuation.resume(Unit)
+                    // Reconciliation must not be conditional on the caller still being around —
+                    // see reconcileThenResumeIfActive's KDoc. The form was shown and the user's
+                    // decision (if any) is already persisted by UMP regardless of whether
+                    // gatherConsent()'s caller is still listening.
+                    reconcileThenResumeIfActive(continuation, Unit) {
+                        updatePrivacyState(consentInformation)
+                        _canRequestAds.value = consentInformation.canRequestAds()
+                        _status.value = consentInformationStatus(consentInformation)
+                    }
                 }
             }
-            updatePrivacyState(consentInformation)
-            _canRequestAds.value = consentInformation.canRequestAds()
-            val status = consentInformationStatus(consentInformation).also { _status.value = it }
-            status
+            _status.value
         }
 
-    override suspend fun showPrivacyOptions(): Boolean {
-        val activity = activityProvider() ?: return false
-        return withContext(Dispatchers.Main.immediate) {
-            val success = suspendCancellableCoroutine { continuation ->
-                UserMessagingPlatform.showPrivacyOptionsForm(activity) { if (continuation.isActive) continuation.resume(it == null) }
-            }
-            // The user may have changed their choices in the form; refresh exposed state
-            // so consumers don't read stale consent / canRequestAds values.
+    override suspend fun showPrivacyOptions(): Boolean =
+        withContext(Dispatchers.Main.immediate) {
+            // Acquired inside the main hop, not before it -- matching requestConsentInfoUpdate
+            // and gatherConsent: this reads Activity lifecycle state, which is main-thread-owned
+            // (invariant 5).
+            val activity = activityProvider() ?: return@withContext false
             val consentInformation = UserMessagingPlatform.getConsentInformation(appContext)
-            updatePrivacyState(consentInformation)
-            _canRequestAds.value = consentInformation.canRequestAds()
-            _status.value = consentInformationStatus(consentInformation)
-            // If the user granted consent from the privacy form after an earlier denial,
-            // resume initialization — otherwise the SDK would stay uninitialized forever.
-            if (_canRequestAds.value) lastConfig?.let { onCanRequestAds(it) }
-            success
+            suspendCancellableCoroutine { continuation ->
+                UserMessagingPlatform.showPrivacyOptionsForm(activity) { formError ->
+                    // The user may have changed their choices in the form; refresh exposed
+                    // state so consumers don't read stale consent / canRequestAds values.
+                    // Must run even if the caller awaiting showPrivacyOptions() was
+                    // cancelled — the form already closed and UMP already persisted
+                    // whatever the user chose. See reconcileThenResumeIfActive's KDoc.
+                    reconcileThenResumeIfActive(continuation, formError == null) {
+                        updatePrivacyState(consentInformation)
+                        _canRequestAds.value = consentInformation.canRequestAds()
+                        _status.value = consentInformationStatus(consentInformation)
+                        // If the user granted consent from the privacy form after an
+                        // earlier denial, resume initialization — otherwise the SDK would
+                        // stay uninitialized forever. Launched on consentScope, not
+                        // awaited here: this callback (and the reconciliation above) must
+                        // complete regardless of whether the original caller is still
+                        // around to observe it.
+                        if (_canRequestAds.value) {
+                            lastConfig?.let { config -> consentScope.launch { onCanRequestAds(config) } }
+                        }
+                    }
+                }
+            }
         }
-    }
 
     override suspend fun resetConsentForDebug(): Boolean {
         val activity = activityProvider() ?: return false

--- a/admob-cmp-core/src/androidMain/kotlin/dev/avinya/ads/AndroidGoogleAdManager.kt
+++ b/admob-cmp-core/src/androidMain/kotlin/dev/avinya/ads/AndroidGoogleAdManager.kt
@@ -2,6 +2,8 @@ package dev.avinya.ads
 
 import android.app.Activity
 import android.content.Context
+import android.content.pm.PackageManager
+import dev.avinya.ads.internal.DeclaredAppId
 import dev.avinya.ads.internal.InitializationTimeouts
 import dev.avinya.ads.internal.NativeAdManagerImpl
 import dev.avinya.ads.internal.awaitNativeCallback
@@ -72,6 +74,32 @@ internal class AndroidGoogleAdManager(
     }
 
     override fun appId(config: AdConfig): String = config.androidAppId
+
+    internal override val declaredAppIdSource: String =
+        "AndroidManifest.xml meta-data \"com.google.android.gms.ads.APPLICATION_ID\""
+
+    // NOT what GMA Next-Gen itself uses -- see initializeMobileAdsNative below, which passes
+    // config.androidAppId straight into InitializationConfig.Builder. This manifest value is
+    // read by the User Messaging Platform SDK for its own consent-app resolution, so a mismatch
+    // here means GMA and UMP could resolve two different apps' identities, not that "GMA will
+    // use the wrong one".
+    internal override val declaredAppIdConsumerDescription: String =
+        "The User Messaging Platform (UMP) SDK resolves its own application identity from this " +
+            "manifest value when gathering consent; GMA Next-Gen itself always initializes with " +
+            "AdConfig.androidAppId directly and never reads this key."
+
+    // A failure reading package manager state (a permission issue, a test environment without
+    // one) is Unknown, not Missing: it is not evidence the manifest lacks the key, so it must
+    // never be reported as a configuration gap -- see DeclaredAppId's KDoc.
+    internal override fun declaredAppId(): DeclaredAppId = try {
+        val value = appContext.packageManager
+            .getApplicationInfo(appContext.packageName, PackageManager.GET_META_DATA)
+            .metaData
+            ?.getString("com.google.android.gms.ads.APPLICATION_ID")
+        if (value != null) DeclaredAppId.Present(value) else DeclaredAppId.Missing
+    } catch (t: Throwable) {
+        DeclaredAppId.Unknown
+    }
 
     override fun captureDiagnosticsSnapshotOnMain() {
         androidDiagnostics.captureSnapshotOnMain()

--- a/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/AdLogger.kt
+++ b/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/AdLogger.kt
@@ -43,6 +43,11 @@ public fun interface AdLogSink {
  * **Routing to your own logger:** set [sink] to forward matching messages to Timber, OSLog,
  * a crash-reporter's breadcrumb trail, or any other destination — see [AdLogSink] for
  * whether this replaces or supplements the platform log.
+ *
+ * **[sink] is treated as untrusted, best-effort host code.** If it throws, the SDK never lets
+ * that exception propagate into its own state machines, native callbacks, or cleanup paths —
+ * it is caught, the failure is logged once through the platform log, and the original message
+ * is still delivered there so it is not lost.
  */
 public object AdLogger {
     private const val TAG = "AdMobCMP"
@@ -64,9 +69,26 @@ public object AdLogger {
     private fun dispatch(level: AdLogLevel, message: String, throwable: Throwable?) {
         if (level.ordinal < minLevel.ordinal) return
         val activeSink = sink
-        if (activeSink != null) {
+        if (activeSink == null) {
+            AdPlatformLogger.log(level, TAG, message, throwable)
+            return
+        }
+        // sink is host code and must be treated as untrusted: a throwing sink must never
+        // become a host-app crash or corrupt SDK control flow (a state machine transition, a
+        // native callback, a cleanup path). Falls through to the platform log on failure —
+        // both to report the sink's own failure and so the original message is not lost.
+        // Deliberately calls AdPlatformLogger directly rather than dispatch()/sink again: a
+        // sink that throws on every call must not be able to recurse.
+        try {
             activeSink.log(level, TAG, message, throwable)
-        } else {
+        } catch (t: Throwable) {
+            AdPlatformLogger.log(
+                AdLogLevel.Error,
+                TAG,
+                "AdLogger.sink threw while handling a log message; falling back to the " +
+                    "platform log for this message.",
+                t,
+            )
             AdPlatformLogger.log(level, TAG, message, throwable)
         }
     }

--- a/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/GoogleAdManagerBase.kt
+++ b/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/GoogleAdManagerBase.kt
@@ -7,6 +7,8 @@ import dev.avinya.ads.internal.AppliedConfigurationDecision
 import dev.avinya.ads.internal.ConsentSessionState
 import dev.avinya.ads.internal.FullScreenPresentationArbiter
 import dev.avinya.ads.internal.FullScreenStateLock
+import dev.avinya.ads.internal.DeclaredAppId
+import dev.avinya.ads.internal.appIdConfigurationWarningOrNull
 import dev.avinya.ads.internal.appliedConfigurationDecision
 import dev.avinya.ads.internal.dispatchAfterInitializeHooks
 import dev.avinya.ads.internal.ownedSnapshot
@@ -157,6 +159,29 @@ internal abstract class GoogleAdManagerBase : AdManager, FullScreenPresenceAware
 
     /** `config.androidAppId` or `config.iosAppId` — the one field difference in identity resolution. */
     protected abstract fun appId(config: AdConfig): String
+
+    /**
+     * Reads the app ID declared in the platform's own configuration source, independent of
+     * [AdConfig] — `AndroidManifest.xml` meta-data on Android, `Info.plist` on iOS. See
+     * [DeclaredAppId] for what each outcome means and [appIdConfigurationWarningOrNull] for how
+     * it is turned into a warning.
+     *
+     * `internal`, not `protected`: this class is itself `internal`, so widening this from
+     * `protected` costs nothing on the public ABI, and it lets platform host tests exercise the
+     * per-platform reader directly instead of only indirectly through a full `initialize()`.
+     */
+    internal open fun declaredAppId(): DeclaredAppId = DeclaredAppId.Unknown
+
+    /** Human-readable description of where [declaredAppId] reads from, for the configuration warning. */
+    internal open val declaredAppIdSource: String = "the platform manifest"
+
+    /**
+     * Human-readable description of what actually consumes [declaredAppId] and how that relates
+     * to [appId], for the configuration warning. Deliberately per-platform: on Android the
+     * consumer is UMP, not GMA itself — see [appIdConfigurationWarningOrNull]'s KDoc for why
+     * that distinction matters.
+     */
+    internal open val declaredAppIdConsumerDescription: String = ""
 
     /**
      * Reads GMA's/GAD's version and adapter statuses onto the platform's diagnostics object.
@@ -332,6 +357,18 @@ internal abstract class GoogleAdManagerBase : AdManager, FullScreenPresenceAware
     ): AdManagerStatus {
         AdLogger.i("$platformTag initialize requested. consentMode=$consentMode")
         config.testModeWarningOrNull()?.let(AdLogger::w)
+        // Checked before consent, not inside initializeMobileAds: on Android the value this
+        // reads is what UMP (not GMA) resolves its identity from, so a mismatch is actionable
+        // context for the consent gathering call right below, not just for GMA's own
+        // initialization later. Best-effort and non-fatal by design -- see
+        // appIdConfigurationWarningOrNull's KDoc. Checked on every initialize() attempt, not
+        // cached, matching testModeWarningOrNull's own cadence just above.
+        appIdConfigurationWarningOrNull(
+            appId(config),
+            declaredAppId(),
+            declaredAppIdSource,
+            declaredAppIdConsumerDescription,
+        )?.let(AdLogger::w)
 
         val previousStatus = _status.value
         _status.value = AdManagerStatus.Initializing

--- a/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/AppIdVerification.kt
+++ b/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/AppIdVerification.kt
@@ -1,0 +1,72 @@
+package dev.avinya.ads.internal
+
+/**
+ * The app ID declared in the platform's own configuration source (`AndroidManifest.xml`
+ * meta-data, `Info.plist`), independent of [AdConfig][dev.avinya.ads.AdConfig].
+ *
+ * A plain nullable `String` can't distinguish two very different situations: "the key is
+ * genuinely absent from the manifest/plist" (a real configuration gap worth flagging) versus
+ * "the platform read itself failed for unrelated reasons" (a permission issue, a test
+ * environment with no package manager, an unexpected exception) which is not evidence of
+ * misconfiguration and must never be reported as one. [Missing] and [Unknown] keep those apart.
+ */
+internal sealed interface DeclaredAppId {
+    /** The declared value was read successfully. */
+    data class Present(val value: String) : DeclaredAppId
+
+    /** The read succeeded, but no value is set for the key — a real configuration gap. */
+    data object Missing : DeclaredAppId
+
+    /** The value could not be determined (read failure, unsupported environment). Never a warning. */
+    data object Unknown : DeclaredAppId
+}
+
+/**
+ * Builds a warning message when [declared] does not agree with what
+ * [AdConfig][dev.avinya.ads.AdConfig] was configured with, or `null` when there is nothing to
+ * warn about.
+ *
+ * What "agree" means, and what actually consumes [declared], differs by platform — see
+ * [declaredAppIdConsumerDescription] for the per-platform explanation baked into the message.
+ * On Android, `AndroidManifest.xml`'s `APPLICATION_ID` meta-data is read by the User Messaging
+ * Platform SDK for consent, while GMA Next-Gen itself initializes with `AdConfig.androidAppId`
+ * directly and never touches that manifest value — so an Android mismatch here means GMA and
+ * UMP could resolve two different apps' identities, not that "GMA will use the wrong one". On
+ * iOS, `Info.plist`'s `GADApplicationIdentifier` really is what the native Google Mobile Ads
+ * SDK itself resolves and uses at startup.
+ *
+ * This is a **warning, not a hard failure** in both the mismatch and the missing case: a
+ * configuration gap caught here must not turn into an initialization outage for every ad
+ * format. [DeclaredAppId.Unknown] is deliberately never a warning — an unreadable value is not
+ * evidence of misconfiguration this check can usefully report on.
+ *
+ * IDs are redacted to their last 6 characters: full ad app IDs should not be written to logs
+ * verbatim.
+ *
+ * @param declaredAppIdSource human-readable description of where [declared] is read from.
+ * @param declaredAppIdConsumerDescription human-readable description of what actually consumes
+ *   [declared] and how that relates to [configuredAppId] -- see the platform-specific text
+ *   above.
+ */
+internal fun appIdConfigurationWarningOrNull(
+    configuredAppId: String,
+    declared: DeclaredAppId,
+    declaredAppIdSource: String,
+    declaredAppIdConsumerDescription: String,
+): String? = when (declared) {
+    DeclaredAppId.Unknown -> null
+    DeclaredAppId.Missing -> "AdConfig is configured with app ID (…${configuredAppId.takeLast(6)}), " +
+        "but $declaredAppIdSource has no value set. $declaredAppIdConsumerDescription This is a " +
+        "configuration gap, not just a mismatch -- fix it even though the SDK does not fail " +
+        "initialization for it."
+    is DeclaredAppId.Present -> {
+        if (declared.value == configuredAppId) {
+            null
+        } else {
+            "AdConfig's app ID (…${configuredAppId.takeLast(6)}) does not match the value declared " +
+                "in $declaredAppIdSource (…${declared.value.takeLast(6)}). " +
+                "$declaredAppIdConsumerDescription This usually means AdConfig and " +
+                "$declaredAppIdSource were updated independently."
+        }
+    }
+}

--- a/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/ConsentReconciliation.kt
+++ b/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/ConsentReconciliation.kt
@@ -1,0 +1,27 @@
+package dev.avinya.ads.internal
+
+import kotlin.coroutines.resume
+import kotlinx.coroutines.CancellableContinuation
+
+/**
+ * Runs [reconcile] unconditionally, then resumes [continuation] with [value] only if it is
+ * still active.
+ *
+ * UMP's native form/update callback fires exactly once regardless of whether the Kotlin
+ * caller is still listening. Cancelling the coroutine that started `gatherConsent()` or
+ * `showPrivacyOptions()` does not cancel the form the user is looking at, and does not undo
+ * the consent decision UMP has already persisted natively — a `ConsentController` that only
+ * reconciles its own state (`canRequestAds`, consent status) when the waiter is still active
+ * would silently drop a real privacy decision the moment a host coroutine dies mid-form
+ * (navigation, rotation, process death). [reconcile] is exactly that state and must always
+ * run. Only *resuming the waiter* is conditional: resuming an inactive continuation is a
+ * no-op at best and an `IllegalStateException` at worst.
+ */
+internal inline fun <T> reconcileThenResumeIfActive(
+    continuation: CancellableContinuation<T>,
+    value: T,
+    reconcile: () -> Unit,
+) {
+    reconcile()
+    if (continuation.isActive) continuation.resume(value)
+}

--- a/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/FullScreenSlotCore.kt
+++ b/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/FullScreenSlotCore.kt
@@ -111,9 +111,9 @@ internal class FullScreenPresentationHandle(
         try {
             restore.restore()
         } catch (t: Throwable) {
-            try {
-                AdLogger.e("Failed to restore full-screen audio state after presentation.", t)
-            } catch (_: Throwable) { /* logger failure must not break the terminal close */ }
+            // AdLogger.dispatch() itself contains a throwing host sink, so no nested guard is
+            // needed here any more.
+            AdLogger.e("Failed to restore full-screen audio state after presentation.", t)
         }
     }
 
@@ -711,9 +711,9 @@ internal abstract class FullScreenSlotCore<AdT : Any>(
             try {
                 onPresentationChanged(-1)
             } catch (t: Throwable) {
-                try {
-                    AdLogger.e("Failed to close full-screen presentation presence for ${placement.id}.", t)
-                } catch (_: Throwable) { /* logger failure must not break presentation */ }
+                // AdLogger.dispatch() itself contains a throwing host sink, so no nested guard
+                // is needed here any more.
+                AdLogger.e("Failed to close full-screen presentation presence for ${placement.id}.", t)
             }
             // Released last, and unconditionally: FullScreenPresentationHandle's CAS loop already
             // guarantees this lambda runs exactly once, so this is the single release path. No
@@ -737,9 +737,9 @@ internal abstract class FullScreenSlotCore<AdT : Any>(
         try {
             onPresentationChanged(1)
         } catch (t: Throwable) {
-            try {
-                AdLogger.e("Failed to open full-screen presentation presence for ${placement.id}.", t)
-            } catch (_: Throwable) { /* logger failure must not break presentation */ }
+            // AdLogger.dispatch() itself contains a throwing host sink, so no nested guard is
+            // needed here any more.
+            AdLogger.e("Failed to open full-screen presentation presence for ${placement.id}.", t)
         }
         return handle
     }

--- a/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/AdLoggerTest.kt
+++ b/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/AdLoggerTest.kt
@@ -1,0 +1,67 @@
+package dev.avinya.ads
+
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class AdLoggerTest {
+
+    private val originalMinLevel = AdLogger.minLevel
+    private val originalSink = AdLogger.sink
+
+    @BeforeTest
+    fun setUp() {
+        AdLogger.minLevel = AdLogLevel.Verbose
+    }
+
+    @AfterTest
+    fun tearDown() {
+        // AdLogger's mutable properties are process-wide, so a test that leaves a sink
+        // installed would leak into unrelated tests run in the same process.
+        AdLogger.sink = originalSink
+        AdLogger.minLevel = originalMinLevel
+    }
+
+    @Test
+    fun `a throwing sink does not propagate out of AdLogger`() {
+        var invocations = 0
+        AdLogger.sink = AdLogSink { _, _, _, _ ->
+            invocations++
+            error("boom, host sink is misbehaving")
+        }
+
+        // Must not throw: a public SDK cannot let untrusted host callback code corrupt its
+        // own control flow (a state machine transition, a native callback, a cleanup path).
+        AdLogger.e("something happened")
+
+        assertEquals(1, invocations, "the sink must still have been given the chance to run")
+    }
+
+    @Test
+    fun `a sink that always throws does not recurse into itself`() {
+        var invocations = 0
+        AdLogger.sink = AdLogSink { _, _, _, _ ->
+            invocations++
+            error("boom")
+        }
+
+        // If the failure path routed back through dispatch()/sink instead of the platform
+        // logger directly, a permanently-throwing sink would recurse without bound.
+        AdLogger.e("first")
+        AdLogger.e("second")
+
+        assertEquals(2, invocations, "each call must invoke the sink exactly once, not recurse")
+    }
+
+    @Test
+    fun `a non-throwing sink still receives the message normally`() {
+        val received = mutableListOf<String>()
+        AdLogger.sink = AdLogSink { _, _, message, _ -> received += message }
+
+        AdLogger.w("routine warning")
+
+        assertTrue(received.contains("routine warning"))
+    }
+}

--- a/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/AppIdVerificationTest.kt
+++ b/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/AppIdVerificationTest.kt
@@ -1,0 +1,76 @@
+package dev.avinya.ads
+
+import dev.avinya.ads.internal.DeclaredAppId
+import dev.avinya.ads.internal.appIdConfigurationWarningOrNull
+import kotlin.test.Test
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class AppIdVerificationTest {
+
+    private val source = "Info.plist key \"GADApplicationIdentifier\""
+    private val consumer = "The native Google Mobile Ads SDK resolves its application identity " +
+        "from this Info.plist value at startup, independent of AdConfig."
+
+    @Test
+    fun `warns when the declared app id differs from AdConfig`() {
+        val warning = appIdConfigurationWarningOrNull(
+            configuredAppId = "ca-app-pub-1111111111111111",
+            declared = DeclaredAppId.Present("ca-app-pub-2222222222222222"),
+            declaredAppIdSource = source,
+            declaredAppIdConsumerDescription = consumer,
+        )
+
+        requireNotNull(warning)
+        assertTrue(warning.contains(source))
+        assertTrue(warning.contains(consumer))
+        // Full IDs must never be written to the log verbatim -- only a short suffix.
+        assertTrue(warning.contains("…111111"))
+        assertTrue(warning.contains("…222222"))
+        assertTrue("ca-app-pub-1111111111111111" !in warning)
+        assertTrue("ca-app-pub-2222222222222222" !in warning)
+    }
+
+    @Test
+    fun `stays silent when the declared app id matches AdConfig`() {
+        val warning = appIdConfigurationWarningOrNull(
+            configuredAppId = "ca-app-pub-1111111111111111",
+            declared = DeclaredAppId.Present("ca-app-pub-1111111111111111"),
+            declaredAppIdSource = source,
+            declaredAppIdConsumerDescription = consumer,
+        )
+
+        assertNull(warning)
+    }
+
+    @Test
+    fun `warns when the declared app id is confirmed missing not just unequal`() {
+        val warning = appIdConfigurationWarningOrNull(
+            configuredAppId = "ca-app-pub-1111111111111111",
+            declared = DeclaredAppId.Missing,
+            declaredAppIdSource = source,
+            declaredAppIdConsumerDescription = consumer,
+        )
+
+        requireNotNull(warning)
+        assertTrue(warning.contains(source))
+        assertTrue(warning.contains(consumer))
+        assertTrue(warning.contains("…111111"))
+        assertTrue("ca-app-pub-1111111111111111" !in warning)
+    }
+
+    @Test
+    fun `stays silent when the declared app id could not be determined`() {
+        // An unreadable value (permission failure, unsupported environment) is not itself
+        // evidence of misconfiguration -- see DeclaredAppId's KDoc. It must never be reported
+        // as either a mismatch or a missing-configuration warning.
+        val warning = appIdConfigurationWarningOrNull(
+            configuredAppId = "ca-app-pub-1111111111111111",
+            declared = DeclaredAppId.Unknown,
+            declaredAppIdSource = source,
+            declaredAppIdConsumerDescription = consumer,
+        )
+
+        assertNull(warning)
+    }
+}

--- a/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/ConsentReconciliationTest.kt
+++ b/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/ConsentReconciliationTest.kt
@@ -1,0 +1,102 @@
+package dev.avinya.ads
+
+import dev.avinya.ads.internal.reconcileThenResumeIfActive
+import kotlin.coroutines.resume
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CancellableContinuation
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+
+/**
+ * [reconcileThenResumeIfActive] is the mechanism behind the AndroidConsentController /
+ * IosConsentController fix: a UMP native callback (form dismissed, privacy options form
+ * dismissed) must always reconcile the SDK's own consent state, even if the coroutine that
+ * originally awaited it was cancelled. Only resuming that waiter is conditional.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ConsentReconciliationTest {
+
+    @Test
+    fun `reconciles and resumes an active waiter with the given value`() = runTest {
+        val captured = CompletableDeferred<CancellableContinuation<String>>()
+        val result = async {
+            suspendCancellableCoroutine<String> { continuation -> captured.complete(continuation) }
+        }
+        val continuation = captured.await()
+        var reconciled = false
+
+        reconcileThenResumeIfActive(continuation, "granted") { reconciled = true }
+
+        assertEquals("granted", result.await())
+        assertTrue(reconciled, "reconcile must run for an active waiter")
+    }
+
+    @Test
+    fun `still reconciles when the waiter was already cancelled without resuming it`() = runTest {
+        val captured = CompletableDeferred<CancellableContinuation<String>>()
+        val job = launch {
+            suspendCancellableCoroutine<String> { continuation -> captured.complete(continuation) }
+        }
+        val continuation = captured.await()
+        job.cancelAndJoin()
+        advanceUntilIdle()
+        var reconciled = false
+
+        // Must not throw resuming an already-cancelled continuation, and -- the exact bug this
+        // guards against -- must still run reconcile: a real privacy decision persisted by UMP
+        // must never be dropped just because the caller that started gatherConsent() /
+        // showPrivacyOptions() went away (navigation, rotation, process death) before the
+        // native callback fired.
+        reconcileThenResumeIfActive(continuation, "granted") { reconciled = true }
+
+        assertTrue(reconciled, "reconcile must still run even though the waiter is gone")
+    }
+
+    @Test
+    fun `reconcile runs to completion before the resume attempt`() = runTest {
+        val captured = CompletableDeferred<CancellableContinuation<String>>()
+        val result = async {
+            suspendCancellableCoroutine<String> { continuation -> captured.complete(continuation) }
+        }
+        val continuation = captured.await()
+        val order = mutableListOf<String>()
+
+        reconcileThenResumeIfActive(continuation, "granted") { order += "reconcile" }
+        order += "resumed"
+
+        assertEquals("granted", result.await())
+        assertEquals(listOf("reconcile", "resumed"), order)
+    }
+
+    // Documents the invariant reconcileThenResumeIfActive's isActive-check-then-resume shape
+    // relies on: kotlinx.coroutines deliberately makes Continuation.resume() on an
+    // already-cancelled CancellableContinuation a safe no-op (see CancellableContinuationImpl's
+    // handling of the CancelledContinuation state) rather than throwing -- specifically so that
+    // "the loser of a resume/cancel race is safe to call resume anyway" is a supported pattern.
+    // That is what makes the isActive check here (and at every other native-callback site in
+    // this codebase) race-safe without needing tryResume/completeResume: even if cancellation
+    // lands between the isActive check and the resume() call, resume() itself tolerates it.
+    // If a future kotlinx.coroutines version ever changes this, this test fails loudly instead
+    // of the change silently becoming unsafe.
+    @Test
+    fun `resume on an already-cancelled continuation does not throw`() = runTest {
+        val captured = CompletableDeferred<CancellableContinuation<String>>()
+        val job = launch {
+            suspendCancellableCoroutine<String> { continuation -> captured.complete(continuation) }
+        }
+        val continuation = captured.await()
+        job.cancelAndJoin()
+        advanceUntilIdle()
+
+        // No isActive check at all -- this is the exact call the TOCTOU claim says is unsafe.
+        continuation.resume("late value")
+    }
+}

--- a/admob-cmp-core/src/iosMain/kotlin/dev/avinya/ads/IosConsentController.kt
+++ b/admob-cmp-core/src/iosMain/kotlin/dev/avinya/ads/IosConsentController.kt
@@ -18,9 +18,12 @@ import UserMessagingPlatform.UMPPrivacyOptionsRequirementStatusRequired
 import UserMessagingPlatform.UMPRequestParameters
 import kotlin.coroutines.resume
 import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import dev.avinya.ads.internal.InitializationTimeouts
@@ -28,6 +31,7 @@ import dev.avinya.ads.internal.NativeCallbackTimeoutException
 import dev.avinya.ads.internal.awaitHost
 import dev.avinya.ads.internal.awaitNativeCallback
 import dev.avinya.ads.internal.ownedSnapshot
+import dev.avinya.ads.internal.reconcileThenResumeIfActive
 
 internal class IosConsentController(
     val onCanRequestAds: suspend (AdConfig) -> Unit
@@ -38,6 +42,11 @@ internal class IosConsentController(
     // Retained so showPrivacyOptions() can resume initialization if the user grants
     // consent from the privacy form after an earlier denial.
     private var lastConfig: AdConfig? = null
+    // Owns the initialize() resume triggered by showPrivacyOptions() below, so a granted
+    // consent decision still reaches initialize() even if the caller that awaited
+    // showPrivacyOptions() was itself cancelled (navigation, view teardown) before this
+    // runs. Same shape as GoogleAdManagerBase.admissionScope: process-wide, never cancelled.
+    private val consentScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
 
     override val status: StateFlow<ConsentStatus> = _status
     override val privacyOptionsRequirementStatus: StateFlow<PrivacyOptionsRequirementStatus> = _privacy
@@ -73,6 +82,16 @@ internal class IosConsentController(
                 suspendCancellableCoroutine<Unit> { continuation ->
                     continuation.invokeOnCancellation { }
                     consentInformation.requestConsentInfoUpdateWithParameters(buildParams(config)) { error ->
+                        // Deliberately still gated on isActive, NOT routed through
+                        // reconcileThenResumeIfActive: this is the bounded, non-interactive path
+                        // covered by the huge comment above -- canRequestAds/status must NOT be
+                        // reconciled from a callback that arrives after awaitNativeCallback's
+                        // internal withTimeoutOrNull has already cancelled this continuation and
+                        // published ConsentStatus.Failed(timeout) below. Doing so unconditionally
+                        // would let a late callback silently overwrite that terminal Failed status
+                        // with a stale success, diverging from AndroidConsentController's
+                        // equivalent path (updateWithActivity), which the comment above this
+                        // function requires stay identical.
                         if (continuation.isActive) {
                             updatePrivacyState(consentInformation)
                             _canRequestAds.value = consentInformation.canRequestAds
@@ -125,12 +144,15 @@ internal class IosConsentController(
         }
         suspendCancellableCoroutine { continuation ->
             continuation.invokeOnCancellation { }
-            UMPConsentForm.loadAndPresentIfRequiredFromViewController(rootVC) { error ->
-                if (continuation.isActive) {
+            UMPConsentForm.loadAndPresentIfRequiredFromViewController(rootVC) {
+                // Reconciliation must not be conditional on the caller still being around —
+                // see reconcileThenResumeIfActive's KDoc. The form was shown and the user's
+                // decision (if any) is already persisted by UMP regardless of whether
+                // gatherConsent()'s caller is still listening.
+                reconcileThenResumeIfActive(continuation, Unit) {
                     updatePrivacyState(consentInformation)
                     _canRequestAds.value = consentInformation.canRequestAds
                     _status.value = consentInformationStatus(consentInformation)
-                    continuation.resume(Unit)
                 }
             }
         }
@@ -139,22 +161,31 @@ internal class IosConsentController(
 
     override suspend fun showPrivacyOptions(): Boolean = withContext(Dispatchers.Main.immediate) {
         val rootVC = topViewController() ?: return@withContext false
-        val success = suspendCancellableCoroutine { continuation ->
+        val consentInformation = UMPConsentInformation.sharedInstance
+        suspendCancellableCoroutine { continuation ->
             continuation.invokeOnCancellation { }
             UMPConsentForm.presentPrivacyOptionsFormFromViewController(rootVC) { error ->
-                if (continuation.isActive) continuation.resume(error == null)
+                // The user may have changed their choices; refresh exposed state so
+                // consumers don't read stale consent / canRequestAds values. Must run even
+                // if the caller awaiting showPrivacyOptions() was cancelled — the form
+                // already closed and UMP already persisted whatever the user chose. See
+                // reconcileThenResumeIfActive's KDoc.
+                reconcileThenResumeIfActive(continuation, error == null) {
+                    updatePrivacyState(consentInformation)
+                    _canRequestAds.value = consentInformation.canRequestAds
+                    _status.value = consentInformationStatus(consentInformation)
+                    // If the user granted consent from the privacy form after an earlier
+                    // denial, resume initialization — otherwise the SDK would stay
+                    // uninitialized forever. Launched on consentScope, not awaited here:
+                    // this callback (and the reconciliation above) must complete
+                    // regardless of whether the original caller is still around to
+                    // observe it.
+                    if (_canRequestAds.value) {
+                        lastConfig?.let { config -> consentScope.launch { onCanRequestAds(config) } }
+                    }
+                }
             }
         }
-        // The user may have changed their choices; refresh exposed state so consumers
-        // don't read stale consent / canRequestAds values.
-        val consentInformation = UMPConsentInformation.sharedInstance
-        updatePrivacyState(consentInformation)
-        _canRequestAds.value = consentInformation.canRequestAds
-        _status.value = consentInformationStatus(consentInformation)
-        // If the user granted consent from the privacy form after an earlier denial,
-        // resume initialization — otherwise the SDK would stay uninitialized forever.
-        if (_canRequestAds.value) lastConfig?.let { onCanRequestAds(it) }
-        success
     }
 
     override suspend fun resetConsentForDebug(): Boolean = withContext(Dispatchers.Main.immediate) {

--- a/admob-cmp-core/src/iosMain/kotlin/dev/avinya/ads/IosGoogleAdManager.kt
+++ b/admob-cmp-core/src/iosMain/kotlin/dev/avinya/ads/IosGoogleAdManager.kt
@@ -9,6 +9,7 @@ import GoogleMobileAds.GADCurrentOrientationInlineAdaptiveBannerAdSizeWithWidth
 import GoogleMobileAds.GADInlineAdaptiveBannerAdSizeWithWidthAndMaxHeight
 import GoogleMobileAds.GADLargeAnchoredAdaptiveBannerAdSizeWithWidth
 import GoogleMobileAds.GADMobileAds
+import dev.avinya.ads.internal.DeclaredAppId
 import dev.avinya.ads.internal.InitializationTimeouts
 import dev.avinya.ads.internal.NativeAdManagerImpl
 import dev.avinya.ads.internal.awaitNativeCallback
@@ -24,6 +25,7 @@ import kotlinx.cinterop.CValue
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.readValue
 import platform.CoreGraphics.CGSizeMake
+import platform.Foundation.NSBundle
 
 private object IosAdManagerHolder {
     val instance: IosGoogleAdManager = IosGoogleAdManager()
@@ -78,6 +80,24 @@ internal class IosGoogleAdManager : GoogleAdManagerBase() {
     }
 
     override fun appId(config: AdConfig): String = config.iosAppId
+
+    internal override val declaredAppIdSource: String = "Info.plist key \"GADApplicationIdentifier\""
+
+    // GADMobileAds really does resolve its own app ID from this Info.plist key at startup,
+    // independent of AdConfig -- unlike Android, where the manifest equivalent is read by UMP,
+    // not by GMA itself. See GoogleAdManagerBase's declaredAppId KDoc.
+    internal override val declaredAppIdConsumerDescription: String =
+        "The native Google Mobile Ads SDK resolves its application identity from this " +
+            "Info.plist value at startup, independent of AdConfig."
+
+    // infoDictionary itself is null only if the bundle could not be read at all (Unknown, never
+    // a warning); a present dictionary with no String value for this key is a genuine
+    // configuration gap (Missing) -- see DeclaredAppId's KDoc.
+    internal override fun declaredAppId(): DeclaredAppId {
+        val infoDictionary = NSBundle.mainBundle.infoDictionary ?: return DeclaredAppId.Unknown
+        val value = infoDictionary["GADApplicationIdentifier"] as? String
+        return if (value != null) DeclaredAppId.Present(value) else DeclaredAppId.Missing
+    }
 
     override fun captureDiagnosticsSnapshotOnMain() {
         iosDiagnostics.captureSnapshotOnMain()

--- a/admob-cmp-core/src/iosTest/kotlin/dev/avinya/ads/IosGoogleAdManagerNativePolicyTest.kt
+++ b/admob-cmp-core/src/iosTest/kotlin/dev/avinya/ads/IosGoogleAdManagerNativePolicyTest.kt
@@ -1,5 +1,6 @@
 package dev.avinya.ads
 
+import dev.avinya.ads.internal.DeclaredAppId
 import dev.avinya.ads.nativead.NativeAdMemoryPolicy
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -22,5 +23,17 @@ class IosGoogleAdManagerNativePolicyTest {
         manager.configureNativeAdsAfterAcceptedInitialization(config)
 
         assertEquals(config.nativeAdMemoryPolicy, manager.nativeAds.policy)
+    }
+
+    @Test
+    fun `declaredAppId reports Missing for the xctest host bundle without throwing`() {
+        // The xctest host bundle's Info.plist has a real infoDictionary but no
+        // GADApplicationIdentifier key, so this deterministically exercises the confirmed-absent
+        // path (an unmocked NSBundle.mainBundle can't be pointed at a fixture Info.plist from a
+        // KMP unit test) -- appIdConfigurationWarningOrNull (covered directly in
+        // AppIdVerificationTest) turns Missing into a real warning, distinct from Unknown.
+        val manager = IosGoogleAdManager()
+
+        assertEquals(DeclaredAppId.Missing, manager.declaredAppId())
     }
 }


### PR DESCRIPTION
## What does this change?

Hardens four SDK runtime paths where a failure previously escaped into ad-lifecycle
code or left the SDK in a state the caller could not observe. No public binary
signature changes — the change is entirely in behaviour under failure and
cancellation.

## What's in each commit

**`fix(compose): harden native layout rendering diagnostics`** — Android
call-to-action labels are centred without changing the painted asset bounds, and an
invalid native-ad layout is reported once per layout rather than once per render
pass, with layout identities and static text kept out of the logs.

**`fix(core): isolate failures from custom log sinks`** — an exception thrown by an
application-provided `AdLogSink` no longer escapes into the ad lifecycle operation
that emitted the message; a throwing sink falls back to the platform log.

**`feat(core): warn on declared app ID mismatches`** — the runtime `AdAppIds`
configuration is compared against the Android manifest `APPLICATION_ID` metadata and
the iOS `GADApplicationIdentifier` in `Info.plist`. Verification is non-fatal — a
mismatch warns and initialization proceeds — and identifiers are redacted in the
diagnostic.

**`fix(core): reconcile consent after caller cancellation`** — SDK state is always
reconciled once an interactive UMP callback fires, even when the original waiter has
been cancelled. Initialization resumes from a detached Main-scope continuation, so a
cancelled consent request can no longer leave the manager awaiting a callback that
already arrived.

## Checklist

- [x] Added or updated a test that fails before this change and passes after it
- [x] Ran `./gradlew :admob-cmp-core:testAndroidHostTest` and `:admob-cmp-core:iosSimulatorArm64Test`
- [x] If this touches the public API of `admob-cmp-core` or `admob-cmp-compose`: ran
      `updateKotlinAbi` and committed the regenerated `api/*.klib.api` dump
- [ ] Updated docs in `docs-site/src/content/docs/` in this PR, if user-facing behavior changed
- [ ] Updated [the changelog](https://ads.avinya.dev/reference/changelog/), if behavior a consumer can observe changed
- [x] Ran `./scripts/release-readiness.sh` locally and got `READINESS: PASS` (or explained why it couldn't be run)

## Notes for the reviewer

**`READINESS: PASS`, full run — no `--skip-docs`,** since the diff touches
`admob-cmp-core/` and `admob-cmp-compose/`. All nine sections executed and passed:
version lockstep; Gradle plugin build + supply-chain policy; static analysis and
coverage; Android + ABI + publication metadata; the Central task graph; iOS + klib
ABI; the published-consumer round trip; the Xcode consumer; and docs (Dokka + Astro
+ visual checks + verify, 30 pages audited). Nothing failed and needed fixing during
the run. That run covers both named test tasks, for `admob-cmp-core` and
`admob-cmp-compose` alike.

**On the first box:** tests accompany each commit — `AdLoggerTest`,
`AppIdVerificationTest`, `ConsentReconciliationTest`,
`AdLayoutValidationLoggingTest`, `AndroidNativeAdRendererLoggingTest`, and
`AndroidGoogleAdManagerNativePolicyTest` — and all of them pass. The commits predate
this verification pass, so the pre-change red state was not re-observed here.

**On the ABI box:** no public API changed, so there was nothing to regenerate. The
`api/*.klib.api` dumps are untouched by this branch and the ABI sections passed
against the frozen dump.

**The two docs boxes are deliberately unchecked.** Three of the four commits are
observable from host code — the app ID mismatch warning, the log-sink fallback, and
the post-cancellation consent reconciliation — and none has an entry in the
`## Unreleased` section of `docs-site/src/content/docs/reference/changelog.mdx`. That
section already documents the `AdLogger.minLevel` / `AdLogger.sink` API added in
`b55aa36a` and reads as complete without the sink-isolation refinement. Wording the
release notes was left to the owner rather than guessed at; they can go in before
merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
