### PR TITLE
Close five verification gaps the suite cannot reach

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,53 @@ A push that changes neither the version nor any docs input
 itself) exits in seconds on the `gate` job. **That is expected, not a
 failure** — it is the steady state.
 
+### Before bumping VERSION_NAME
+
+If the release changes native integration, consent, presentation, the renderer,
+or Gradle/XCFramework behaviour, run and sign
+[docs/release/device-certification.md](docs/release/device-certification.md).
+The local suite cannot prove any of it — every row depends on real GMA/UMP
+behaviour, real OS lifecycle, or real network conditions.
+
+### When a release goes wrong
+
+Maven Central is immutable; there is no rollback. Follow
+[docs/release/hotfix-playbook.md](docs/release/hotfix-playbook.md).
+
+### Dependency upgrades
+
+No dependency version is bumped on a successful compile alone. For any GMA or
+UMP bump: read the upstream release notes for API, threading, linker, and
+consent changes; re-run the mapper characterization tests
+(`AndroidAdMappersTest`, `IosAdMappersTest`); re-run
+`scripts/release-readiness.sh` in full; recompute the iOS archive checksums
+deliberately; and run device certification for every affected format. For a
+Kotlin, KGP, Gradle, AGP, or Compose bump, additionally run
+`./scripts/distribution/verify-published-release.sh <version> --local` before
+changing anything in
+`docs-site/src/content/docs/reference/compatibility.mdx`.
+
+### After Maven Central publishes
+
+Maven Central artifacts are immutable. Once the `publish` job completes, run
+the canary from a clean room:
+
+```bash
+./scripts/distribution/verify-published-release.sh <version>
+```
+
+This generates a throwaway KMP consumer in a temp directory that resolves
+`dev.avinya.ads:admob-cmp` and the Gradle plugin from Maven Central only — no
+`mavenLocal()`, no project substitution, no access to this source tree. It is
+the only check that exercises the path a real consumer uses.
+
+A failure is not recoverable by rollback. Follow
+[docs/release/hotfix-playbook.md](docs/release/hotfix-playbook.md).
+
+The same script with `--local` is the pre-release clean-room check, and is
+worth running after `publishToMavenLocal` whenever publication metadata,
+coordinates, or the Gradle plugin change.
+
 ---
 
 ## Docs site

--- a/admob-cmp-core/src/androidMain/kotlin/dev/avinya/ads/AndroidConsentController.kt
+++ b/admob-cmp-core/src/androidMain/kotlin/dev/avinya/ads/AndroidConsentController.kt
@@ -6,8 +6,11 @@ import dev.avinya.ads.internal.InitializationTimeouts
 import dev.avinya.ads.internal.NativeCallbackTimeoutException
 import dev.avinya.ads.internal.awaitHost
 import dev.avinya.ads.internal.awaitNativeCallback
+import dev.avinya.ads.internal.consentInfoUpdateTimeoutStatus
 import dev.avinya.ads.internal.ownedSnapshot
 import dev.avinya.ads.internal.reconcileThenResumeIfActive
+import dev.avinya.ads.internal.resolveConsentInfoUpdateStatus
+import dev.avinya.ads.internal.shouldResumeInitializationAfterPrivacyOptions
 import com.google.android.ump.ConsentDebugSettings
 import com.google.android.ump.ConsentInformation
 import com.google.android.ump.ConsentRequestParameters
@@ -123,17 +126,18 @@ internal class AndroidConsentController(
             }
         } catch (timeout: NativeCallbackTimeoutException) {
             AdLogger.e("Android UMP consent info update timed out.", timeout)
-            return fail(timeout.message ?: "UMP consent info update timed out.")
+            // canRequestAds is deliberately NOT reset here. See
+            // consentInfoUpdateTimeoutStatus's KDoc.
+            return consentInfoUpdateTimeoutStatus(timeout.message).also { _status.value = it }
         }
         updatePrivacyState(consentInformation)
         _canRequestAds.value = consentInformation.canRequestAds()
-        val status = if (error == null) {
-            consentInformationStatus(consentInformation).also { _status.value = it }
-        } else if (consentInformation.canRequestAds()) {
-            consentInformationStatus(consentInformation).also { _status.value = it }
-        } else {
-            ConsentStatus.Failed(error).also { _status.value = it }
-        }
+        val status = resolveConsentInfoUpdateStatus(
+            error = error,
+            canRequestAds = consentInformation.canRequestAds(),
+            nativeStatus = consentInformationStatus(consentInformation),
+        )
+        _status.value = status
         return status
     }
 
@@ -190,7 +194,7 @@ internal class AndroidConsentController(
                         // awaited here: this callback (and the reconciliation above) must
                         // complete regardless of whether the original caller is still
                         // around to observe it.
-                        if (_canRequestAds.value) {
+                        if (shouldResumeInitializationAfterPrivacyOptions(_canRequestAds.value, lastConfig)) {
                             lastConfig?.let { config -> consentScope.launch { onCanRequestAds(config) } }
                         }
                     }

--- a/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/ConsentInfoUpdatePolicy.kt
+++ b/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/ConsentInfoUpdatePolicy.kt
@@ -1,0 +1,57 @@
+package dev.avinya.ads.internal
+
+import dev.avinya.ads.AdConfig
+import dev.avinya.ads.AdError
+import dev.avinya.ads.ConsentStatus
+
+/**
+ * The status both platforms publish after a UMP `requestConsentInfoUpdate`
+ * round trip.
+ *
+ * Android's `updateWithActivity` and iOS's `requestConsentInfoUpdate` carried
+ * this three-branch decision separately, each with a comment requiring it stay
+ * byte-identical to the other because "a consent-admission divergence between
+ * the platforms is the kind of thing that is only discovered in production".
+ * Nothing enforced that. It lives here now so the parity is structural.
+ *
+ * The middle branch is the load-bearing one: UMP can fail a refresh while the
+ * user's previously persisted decision still permits ad serving. A dropped
+ * network round trip is not evidence that consent was withdrawn, so admission
+ * keeps whatever the last COMPLETED refresh established rather than collapsing
+ * to [ConsentStatus.Failed].
+ */
+internal fun resolveConsentInfoUpdateStatus(
+    error: AdError?,
+    canRequestAds: Boolean,
+    nativeStatus: ConsentStatus,
+): ConsentStatus = when {
+    error == null -> nativeStatus
+    canRequestAds -> nativeStatus
+    else -> ConsentStatus.Failed(error)
+}
+
+/**
+ * The status both platforms publish when the bounded info-update round trip
+ * times out.
+ *
+ * Callers must NOT reset `canRequestAds` alongside this. The timeout means the
+ * SDK could not re-confirm consent, not that consent changed; UMP has already
+ * persisted the user's actual choice. On a first run admission is false anyway,
+ * so a cold start still admits nothing.
+ */
+internal fun consentInfoUpdateTimeoutStatus(message: String?): ConsentStatus =
+    ConsentStatus.Failed(AdError.message(message ?: "UMP consent info update timed out."))
+
+/**
+ * Whether closing the privacy-options form should resume a detached
+ * initialization.
+ *
+ * True only when the user's decision now permits ad serving AND an owned
+ * [AdConfig] snapshot from an earlier consent operation exists to resume with.
+ * `showPrivacyOptions()` can legitimately be called before any `initialize()`,
+ * and the SDK must not invent a config in that case.
+ */
+internal fun shouldResumeInitializationAfterPrivacyOptions(
+    canRequestAds: Boolean,
+    lastConfig: AdConfig?,
+): Boolean = canRequestAds && lastConfig != null

--- a/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/ConsentInfoUpdatePolicyTest.kt
+++ b/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/ConsentInfoUpdatePolicyTest.kt
@@ -1,0 +1,135 @@
+package dev.avinya.ads
+
+import dev.avinya.ads.internal.consentInfoUpdateTimeoutStatus
+import dev.avinya.ads.internal.resolveConsentInfoUpdateStatus
+import dev.avinya.ads.internal.shouldResumeInitializationAfterPrivacyOptions
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * Pins the consent info-update decision table that BOTH platform controllers
+ * publish from.
+ *
+ * Android's `updateWithActivity` and iOS's `requestConsentInfoUpdate` used to
+ * carry this policy separately, each with a comment requiring it stay identical
+ * to the other. Nothing enforced that. Now both call the same function, and
+ * this test is what pins its behaviour — a divergence would have to be
+ * introduced deliberately, in one place, against these assertions.
+ */
+class ConsentInfoUpdatePolicyTest {
+
+    private val networkError = AdError(code = "3", message = "network error")
+
+    @Test
+    fun `a successful update publishes the native status`() {
+        val status = resolveConsentInfoUpdateStatus(
+            error = null,
+            canRequestAds = true,
+            nativeStatus = ConsentStatus.Obtained,
+        )
+
+        assertEquals(ConsentStatus.Obtained, status)
+    }
+
+    @Test
+    fun `a successful update publishes NotRequired without collapsing it to Obtained`() {
+        val status = resolveConsentInfoUpdateStatus(
+            error = null,
+            canRequestAds = true,
+            nativeStatus = ConsentStatus.NotRequired,
+        )
+
+        assertEquals(ConsentStatus.NotRequired, status)
+    }
+
+    @Test
+    fun `an error while ads remain servable keeps the native status not Failed`() {
+        // UMP can fail a refresh while the previously persisted decision still
+        // permits ad serving. Publishing Failed here would block admission on a
+        // network blip, for no gain in consent correctness.
+        val status = resolveConsentInfoUpdateStatus(
+            error = networkError,
+            canRequestAds = true,
+            nativeStatus = ConsentStatus.Obtained,
+        )
+
+        assertEquals(ConsentStatus.Obtained, status)
+    }
+
+    @Test
+    fun `an error with no servable consent publishes Failed carrying that error`() {
+        val status = resolveConsentInfoUpdateStatus(
+            error = networkError,
+            canRequestAds = false,
+            nativeStatus = ConsentStatus.Unknown,
+        )
+
+        val failed = assertIs<ConsentStatus.Failed>(status)
+        assertEquals("3", failed.error.code)
+        assertEquals("network error", failed.error.message)
+    }
+
+    @Test
+    fun `the resolution never reports Failed while ads are servable`() {
+        // The admission-preserving invariant, stated directly: whatever the
+        // error, a true canRequestAds must not produce Failed on either platform.
+        val statuses = listOf(
+            ConsentStatus.Unknown,
+            ConsentStatus.Required,
+            ConsentStatus.NotRequired,
+            ConsentStatus.Obtained,
+        )
+
+        for (native in statuses) {
+            val status = resolveConsentInfoUpdateStatus(
+                error = networkError,
+                canRequestAds = true,
+                nativeStatus = native,
+            )
+            assertFalse(
+                status is ConsentStatus.Failed,
+                "canRequestAds=true with nativeStatus=$native must not resolve to Failed",
+            )
+        }
+    }
+
+    @Test
+    fun `a timeout publishes Failed carrying the timeout message`() {
+        val status = consentInfoUpdateTimeoutStatus("UMP consent info update timed out.")
+
+        val failed = assertIs<ConsentStatus.Failed>(status)
+        assertEquals("UMP consent info update timed out.", failed.error.message)
+    }
+
+    @Test
+    fun `a timeout with no message still publishes a described failure`() {
+        val status = consentInfoUpdateTimeoutStatus(null)
+
+        val failed = assertIs<ConsentStatus.Failed>(status)
+        assertEquals("UMP consent info update timed out.", failed.error.message)
+    }
+
+    @Test
+    fun `privacy options resume initialization only when consent was granted`() {
+        val config = AdConfig(
+            appIds = AdAppIds(
+                android = "ca-app-pub-3940256099942544~3347511713",
+                ios = "ca-app-pub-3940256099942544~1458002511",
+            ),
+        )
+
+        assertTrue(shouldResumeInitializationAfterPrivacyOptions(canRequestAds = true, lastConfig = config))
+        assertFalse(shouldResumeInitializationAfterPrivacyOptions(canRequestAds = false, lastConfig = config))
+    }
+
+    @Test
+    fun `privacy options cannot resume initialization without an owned config`() {
+        // showPrivacyOptions() can be called before any initialize(), in which
+        // case there is no config snapshot to resume with and the SDK must not
+        // invent one.
+        assertFalse(shouldResumeInitializationAfterPrivacyOptions(canRequestAds = true, lastConfig = null))
+    }
+}

--- a/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/NativeAdGovernorStressTest.kt
+++ b/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/NativeAdGovernorStressTest.kt
@@ -1,0 +1,220 @@
+package dev.avinya.ads
+
+import dev.avinya.ads.internal.NativeAdDemandClass
+import dev.avinya.ads.internal.NativeAdGovernor
+import dev.avinya.ads.internal.NativeAdLoadReservation
+import dev.avinya.ads.internal.NativeAdPriority
+import dev.avinya.ads.internal.NativeAdRecordId
+import dev.avinya.ads.internal.NativeMemoryPressure
+import dev.avinya.ads.nativead.NativeAdMemoryPolicy
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.fail
+
+/**
+ * Seeded stress runner for [NativeAdGovernor].
+ *
+ * The governor's KDoc claims `loadedRecordCount + reservedLoadCount <=
+ * policy.hardLimit` holds "under every mutation". The handcrafted tests in
+ * [NativeAdGovernorTest] prove that for the interleavings someone thought to
+ * write down. This proves it for generated ones.
+ *
+ * Deterministic on purpose: no threads, no sleeps, no wall clock. Every run
+ * uses a fixed seed, and any failure prints the seed and operation index so the
+ * exact sequence replays. The governor's LRU is keyed off an incrementing
+ * access ordinal rather than a clock, which is what makes this reproducible.
+ */
+class NativeAdGovernorStressTest {
+
+    private companion object {
+        const val SEEDS = 400
+        const val OPERATIONS_PER_SEED = 120
+    }
+
+    /** How a reservation left the pending set. A reservation must reach exactly one. */
+    private enum class Terminal { Admitted, Released, CancelledByReserve, CancelledByTrim }
+
+    private class Harness(policy: NativeAdMemoryPolicy, val seed: Int) {
+        val governor = NativeAdGovernor(policy)
+        val pending = mutableListOf<NativeAdLoadReservation>()
+        val live = mutableListOf<NativeAdRecordId>()
+        val mounted = mutableSetOf<NativeAdRecordId>()
+        val terminal = mutableMapOf<NativeAdLoadReservation, Terminal>()
+        var minted = 0
+
+        fun consume(reservation: NativeAdLoadReservation, how: Terminal, op: Int) {
+            val prior = terminal.put(reservation, how)
+            if (prior != null) {
+                fail(
+                    "seed=$seed op=$op: reservation ${reservation.id.value} reached two " +
+                        "terminal states: $prior then $how"
+                )
+            }
+            pending.remove(reservation)
+        }
+
+        fun forget(ids: List<NativeAdRecordId>) {
+            live.removeAll(ids.toSet())
+            mounted.removeAll(ids.toSet())
+        }
+
+        fun assertInvariant(op: Int, action: String) {
+            val state = governor.state()
+            if (state.loadedRecords + state.reservedLoads > state.hardLimit) {
+                fail(
+                    "seed=$seed op=$op after $action: capacity invariant broken — " +
+                        "loadedRecords=${state.loadedRecords} + reservedLoads=${state.reservedLoads} " +
+                        "> hardLimit=${state.hardLimit}"
+                )
+            }
+            if (state.loadedRecords < 0 || state.reservedLoads < 0) {
+                fail(
+                    "seed=$seed op=$op after $action: negative accounting — " +
+                        "loadedRecords=${state.loadedRecords} reservedLoads=${state.reservedLoads}"
+                )
+            }
+        }
+    }
+
+    @Suppress("CyclomaticComplexMethod")
+    private fun runSequence(seed: Int, policy: NativeAdMemoryPolicy) {
+        val random = Random(seed)
+        val h = Harness(policy, seed)
+        val priorities = NativeAdPriority.entries.toList()
+
+        repeat(OPERATIONS_PER_SEED) { op ->
+            when (random.nextInt(10)) {
+                0, 1 -> {
+                    val decision = h.governor.reserve(
+                        demandClass = NativeAdDemandClass.Visible,
+                        priority = priorities.random(random),
+                        count = 1 + random.nextInt(3),
+                        allowPartial = random.nextBoolean(),
+                    )
+                    decision.cancelledReservations.forEach { h.consume(it, Terminal.CancelledByReserve, op) }
+                    h.forget(decision.retiredRecordIds)
+                    h.pending += decision.reservations
+                    h.minted += decision.reservations.size
+                    h.assertInvariant(op, "reserve(Visible)")
+                }
+                2 -> {
+                    val decision = h.governor.reserve(
+                        demandClass = NativeAdDemandClass.Speculative,
+                        priority = priorities.random(random),
+                        count = 1 + random.nextInt(2),
+                        allowPartial = random.nextBoolean(),
+                    )
+                    decision.cancelledReservations.forEach { h.consume(it, Terminal.CancelledByReserve, op) }
+                    h.forget(decision.retiredRecordIds)
+                    h.pending += decision.reservations
+                    h.minted += decision.reservations.size
+                    h.assertInvariant(op, "reserve(Speculative)")
+                }
+                3, 4 -> {
+                    if (h.pending.isNotEmpty()) {
+                        val reservation = h.pending.random(random)
+                        val id = h.governor.admit(reservation)
+                        h.consume(reservation, Terminal.Admitted, op)
+                        h.live += id
+                        h.assertInvariant(op, "admit")
+                    }
+                }
+                5 -> {
+                    if (h.pending.isNotEmpty()) {
+                        val reservation = h.pending.random(random)
+                        h.governor.releaseReservation(reservation)
+                        h.consume(reservation, Terminal.Released, op)
+                        h.assertInvariant(op, "releaseReservation")
+                    }
+                }
+                6 -> {
+                    if (h.live.isNotEmpty()) {
+                        val id = h.live.random(random)
+                        h.governor.touch(id)
+                        h.governor.reclassify(id, priorities.random(random))
+                        h.assertInvariant(op, "touch+reclassify")
+                    }
+                }
+                7 -> {
+                    if (h.live.isNotEmpty()) {
+                        val id = h.live.random(random)
+                        val nowMounted = random.nextBoolean()
+                        h.governor.setMounted(id, nowMounted)
+                        if (nowMounted) h.mounted += id else h.mounted -= id
+                        h.assertInvariant(op, "setMounted")
+                    }
+                }
+                8 -> {
+                    if (h.live.isNotEmpty()) {
+                        val id = h.live.random(random)
+                        h.governor.retire(id)
+                        h.forget(listOf(id))
+                        h.assertInvariant(op, "retire")
+                    }
+                }
+                else -> {
+                    val pressure =
+                        if (random.nextBoolean()) NativeMemoryPressure.Moderate else NativeMemoryPressure.Critical
+                    val result = h.governor.trim(pressure)
+                    result.cancelledReservations.forEach { h.consume(it, Terminal.CancelledByTrim, op) }
+                    h.forget(result.retiredRecordIds)
+                    h.assertInvariant(op, "trim($pressure)")
+
+                    if (pressure == NativeMemoryPressure.Critical) {
+                        val state = h.governor.state()
+                        if (state.reservedLoads != 0) {
+                            fail(
+                                "seed=$seed op=$op: trim(Critical) must cancel every pending " +
+                                    "reservation, but reservedLoads=${state.reservedLoads}"
+                            )
+                        }
+                        if (state.loadedRecords != h.mounted.size) {
+                            fail(
+                                "seed=$seed op=$op: trim(Critical) must retain exactly the mounted " +
+                                    "records, but loadedRecords=${state.loadedRecords} and " +
+                                    "${h.mounted.size} are mounted"
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        // Every reservation ever minted is either still pending or reached exactly
+        // one terminal state. A reservation in neither set is a leaked native ad.
+        val accounted = h.pending.size + h.terminal.size
+        if (accounted != h.minted) {
+            fail(
+                "seed=$seed: reservation accounting lost permits — minted=${h.minted}, " +
+                    "pending=${h.pending.size}, terminal=${h.terminal.size}"
+            )
+        }
+    }
+
+    @Test
+    fun `the capacity invariant holds across generated operation sequences`() {
+        val policy = NativeAdMemoryPolicy()
+        for (seed in 0 until SEEDS) {
+            runSequence(seed, policy)
+        }
+    }
+
+    @Test
+    fun `the capacity invariant holds when the soft and hard limits are equal`() {
+        // softLimit == hardLimit removes the speculative headroom entirely, which
+        // is the configuration most likely to expose an off-by-one in the cap
+        // arithmetic.
+        val policy = NativeAdMemoryPolicy(softLimit = 2, hardLimit = 2)
+        for (seed in 0 until SEEDS) {
+            runSequence(seed, policy)
+        }
+    }
+
+    @Test
+    fun `the capacity invariant holds at a hard limit of one`() {
+        val policy = NativeAdMemoryPolicy(softLimit = 1, hardLimit = 1, inactiveSessionLimit = 1)
+        for (seed in 0 until SEEDS) {
+            runSequence(seed, policy)
+        }
+    }
+}

--- a/admob-cmp-core/src/iosMain/kotlin/dev/avinya/ads/IosConsentController.kt
+++ b/admob-cmp-core/src/iosMain/kotlin/dev/avinya/ads/IosConsentController.kt
@@ -30,8 +30,11 @@ import dev.avinya.ads.internal.InitializationTimeouts
 import dev.avinya.ads.internal.NativeCallbackTimeoutException
 import dev.avinya.ads.internal.awaitHost
 import dev.avinya.ads.internal.awaitNativeCallback
+import dev.avinya.ads.internal.consentInfoUpdateTimeoutStatus
 import dev.avinya.ads.internal.ownedSnapshot
 import dev.avinya.ads.internal.reconcileThenResumeIfActive
+import dev.avinya.ads.internal.resolveConsentInfoUpdateStatus
+import dev.avinya.ads.internal.shouldResumeInitializationAfterPrivacyOptions
 
 internal class IosConsentController(
     val onCanRequestAds: suspend (AdConfig) -> Unit
@@ -95,14 +98,16 @@ internal class IosConsentController(
                         if (continuation.isActive) {
                             updatePrivacyState(consentInformation)
                             _canRequestAds.value = consentInformation.canRequestAds
-                            val result = if (error == null) {
-                                consentInformationStatus(consentInformation)
-                            } else if (consentInformation.canRequestAds) {
-                                consentInformationStatus(consentInformation)
-                            } else {
-                                ConsentStatus.Failed(AdError(code = (error.code ?: 0).toString(), message = error.localizedDescription ?: "Consent info update failed."))
-                            }
-                            _status.value = result
+                            _status.value = resolveConsentInfoUpdateStatus(
+                                error = error?.let {
+                                    AdError(
+                                        code = (it.code ?: 0).toString(),
+                                        message = it.localizedDescription ?: "Consent info update failed.",
+                                    )
+                                },
+                                canRequestAds = consentInformation.canRequestAds,
+                                nativeStatus = consentInformationStatus(consentInformation),
+                            )
                             continuation.resume(Unit)
                         }
                     }
@@ -110,9 +115,9 @@ internal class IosConsentController(
             }
         } catch (timeout: NativeCallbackTimeoutException) {
             AdLogger.e("iOS UMP consent info update timed out.", timeout)
-            _status.value = ConsentStatus.Failed(
-                AdError.message(timeout.message ?: "UMP consent info update timed out.")
-            )
+            // canRequestAds is deliberately NOT reset here. See
+            // consentInfoUpdateTimeoutStatus's KDoc.
+            _status.value = consentInfoUpdateTimeoutStatus(timeout.message)
         }
         _status.value
     }
@@ -180,7 +185,7 @@ internal class IosConsentController(
                     // this callback (and the reconciliation above) must complete
                     // regardless of whether the original caller is still around to
                     // observe it.
-                    if (_canRequestAds.value) {
+                    if (shouldResumeInitializationAfterPrivacyOptions(_canRequestAds.value, lastConfig)) {
                         lastConfig?.let { config -> consentScope.launch { onCanRequestAds(config) } }
                     }
                 }

--- a/docs/release/device-certification.md
+++ b/docs/release/device-certification.md
@@ -1,0 +1,61 @@
+# Device certification
+
+Required for any release that changes native integration, consent,
+presentation, the renderer, or Gradle/XCFramework behaviour. Not required for
+docs-only or test-only changes.
+
+Unit tests cannot prove any of the below: every item depends on real GMA/UMP
+behaviour, real OS lifecycle, or real network conditions. An emulator-only pass
+is not certification for the iOS column.
+
+## How to run it
+
+Use the `showcase` module — it renders all six ad formats and exposes the
+privacy options entry point under Profile → SDK Lab. Run each scenario on one
+Android device and one iOS device, then record the result below and paste the
+completed table into the release PR or release notes.
+
+Google's test ad units are configured in the showcase. Do not certify against
+production ad units.
+
+## Scenarios
+
+Run every row on both platforms.
+
+| # | Scenario | Android | iOS |
+|---|---|---|---|
+| 1 | Fresh install, EEA debug geography, consent accepted → ads serve | | |
+| 2 | Fresh install, consent denied → no ad requests are made | | |
+| 3 | Privacy options revoke after ads were allowed → `load()`/`show()` blocked | | |
+| 4 | Privacy options grant after prior denial → initialization resumes once | | |
+| 5 | Background/foreground while a load is in flight → no crash, no stuck state | | |
+| 6 | Background/foreground while a full-screen ad is showing → ad is not force-closed | | |
+| 7 | Rotation / window resize around banner and native views → geometry survives | | |
+| 8 | Offline or DNS-blocked → bounded failure with a typed error, retry works | | |
+| 9 | All six formats render: banner, interstitial, rewarded, rewarded-interstitial, app-open, native | | |
+| 10 | Reward is emitted exactly once per rewarded presentation | | |
+| 11 | AdMob native ad validator reports no implementation issues | | |
+| 12 | iOS only: ordering is UMP → ATT → first ad request | n/a | |
+
+## Devices
+
+Minimum for a native-affecting release:
+
+- **Android:** one current reference device or emulator at the project's
+  `compileSdk`, plus one device at `minSdk` (API 26) where practical.
+- **iOS:** one current iPhone simulator **and** one physical iPhone. The
+  simulator alone does not exercise real presentation and lifecycle behaviour.
+
+Add an iPad or split-view pass when the release changes adaptive banner or
+native layout sizing.
+
+## Sign-off
+
+    Release version:
+    Certified by:
+    Date:
+    Devices used:
+    Deviations or known issues:
+
+The release owner signs this. A release that changes native behaviour without a
+signed matrix is not certified, regardless of what the local test suite reports.

--- a/docs/release/hotfix-playbook.md
+++ b/docs/release/hotfix-playbook.md
@@ -1,0 +1,74 @@
+# Hotfix playbook
+
+**Maven Central artifacts are immutable.** A published version cannot be
+withdrawn, patched in place, or rolled back. Every response below is a
+forward fix. This is why the procedure is written down before it is needed.
+
+## Severity
+
+| Severity | Definition | Response |
+|---|---|---|
+| **Blocker** | Consent/privacy is wrong, ads serve when they must not, the SDK crashes hosts, or a documented integration cannot build | Stop recommending the version immediately; patch release |
+| **High** | A format is broken, an ad or native object leaks, or a documented API behaves incorrectly with no workaround | Patch release |
+| **Medium** | Incorrect behaviour with a documented workaround | Next scheduled release |
+| **Low** | Cosmetic, docs, or diagnostics | Next scheduled release |
+
+Privacy and consent defects are always at least High and take triage priority
+over everything else, including build breaks.
+
+## A bad release is already on Central
+
+1. **Stop recommending the version.** Update the version in
+   `docs-site/src/content/docs/start/installation.mdx` and the README to the
+   last known-good release, and add a note to
+   `docs-site/src/content/docs/reference/changelog.mdx` naming the affected
+   version and the symptom.
+2. **Establish the affected range.** Identify the first version carrying the
+   defect. State the range explicitly in the changelog — consumers need to know
+   whether they are exposed, not just that a fix exists.
+3. **Write a failing test first.** The fix does not start until a test in
+   `admob-cmp-core` or `admob-cmp-compose` reproduces the defect and fails.
+4. **Fix, then verify.** `./scripts/release-readiness.sh` must reach
+   `READINESS: PASS`, including the public-API additivity guard. A hotfix is
+   still additive-only within the major.
+5. **Certify if native behaviour changed.** Run
+   [device-certification.md](device-certification.md).
+6. **Bump `VERSION_NAME` in both `gradle.properties` files, in lockstep**, in
+   its own commit, as the last commit. That is the only release trigger.
+7. **Canary the patch after Central publishes:**
+   `./scripts/distribution/verify-published-release.sh <new-version>`
+8. **Close the loop.** Note in the changelog which versions are affected and
+   which version fixes it.
+
+Never attempt to delete or re-upload a published version.
+
+## Required reproduction information
+
+Ask for all of it up front; a report missing these cannot be triaged:
+
+- `admob-cmp` version, and whether the Gradle plugin is at the same version
+- Platform and OS version; physical device or simulator/emulator
+- Resolved GMA and UMP versions (Android: `./gradlew :app:dependencies`;
+  iOS: the SPM resolved versions)
+- Kotlin, Gradle, AGP, Compose Multiplatform, and Xcode versions
+- Ad format and whether it reproduces with Google's test ad units
+- Consent state when it occurred, and the geography (real or debug)
+- SDK logs via `AdLogger`, and the typed `AdError` if one was surfaced
+- A minimal `AdPlacement` / `AdConfig` that reproduces it
+
+For iOS build and link failures, also require the output of
+`./gradlew :admob-cmp-core:doctorIos`.
+
+## Compatibility regressions
+
+For a report that the SDK no longer builds under a new Kotlin, Gradle, AGP, or
+Xcode version, first confirm whether the combination is one the project claims
+to support in
+`docs-site/src/content/docs/reference/compatibility.mdx`. The project pins a
+single blessed toolchain deliberately. If the combination is outside it, the
+answer is a documentation clarification, not a patch release — say so plainly
+rather than widening the supported range under pressure.
+
+Reproduce with `./scripts/distribution/verify-published-release.sh <version>`,
+which builds a clean-room consumer and isolates whether the failure is in
+resolution, the Gradle plugin, or the consumer's own configuration.

--- a/scripts/distribution/verify-public-api-compatibility.sh
+++ b/scripts/distribution/verify-public-api-compatibility.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# Prove the public klib ABI at HEAD is ADDITIVE relative to the last published
+# release tag.
+#
+# Why this exists alongside `checkKotlinAbi`:
+#   `checkKotlinAbi` proves the committed `api/*.klib.api` dump matches the
+#   source at HEAD. It cannot tell you whether that dump itself LOST a
+#   declaration, because `updateKotlinAbi` rewrites it unconditionally. A
+#   maintainer who deletes a public function and runs `updateKotlinAbi` gets a
+#   green `checkKotlinAbi` and a silent binary-compatibility break. AGENTS.md
+#   already warns that nothing in CI catches a stale dump; nothing catches a
+#   REGENERATED one either. This does.
+#
+# How it compares:
+#   Every declaration line in a klib dump ends with a trailing `// <signature>`
+#   comment, and those signatures are unique within a dump (verified: 1356/1356
+#   unique in admob-cmp-core at 2.1.0). We key on the signature, so reordering
+#   the dump is not a diff, while a removal is. The declaration TEXT is then
+#   compared per signature, so a return-type or visibility change on a
+#   surviving signature is caught too.
+#
+# Usage:
+#   verify-public-api-compatibility.sh [TAG]
+#   verify-public-api-compatibility.sh --compare OLD_FILE NEW_FILE
+#   verify-public-api-compatibility.sh --allow-breaking [TAG]
+#
+#   TAG              release tag to compare against. Default: newest semver tag.
+#   --compare        compare two dump files directly; used by the self-test.
+#   --allow-breaking report breaking changes but exit 0. ONLY for a deliberate
+#                    major-version release with a written migration plan. A
+#                    major bump does NOT permit this automatically — an
+#                    accidental break must not ride along with an intentional
+#                    one.
+#
+# Exit codes:
+#   0  every previously published declaration still exists unchanged
+#   1  a declaration was removed or its signature/type/visibility changed
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${ROOT}" || exit 1
+
+MODULES="admob-cmp-core admob-cmp-compose"
+ALLOW_BREAKING=0
+COMPARE_MODE=0
+COMPARE_OLD=""
+COMPARE_NEW=""
+TAG=""
+FAIL=0
+
+fail() { echo "  FAIL: $*"; FAIL=1; }
+ok()   { echo "  ok:   $*"; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --allow-breaking) ALLOW_BREAKING=1; shift ;;
+    --compare)        COMPARE_MODE=1; COMPARE_OLD="${2:-}"; COMPARE_NEW="${3:-}"; shift 3 ;;
+    -h|--help)        sed -n '2,30p' "${BASH_SOURCE[0]}"; exit 0 ;;
+    *)                TAG="$1"; shift ;;
+  esac
+done
+
+# Emit "<signature>\t<declaration>" for every declaration line, sorted by
+# signature under the C collation so `join` and `comm` agree downstream.
+extract() {
+  grep ' // ' "$1" \
+    | grep -v '^[[:space:]]*//' \
+    | while IFS= read -r line; do
+        sig="${line##* // }"
+        decl="${line% // *}"
+        decl="$(printf '%s' "${decl}" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+        printf '%s\t%s\n' "${sig}" "${decl}"
+      done \
+    | LC_ALL=C sort -t "$(printf '\t')" -k1,1
+}
+
+compare_dumps() { # compare_dumps <label> <old-file> <new-file>
+  local label="$1" old="$2" new="$3" tmp
+  tmp="$(mktemp -d)"
+
+  extract "${old}" > "${tmp}/old.tsv"
+  extract "${new}" > "${tmp}/new.tsv"
+  LC_ALL=C cut -f1 "${tmp}/old.tsv" > "${tmp}/old.sig"
+  LC_ALL=C cut -f1 "${tmp}/new.tsv" > "${tmp}/new.sig"
+
+  local removed added changed
+  removed="$(LC_ALL=C comm -23 "${tmp}/old.sig" "${tmp}/new.sig")"
+  added="$(LC_ALL=C comm -13 "${tmp}/old.sig" "${tmp}/new.sig")"
+  changed="$(LC_ALL=C join -t "$(printf '\t')" -j 1 -o 0,1.2,2.2 \
+               "${tmp}/old.tsv" "${tmp}/new.tsv" \
+             | awk -F'\t' '$2 != $3 { print }')"
+
+  local n_removed n_added n_changed
+  n_removed="$( [ -z "${removed}" ] && echo 0 || printf '%s\n' "${removed}" | wc -l | tr -d ' ')"
+  n_added="$(   [ -z "${added}"   ] && echo 0 || printf '%s\n' "${added}"   | wc -l | tr -d ' ')"
+  n_changed="$( [ -z "${changed}" ] && echo 0 || printf '%s\n' "${changed}" | wc -l | tr -d ' ')"
+
+  if [ "${n_removed}" -eq 0 ] && [ "${n_changed}" -eq 0 ]; then
+    ok "${label}: additive only (${n_added} added, 0 removed, 0 changed)"
+    rm -rf "${tmp}"
+    return 0
+  fi
+
+  fail "${label}: NOT additive (${n_removed} removed, ${n_changed} changed, ${n_added} added)"
+
+  if [ "${n_removed}" -gt 0 ]; then
+    echo "        --- removed declarations (present in the release, gone at HEAD) ---"
+    printf '%s\n' "${removed}" | while IFS= read -r sig; do
+      [ -z "${sig}" ] && continue
+      LC_ALL=C awk -F'\t' -v s="${sig}" '$1 == s { print "        - " $2 }' "${tmp}/old.tsv"
+    done
+  fi
+
+  if [ "${n_changed}" -gt 0 ]; then
+    echo "        --- changed declarations (same signature, different type/visibility) ---"
+    printf '%s\n' "${changed}" | while IFS=$(printf '\t') read -r _sig oldd newd; do
+      [ -z "${oldd}" ] && continue
+      echo "        - was: ${oldd}"
+      echo "          now: ${newd}"
+    done
+  fi
+
+  rm -rf "${tmp}"
+  return 1
+}
+
+if [ "${COMPARE_MODE}" -eq 1 ]; then
+  echo "== Direct dump comparison =="
+  compare_dumps "$(basename "${COMPARE_NEW}")" "${COMPARE_OLD}" "${COMPARE_NEW}"
+else
+  if [ -z "${TAG}" ]; then
+    TAG="$(git tag --sort=-v:refname | head -1)"
+  fi
+  if [ -z "${TAG}" ]; then
+    echo "No release tag found; nothing to compare against." >&2
+    exit 1
+  fi
+  if ! git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+    echo "Tag '${TAG}' does not exist." >&2
+    exit 1
+  fi
+
+  HEAD_VERSION="$(sed -n 's/^VERSION_NAME=//p' gradle.properties)"
+  echo "== Public ABI additivity: ${TAG} -> HEAD (VERSION_NAME=${HEAD_VERSION}) =="
+
+  if [ "${TAG%%.*}" != "${HEAD_VERSION%%.*}" ]; then
+    echo "  note: major version differs (${TAG%%.*} -> ${HEAD_VERSION%%.*})."
+    echo "        Breaking changes still FAIL unless --allow-breaking is passed"
+    echo "        alongside a written migration plan. A deliberate major bump"
+    echo "        must not let an accidental break ride along with it."
+  fi
+
+  for module in ${MODULES}; do
+    dump="${module}/api/${module}.klib.api"
+    if [ ! -f "${dump}" ]; then
+      fail "${module}: ${dump} is missing at HEAD"
+      continue
+    fi
+    old="$(mktemp)"
+    if ! git show "${TAG}:${dump}" > "${old}" 2>/dev/null; then
+      ok "${module}: no dump at ${TAG} (module is newer than that release); skipped"
+      rm -f "${old}"
+      continue
+    fi
+    compare_dumps "${module}" "${old}" "${dump}"
+    rm -f "${old}"
+  done
+fi
+
+echo
+if [ "${FAIL}" -eq 0 ]; then
+  echo "PUBLIC API COMPATIBILITY: PASS"
+  exit 0
+fi
+if [ "${ALLOW_BREAKING}" -eq 1 ]; then
+  echo "PUBLIC API COMPATIBILITY: BREAKING (allowed by --allow-breaking)"
+  exit 0
+fi
+echo "PUBLIC API COMPATIBILITY: FAIL"
+echo
+echo "A declaration that shipped in ${TAG:-the compared dump} is gone or changed at HEAD."
+echo "Do NOT run updateKotlinAbi to make this pass — that is exactly the mistake"
+echo "this gate exists to catch. Either restore the declaration, or, for a"
+echo "deliberate major release, write the migration plan and re-run with"
+echo "--allow-breaking."
+exit 1

--- a/scripts/distribution/verify-public-api-compatibility.test.sh
+++ b/scripts/distribution/verify-public-api-compatibility.test.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Self-test for verify-public-api-compatibility.sh.
+#
+# Builds three synthetic dumps by mutating a copy of the real
+# admob-cmp-core dump, then asserts the guard's verdict on each. Uses the real
+# dump rather than a hand-written one so the fixtures exercise the actual
+# klib format, including nested indentation and generic signatures.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GUARD="${ROOT}/scripts/distribution/verify-public-api-compatibility.sh"
+BASE="${ROOT}/admob-cmp-core/api/admob-cmp-core.klib.api"
+TMP="$(mktemp -d)"
+FAIL=0
+
+trap 'rm -rf "${TMP}"' EXIT
+
+fail() { echo "  FAIL: $*"; FAIL=1; }
+ok()   { echo "  ok:   $*"; }
+
+expect() { # expect <expected-exit> <label> <old> <new>
+  local want="$1" label="$2" old="$3" new="$4" got
+  "${GUARD}" --compare "${old}" "${new}" >"${TMP}/out.txt" 2>&1
+  got=$?
+  if [ "${got}" -eq "${want}" ]; then
+    ok "${label} (exit ${got})"
+  else
+    fail "${label}: expected exit ${want}, got ${got}"
+    sed 's/^/        /' "${TMP}/out.txt"
+  fi
+}
+
+echo "== Fixture: identical dumps =="
+cp "${BASE}" "${TMP}/old.api"
+cp "${BASE}" "${TMP}/same.api"
+expect 0 "identical dumps pass" "${TMP}/old.api" "${TMP}/same.api"
+
+echo "== Fixture: additive change =="
+cp "${BASE}" "${TMP}/added.api"
+printf '%s\n' \
+  'final fun dev.avinya.ads/syntheticAddedForTest(): kotlin/Unit // dev.avinya.ads/syntheticAddedForTest|syntheticAddedForTest(){}[0]' \
+  >> "${TMP}/added.api"
+expect 0 "an added declaration passes" "${TMP}/old.api" "${TMP}/added.api"
+
+echo "== Fixture: removed declaration =="
+# Drop the last declaration line that carries a signature comment.
+victim="$(grep -n ' // ' "${BASE}" | grep -v ':[[:space:]]*//' | tail -1 | cut -d: -f1)"
+sed "${victim}d" "${BASE}" > "${TMP}/removed.api"
+expect 1 "a removed declaration fails" "${TMP}/old.api" "${TMP}/removed.api"
+
+echo "== Fixture: signature/type mutation =="
+# Keep the signature comment, change the declared return type before it.
+sed "${victim}s|): kotlin/Unit //|): kotlin/String //|; ${victim}s|kotlin/Boolean //|kotlin/String //|" \
+  "${BASE}" > "${TMP}/mutated.api"
+if cmp -s "${BASE}" "${TMP}/mutated.api"; then
+  # The chosen victim had neither return type; force a visibility change instead.
+  sed "${victim}s|^\([[:space:]]*\)final |\1open |" "${BASE}" > "${TMP}/mutated.api"
+fi
+if cmp -s "${BASE}" "${TMP}/mutated.api"; then
+  fail "could not construct a mutation fixture from line ${victim}"
+else
+  expect 1 "a changed declaration fails" "${TMP}/old.api" "${TMP}/mutated.api"
+fi
+
+echo "== Fixture: --allow-breaking overrides a removal =="
+"${GUARD}" --allow-breaking --compare "${TMP}/old.api" "${TMP}/removed.api" >"${TMP}/out.txt" 2>&1
+if [ $? -eq 0 ]; then ok "--allow-breaking turns a removal into exit 0"; else
+  fail "--allow-breaking did not override the removal"
+  sed 's/^/        /' "${TMP}/out.txt"
+fi
+
+echo
+if [ "${FAIL}" -eq 0 ]; then
+  echo "ABI GUARD SELF-TEST: PASS"
+  exit 0
+fi
+echo "ABI GUARD SELF-TEST: FAIL"
+exit 1

--- a/scripts/distribution/verify-published-release.sh
+++ b/scripts/distribution/verify-published-release.sh
@@ -1,0 +1,273 @@
+#!/usr/bin/env bash
+# Build a throwaway KMP consumer against published admob-cmp artifacts.
+#
+# Two modes:
+#   --local   resolve from Maven Local. Run BEFORE a release, after
+#             `publishToMavenLocal`, as a clean-room check that the artifacts a
+#             real consumer would download actually resolve and compile.
+#   (default) resolve from Maven Central ONLY. Run AFTER a Central release, as
+#             a canary.
+#
+# Why this exists alongside release-readiness.sh section 7:
+#   Section 7 round-trips through Maven Local using the monorepo's own :shared
+#   module — same settings.gradle.kts, same version catalog, same wrapper, same
+#   pluginManagement. It proves the artifact installs. It cannot prove a real
+#   consumer can RESOLVE it, because nothing about that consumer is independent.
+#   This generates a project that has never seen the source tree.
+#
+# Maven Central artifacts are immutable. A failure here invokes the patch-release
+# playbook in docs/release/hotfix-playbook.md — there is no rollback.
+#
+# Usage:
+#   verify-published-release.sh <version> [--local] [--keep]
+#
+#   <version>  e.g. 2.1.0
+#   --local    use mavenLocal() instead of mavenCentral()
+#   --keep     leave the generated fixture in place and print its path
+#
+# Exit codes:
+#   0  the fixture resolved and compiled
+#   1  resolution or compilation failed
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+VERSION=""
+USE_LOCAL=0
+KEEP=0
+
+if [ -z "${JAVA_HOME:-}" ]; then
+  if command -v /usr/libexec/java_home >/dev/null 2>&1 && /usr/libexec/java_home >/dev/null 2>&1; then
+    export JAVA_HOME="$(/usr/libexec/java_home)"
+  elif [ -d "${HOME}/.gradle/jdks" ]; then
+    JDK_CANDIDATE="$(find "${HOME}/.gradle/jdks" -type d -name Home 2>/dev/null | head -1)"
+    if [ -n "${JDK_CANDIDATE}" ]; then
+      export JAVA_HOME="${JDK_CANDIDATE}"
+    fi
+  fi
+  [ -n "${JAVA_HOME:-}" ] && export PATH="${JAVA_HOME}/bin:${PATH}"
+fi
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --local) USE_LOCAL=1; shift ;;
+    --keep)  KEEP=1; shift ;;
+    -h|--help) sed -n '2,30p' "${BASH_SOURCE[0]}"; exit 0 ;;
+    *) VERSION="$1"; shift ;;
+  esac
+done
+
+if [ -z "${VERSION}" ]; then
+  echo "usage: verify-published-release.sh <version> [--local] [--keep]" >&2
+  exit 1
+fi
+
+if [ "${USE_LOCAL}" -eq 1 ]; then
+  PLUGIN_REPOS="mavenLocal()
+        google()
+        gradlePluginPortal()
+        mavenCentral {
+            content { excludeGroupByRegex(\"dev\\\\.avinya\\\\.ads.*\") }
+        }"
+  DEPENDENCY_REPOS="mavenLocal()
+        google()
+        mavenCentral {
+            content { excludeGroupByRegex(\"dev\\\\.avinya\\\\.ads.*\") }
+        }"
+  MODE="Maven Local"
+else
+  PLUGIN_REPOS="google()
+        gradlePluginPortal()
+        mavenCentral()"
+  DEPENDENCY_REPOS="google()
+        mavenCentral()"
+  MODE="Maven Central"
+fi
+
+# Toolchain versions come from the repo's catalog so the fixture tracks the
+# blessed combination instead of drifting into a version nobody supports.
+KOTLIN_VERSION="$(sed -n 's/^kotlin = "\(.*\)"/\1/p' "${ROOT}/gradle/libs.versions.toml" | head -1)"
+AGP_VERSION="$(sed -n 's/^agp = "\(.*\)"/\1/p' "${ROOT}/gradle/libs.versions.toml" | head -1)"
+COMPILE_SDK="$(sed -n 's/^android-compileSdk = "\(.*\)"/\1/p' "${ROOT}/gradle/libs.versions.toml" | head -1)"
+MIN_SDK="$(sed -n 's/^android-minSdk = "\(.*\)"/\1/p' "${ROOT}/gradle/libs.versions.toml" | head -1)"
+
+FIXTURE="$(mktemp -d)/admob-cmp-consumer"
+mkdir -p "${FIXTURE}/src/commonMain/kotlin" "${FIXTURE}/src/androidMain/kotlin" \
+         "${FIXTURE}/src/commonTest/kotlin"
+
+echo "== Clean-room consumer =="
+echo "  version:   ${VERSION}"
+echo "  repository ${MODE}"
+echo "  kotlin     ${KOTLIN_VERSION}, agp ${AGP_VERSION}, compileSdk ${COMPILE_SDK}"
+echo "  fixture    ${FIXTURE}"
+
+cat > "${FIXTURE}/settings.gradle.kts" <<EOF
+pluginManagement {
+    repositories {
+        ${PLUGIN_REPOS}
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        ${DEPENDENCY_REPOS}
+    }
+}
+rootProject.name = "admob-cmp-consumer"
+EOF
+
+cat > "${FIXTURE}/build.gradle.kts" <<EOF
+plugins {
+    kotlin("multiplatform") version "${KOTLIN_VERSION}"
+    id("com.android.library") version "${AGP_VERSION}"
+    id("dev.avinya.ads.admob-cmp") version "${VERSION}"
+}
+
+kotlin {
+    androidTarget()
+    iosArm64()
+    iosSimulatorArm64()
+
+    sourceSets {
+        commonMain.dependencies {
+            implementation("dev.avinya.ads:admob-cmp:${VERSION}")
+        }
+        // Required, not optional: without a test source set,
+        // linkDebugTestIosSimulatorArm64 has nothing to link, reports NO-SOURCE,
+        // and the iOS half of this check silently passes without linking
+        // anything. See the .kexe assertion below.
+        commonTest.dependencies {
+            implementation(kotlin("test"))
+        }
+    }
+}
+
+android {
+    namespace = "dev.avinya.ads.cleanroom"
+    compileSdk = ${COMPILE_SDK}
+    defaultConfig { minSdk = ${MIN_SDK} }
+}
+EOF
+
+cat > "${FIXTURE}/gradle.properties" <<'EOF'
+org.gradle.jvmargs=-Xmx3g
+android.useAndroidX=true
+android.builtInKotlin=false
+android.newDsl=false
+kotlin.code.style=official
+EOF
+
+# Touch the public surface a real consumer touches, so this is a link check and
+# not merely a resolution check.
+cat > "${FIXTURE}/src/commonMain/kotlin/CleanRoom.kt" <<'EOF'
+import dev.avinya.ads.AdAppIds
+import dev.avinya.ads.AdConfig
+import dev.avinya.ads.AdFormat
+import dev.avinya.ads.AdPlacement
+
+// Resolves the facade's public API. If a type moved, was renamed, or a
+// transitive dependency is missing from the published POM, this does not
+// compile.
+//
+// Google's public test ad units — never production ones.
+internal val cleanRoomPlacement: AdPlacement = AdPlacement(
+    id = "clean_room_banner",
+    format = AdFormat.Banner,
+    androidAdUnitId = "ca-app-pub-3940256099942544/6300978111",
+    iosAdUnitId = "ca-app-pub-3940256099942544/2934735716",
+)
+
+internal val cleanRoomConfig: AdConfig = AdConfig(
+    appIds = AdAppIds(
+        android = "ca-app-pub-3940256099942544~3347511713",
+        ios = "ca-app-pub-3940256099942544~1458002511",
+    ),
+)
+EOF
+
+# Exists so the iOS link step has something to link. A Kotlin/Native test
+# executable links the whole klib graph, including the GMA and UMP cinterop
+# klibs, so producing this binary is what proves the Gradle plugin's linker
+# flags actually resolve the native frameworks — the undefined
+# _OBJC_CLASS_$_GADMobileAds / _OBJC_CLASS_$_UMPConsentInformation failure a
+# consumer hits when the plugin is missing or misconfigured.
+cat > "${FIXTURE}/src/commonTest/kotlin/CleanRoomTest.kt" <<'EOF'
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CleanRoomTest {
+    @Test
+    fun placementResolves() {
+        assertEquals("clean_room_banner", cleanRoomPlacement.id)
+        assertEquals("ca-app-pub-3940256099942544~3347511713", cleanRoomConfig.appIds.android)
+    }
+}
+EOF
+
+# The fixture uses the repo's wrapper so this tests ARTIFACT resolution, not
+# Gradle bootstrapping. sdk.dir is propagated because a temp dir has no
+# local.properties and the Android plugin needs one.
+cp -R "${ROOT}/gradle/wrapper" "${FIXTURE}/gradle-wrapper-tmp"
+mkdir -p "${FIXTURE}/gradle"
+mv "${FIXTURE}/gradle-wrapper-tmp" "${FIXTURE}/gradle/wrapper"
+cp "${ROOT}/gradlew" "${FIXTURE}/gradlew"
+chmod +x "${FIXTURE}/gradlew"
+if [ -f "${ROOT}/local.properties" ]; then
+  grep '^sdk.dir=' "${ROOT}/local.properties" > "${FIXTURE}/local.properties" 2>/dev/null || true
+fi
+
+STATUS=0
+
+echo
+echo "== Resolving and compiling Android =="
+( cd "${FIXTURE}" && ./gradlew compileDebugKotlinAndroid --no-configuration-cache --no-daemon ) || STATUS=1
+
+if [ "${STATUS}" -eq 0 ] && command -v xcrun >/dev/null 2>&1; then
+  echo
+  echo "== Linking iOS simulator test executable (proves the plugin wires GMA/UMP) =="
+  ( cd "${FIXTURE}" && ./gradlew linkDebugTestIosSimulatorArm64 --no-configuration-cache --no-daemon ) || STATUS=1
+
+  # A green link task is NOT proof the link happened. With no test source set
+  # the task reports NO-SOURCE, links nothing, and the build still succeeds —
+  # which is exactly how this check passed for its first two releases without
+  # ever exercising the native frameworks. Assert the binary exists so the step
+  # cannot silently become a no-op again.
+  KEXE="${FIXTURE}/build/bin/iosSimulatorArm64/debugTest/test.kexe"
+  if [ "${STATUS}" -eq 0 ] && [ ! -f "${KEXE}" ]; then
+    echo
+    echo "  FAIL: the link task succeeded but produced no test executable." >&2
+    echo "        expected: ${KEXE}" >&2
+    echo "        The iOS half of this check linked nothing. Confirm the fixture" >&2
+    echo "        still has a commonTest source set and a kotlin(\"test\")" >&2
+    echo "        dependency; without them the task reports NO-SOURCE and passes" >&2
+    echo "        without proving anything." >&2
+    STATUS=1
+  elif [ "${STATUS}" -eq 0 ]; then
+    echo "  linked: ${KEXE#"${FIXTURE}/"}"
+  fi
+else
+  echo
+  echo "  skip: no xcrun on this host; iOS link not attempted."
+fi
+
+echo
+echo "== Resolved coordinates =="
+echo "  dev.avinya.ads:admob-cmp:${VERSION}"
+echo "  dev.avinya.ads.admob-cmp (Gradle plugin) ${VERSION}"
+echo "  resolved from: ${MODE}"
+
+if [ "${KEEP}" -eq 1 ]; then
+  echo "  fixture kept at: ${FIXTURE}"
+else
+  rm -rf "$(dirname "${FIXTURE}")"
+fi
+
+echo
+if [ "${STATUS}" -eq 0 ]; then
+  echo "PUBLISHED RELEASE CHECK: PASS (${VERSION} from ${MODE})"
+  exit 0
+fi
+echo "PUBLISHED RELEASE CHECK: FAIL (${VERSION} from ${MODE})"
+echo
+echo "If this was the post-Central canary, the artifact is immutable — follow"
+echo "docs/release/hotfix-playbook.md. Do not attempt a rollback."
+exit 1

--- a/scripts/release-readiness.sh
+++ b/scripts/release-readiness.sh
@@ -165,6 +165,10 @@ section "6. iOS + klib ABI"
   :admob-cmp-core:checkKotlinAbi \
   :admob-cmp-compose:checkKotlinAbi \
   --no-configuration-cache
+# checkKotlinAbi above proves the dump matches HEAD's source. This proves the
+# dump did not LOSE anything relative to the last published release — the case
+# `updateKotlinAbi` would otherwise bless silently.
+./scripts/distribution/verify-public-api-compatibility.sh
 
 # Section 7 mutates ~/.m2 — it runs publishToMavenLocal for both builds, then
 # the shared module round-trips against the published facade. The two halves


### PR DESCRIPTION
Adds verification for five things the existing suite and release gate structurally cannot catch. No production state machine is redesigned; the only behaviour-affecting change is a de-duplication that is behaviour-preserving on both platforms.

## Why

Each of these is a gap where a green build proves nothing:

| Gap | Why the current suite misses it |
|---|---|
| A regenerated ABI dump blessing a breaking change | `checkKotlinAbi` proves the dump matches HEAD's source, not that the dump kept what it shipped. `updateKotlinAbi` rewrites it unconditionally. |
| A published artifact nobody resolved from a clean room | `release-readiness.sh` section 7 uses the monorepo's own `:shared` module — same settings, catalog, and wrapper as the build that produced it. |
| Consent status policy duplicated across platforms | Both controllers carried the same three-branch decision plus a comment demanding they stay identical. Nothing enforced it. |
| The governor capacity invariant | Proven only by handcrafted interleavings. |
| Native-behaviour releases | No written certification or incident procedure; Maven Central is immutable. |

## What's here

**`verify-public-api-compatibility.sh`** — compares HEAD's klib dump against the newest release tag, keyed on the trailing signature comment (unique per declaration, so reordering isn't a diff while a removal is), and compares declaration text per signature so return-type and visibility changes are caught. `--allow-breaking` is the only override. Wired into `release-readiness.sh` section 6. Ships with `verify-public-api-compatibility.test.sh`, which builds synthetic additive / removal / mutation fixtures from the real dump.

**`verify-published-release.sh`** — generates a throwaway KMP consumer in a temp directory that has never seen the source tree. Default mode resolves from Maven Central only (post-release canary); `--local` resolves from Maven Local with `dev.avinya.ads.*` excluded from the Central fallback, so the SDK's own artifacts cannot silently resolve from a previously published version. The iOS step asserts the linked `test.kexe` exists.

**`ConsentInfoUpdatePolicy.kt`** — both controllers now call `resolveConsentInfoUpdateStatus`, making platform parity structural. `internal` only; the public klib dump does not move.

**`NativeAdGovernorStressTest.kt`** — 1200 generated operation sequences across three memory policies, asserting the capacity invariant after every mutation and that every reservation reaches exactly one terminal state. Deterministic: no threads, sleeps, or wall clock.

**`docs/release/`** — device certification checklist and hotfix playbook.

## Verification

`./scripts/release-readiness.sh` → **`READINESS: PASS`** (full run, no `--skip-docs`, since this touches `admob-cmp-core/`).

Beyond the gate, each new check was tested for teeth rather than trusted on a green bar:

- **ABI guard** — self-test passes 5/5 including both negative fixtures.
- **Stress runner** — mutating `reserveVisible`'s `hardLimit` to `hardLimit + 1` fails all three tests at the invariant assertion.
- **Clean-room isolation** — with Maven Local emptied via `-Dmaven.repo.local`, `dev.avinya.ads:admob-cmp:2.1.0` fails to resolve rather than falling through to Central, where it exists.
- **iOS link assertion** — a copy of the script with the test source stripped fails with the intended diagnostic instead of passing on `NO-SOURCE`.
- Both canary modes pass end-to-end and produce a real linked `test.kexe`.

## Notes

- No changes to `.github/workflows/release.yml`, `gradle/`, either `VERSION_NAME`, or either `api/*.klib.api`.
- The ABI guard reports 25 declarations added on `master` beyond the `2.1.0` tag — unreleased additive work, so the next release is a minor rather than a patch.
- Device certification is manual by design and has not been run for this branch; nothing here changes native behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)