### PR TITLE
Bound the consent form pin, graduate app id severity, add device tooling

### DIFF
--- a/admob-cmp-core/api/admob-cmp-core.klib.api
+++ b/admob-cmp-core/api/admob-cmp-core.klib.api
@@ -152,6 +152,18 @@ final enum class dev.avinya.ads/AgeRestrictedTreatment : kotlin/Enum<dev.avinya.
     final fun values(): kotlin/Array<dev.avinya.ads/AgeRestrictedTreatment> // dev.avinya.ads/AgeRestrictedTreatment.values|values#static(){}[0]
 }
 
+final enum class dev.avinya.ads/AppIdVerificationPolicy : kotlin/Enum<dev.avinya.ads/AppIdVerificationPolicy> { // dev.avinya.ads/AppIdVerificationPolicy|null[0]
+    enum entry FailWhenUnusable // dev.avinya.ads/AppIdVerificationPolicy.FailWhenUnusable|null[0]
+    enum entry Strict // dev.avinya.ads/AppIdVerificationPolicy.Strict|null[0]
+    enum entry WarnOnly // dev.avinya.ads/AppIdVerificationPolicy.WarnOnly|null[0]
+
+    final val entries // dev.avinya.ads/AppIdVerificationPolicy.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<dev.avinya.ads/AppIdVerificationPolicy> // dev.avinya.ads/AppIdVerificationPolicy.entries.<get-entries>|<get-entries>#static(){}[0]
+
+    final fun valueOf(kotlin/String): dev.avinya.ads/AppIdVerificationPolicy // dev.avinya.ads/AppIdVerificationPolicy.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<dev.avinya.ads/AppIdVerificationPolicy> // dev.avinya.ads/AppIdVerificationPolicy.values|values#static(){}[0]
+}
+
 final enum class dev.avinya.ads/CollapsiblePlacement : kotlin/Enum<dev.avinya.ads/CollapsiblePlacement> { // dev.avinya.ads/CollapsiblePlacement|null[0]
     enum entry Bottom // dev.avinya.ads/CollapsiblePlacement.Bottom|null[0]
     enum entry Top // dev.avinya.ads/CollapsiblePlacement.Top|null[0]
@@ -1675,7 +1687,15 @@ final class dev.avinya.ads/ServerSideVerificationOptions { // dev.avinya.ads/Ser
     final fun toString(): kotlin/String // dev.avinya.ads/ServerSideVerificationOptions.toString|toString(){}[0]
 }
 
+final object dev.avinya.ads/AdAppIdVerification { // dev.avinya.ads/AdAppIdVerification|null[0]
+    final var policy // dev.avinya.ads/AdAppIdVerification.policy|{}policy[0]
+        final fun <get-policy>(): dev.avinya.ads/AppIdVerificationPolicy // dev.avinya.ads/AdAppIdVerification.policy.<get-policy>|<get-policy>(){}[0]
+        final fun <set-policy>(dev.avinya.ads/AppIdVerificationPolicy) // dev.avinya.ads/AdAppIdVerification.policy.<set-policy>|<set-policy>(dev.avinya.ads.AppIdVerificationPolicy){}[0]
+}
+
 final object dev.avinya.ads/AdErrorCode { // dev.avinya.ads/AdErrorCode|null[0]
+    final const val APP_ID_INVALID // dev.avinya.ads/AdErrorCode.APP_ID_INVALID|{}APP_ID_INVALID[0]
+        final fun <get-APP_ID_INVALID>(): kotlin/String // dev.avinya.ads/AdErrorCode.APP_ID_INVALID.<get-APP_ID_INVALID>|<get-APP_ID_INVALID>(){}[0]
     final const val CONSENT_REQUIRED // dev.avinya.ads/AdErrorCode.CONSENT_REQUIRED|{}CONSENT_REQUIRED[0]
         final fun <get-CONSENT_REQUIRED>(): kotlin/String // dev.avinya.ads/AdErrorCode.CONSENT_REQUIRED.<get-CONSENT_REQUIRED>|<get-CONSENT_REQUIRED>(){}[0]
     final const val INITIALIZATION_CONFLICT // dev.avinya.ads/AdErrorCode.INITIALIZATION_CONFLICT|{}INITIALIZATION_CONFLICT[0]

--- a/admob-cmp-core/src/androidHostTest/kotlin/dev/avinya/ads/AndroidGoogleAdManagerNativePolicyTest.kt
+++ b/admob-cmp-core/src/androidHostTest/kotlin/dev/avinya/ads/AndroidGoogleAdManagerNativePolicyTest.kt
@@ -84,6 +84,25 @@ class AndroidGoogleAdManagerNativePolicyTest {
     }
 
     @Test
+    fun `declaredAppId reports Missing when the meta-data value is blank`() {
+        // android:value="" declares the key without declaring an application; UMP can resolve
+        // nothing from it, so it is the same gap as an absent key rather than a mismatch.
+        val context = mock(Context::class.java)
+        val packageManager = mock(PackageManager::class.java)
+        val metaDataBundle = mock(Bundle::class.java)
+        val applicationInfo = ApplicationInfo().apply { metaData = metaDataBundle }
+        `when`(context.packageManager).thenReturn(packageManager)
+        `when`(context.packageName).thenReturn("dev.avinya.showcase")
+        `when`(packageManager.getApplicationInfo("dev.avinya.showcase", PackageManager.GET_META_DATA))
+            .thenReturn(applicationInfo)
+        `when`(metaDataBundle.getString("com.google.android.gms.ads.APPLICATION_ID")).thenReturn("   ")
+
+        val manager = AndroidGoogleAdManager(context) { null }
+
+        assertEquals(DeclaredAppId.Missing, manager.declaredAppId())
+    }
+
+    @Test
     fun `declaredAppId reports Missing when there is no meta-data block at all`() {
         val context = mock(Context::class.java)
         val packageManager = mock(PackageManager::class.java)

--- a/admob-cmp-core/src/androidMain/kotlin/dev/avinya/ads/AndroidConsentController.kt
+++ b/admob-cmp-core/src/androidMain/kotlin/dev/avinya/ads/AndroidConsentController.kt
@@ -2,6 +2,7 @@ package dev.avinya.ads
 
 import android.app.Activity
 import android.content.Context
+import dev.avinya.ads.internal.ConsentStateHolder
 import dev.avinya.ads.internal.InitializationTimeouts
 import dev.avinya.ads.internal.NativeCallbackTimeoutException
 import dev.avinya.ads.internal.awaitHost
@@ -15,11 +16,9 @@ import com.google.android.ump.ConsentDebugSettings
 import com.google.android.ump.ConsentInformation
 import com.google.android.ump.ConsentRequestParameters
 import com.google.android.ump.UserMessagingPlatform
-import kotlin.coroutines.resume
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -30,9 +29,14 @@ internal class AndroidConsentController(
     private val appContext: Context,
     private val onCanRequestAds: suspend (AdConfig) -> Unit
 ) : ConsentController {
-    private val _status = MutableStateFlow<ConsentStatus>(ConsentStatus.Unknown)
-    private val _privacy = MutableStateFlow(PrivacyOptionsRequirementStatus.Unknown)
-    private val _canRequestAds = MutableStateFlow(false)
+    // Regression Guard G2: state MUST be declared before the three overrides.
+    private val state = ConsentStateHolder()
+
+    override val status: StateFlow<ConsentStatus> = state.status
+    override val privacyOptionsRequirementStatus: StateFlow<PrivacyOptionsRequirementStatus> =
+        state.privacyOptionsRequirementStatus
+    override val canRequestAds: StateFlow<Boolean> = state.canRequestAds
+
     // Retained so showPrivacyOptions() can resume initialization if the user grants
     // consent from the privacy form after an earlier denial.
     private var lastConfig: AdConfig? = null
@@ -42,20 +46,20 @@ internal class AndroidConsentController(
     // Same shape as GoogleAdManagerBase.admissionScope: process-wide, never cancelled.
     private val consentScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
 
-    override val status: StateFlow<ConsentStatus> = _status
-    override val privacyOptionsRequirementStatus: StateFlow<PrivacyOptionsRequirementStatus> = _privacy
-    override val canRequestAds: StateFlow<Boolean> = _canRequestAds
-
     override suspend fun requestConsentInfoUpdate(config: AdConfig): ConsentStatus {
         val ownedConfig = prepareConsentConfig(config)
         return withContext(Dispatchers.Main.immediate) {
-            // Acquired inside the main hop, not before it: this reads Activity lifecycle state,
-            // which is main-thread-owned (invariant 5). It waits rather than failing on the first
-            // null because ForegroundStack legitimately empties for a few hundred milliseconds
-            // during any Activity handoff.
-            val activity = awaitHost(InitializationTimeouts.consentHost) { activityProvider() }
-                ?: return@withContext failNoActivity()
-            updateWithActivity(activity, ownedConfig, UserMessagingPlatform.getConsentInformation(appContext))
+            state.serialized {
+                val generation = state.beginOperation()
+                val activity = awaitHost(InitializationTimeouts.consentHost) { activityProvider() }
+                    ?: return@serialized failNoActivity(generation)
+                updateWithActivity(
+                    activity,
+                    ownedConfig,
+                    UserMessagingPlatform.getConsentInformation(appContext),
+                    generation,
+                )
+            }
         }
     }
 
@@ -91,6 +95,7 @@ internal class AndroidConsentController(
         activity: Activity,
         config: AdConfig,
         consentInformation: ConsentInformation,
+        generation: Long,
     ): ConsentStatus {
         val params = buildConsentParams(activity, config)
         // MUST stay bounded: this is a non-interactive network round trip, and UMP can accept
@@ -105,116 +110,175 @@ internal class AndroidConsentController(
         // successful refresh, for no gain in consent correctness. Consent itself has not changed;
         // only our ability to re-confirm it has, and UMP has already persisted the user's choice.
         //
-        // Kept identical to `IosConsentController` on purpose: a consent-admission divergence
-        // between the platforms is the kind of thing that is only discovered in production.
+        // State ordering and reconciliation parity is enforced structurally by ConsentStateHolder;
+        // platform controllers only map native UMP types.
         //
         // The consent FORM and privacy options form below stay unbounded on purpose; a person is
         // reading those.
-        val error = try {
+        //
+        // The callback below reconciles privacy state even when this waiter has already timed out,
+        // because a late callback can carry a revocation.
+        try {
             awaitNativeCallback(
                 operation = "UMP requestConsentInfoUpdate",
                 timeout = InitializationTimeouts.consentInfoUpdate
             ) {
-                suspendCancellableCoroutine<AdError?> { continuation ->
+                suspendCancellableCoroutine<Unit> { continuation ->
                     consentInformation.requestConsentInfoUpdate(
                         activity,
                         params,
-                        { if (continuation.isActive) continuation.resume(null) },
-                        { if (continuation.isActive) continuation.resume(AdError(code = it.errorCode.toString(), message = it.message)) }
+                        {
+                            reconcileThenResumeIfActive(continuation, Unit) {
+                                state.reconcileAndPublish(
+                                    generation,
+                                    privacyRequirement = privacyRequirementOf(consentInformation),
+                                    canRequestAds = consentInformation.canRequestAds(),
+                                    status = resolveConsentInfoUpdateStatus(
+                                        error = null,
+                                        canRequestAds = consentInformation.canRequestAds(),
+                                        nativeStatus = consentInformationStatus(consentInformation),
+                                    ),
+                                )
+                            }
+                        },
+                        { formError ->
+                            val mapped = AdError(
+                                code = formError.errorCode.toString(),
+                                message = formError.message,
+                            )
+                            reconcileThenResumeIfActive(continuation, Unit) {
+                                state.reconcileAndPublish(
+                                    generation,
+                                    privacyRequirement = privacyRequirementOf(consentInformation),
+                                    canRequestAds = consentInformation.canRequestAds(),
+                                    status = resolveConsentInfoUpdateStatus(
+                                        error = mapped,
+                                        canRequestAds = consentInformation.canRequestAds(),
+                                        nativeStatus = consentInformationStatus(consentInformation),
+                                    ),
+                                )
+                            }
+                        },
                     )
                 }
             }
         } catch (timeout: NativeCallbackTimeoutException) {
             AdLogger.e("Android UMP consent info update timed out.", timeout)
-            // canRequestAds is deliberately NOT reset here. See
-            // consentInfoUpdateTimeoutStatus's KDoc.
-            return consentInfoUpdateTimeoutStatus(timeout.message).also { _status.value = it }
+            // canRequestAds is deliberately NOT reset here. See consentInfoUpdateTimeoutStatus's
+            // KDoc. The late callback above will still reconcile it if UMP ever answers.
+            return state.publishOperationStatus(generation, consentInfoUpdateTimeoutStatus(timeout.message))
         }
-        updatePrivacyState(consentInformation)
-        _canRequestAds.value = consentInformation.canRequestAds()
-        val status = resolveConsentInfoUpdateStatus(
-            error = error,
-            canRequestAds = consentInformation.canRequestAds(),
-            nativeStatus = consentInformationStatus(consentInformation),
-        )
-        _status.value = status
-        return status
+        return state.status.value
     }
 
     override suspend fun gatherConsent(config: AdConfig): ConsentStatus =
         withContext(Dispatchers.Main.immediate) {
-            val activity = awaitHost(InitializationTimeouts.consentHost) { activityProvider() }
-                ?: return@withContext failNoActivity()
-            val consentInformation = UserMessagingPlatform.getConsentInformation(appContext)
-            // The acquired Activity is reused rather than calling the public
-            // requestConsentInfoUpdate, which would wait for a host a second time.
-            val ownedConfig = prepareConsentConfig(config)
-            val update = updateWithActivity(activity, ownedConfig, consentInformation)
-            if (update is ConsentStatus.Failed && !consentInformation.canRequestAds()) return@withContext update
-            suspendCancellableCoroutine<Unit> { continuation ->
-                UserMessagingPlatform.loadAndShowConsentFormIfRequired(activity) { formError ->
-                    if (formError != null) {
-                        AdLogger.w("UMP consent form load/show failed: code=${formError.errorCode} message=${formError.message}")
-                    }
-                    // Reconciliation must not be conditional on the caller still being around —
-                    // see reconcileThenResumeIfActive's KDoc. The form was shown and the user's
-                    // decision (if any) is already persisted by UMP regardless of whether
-                    // gatherConsent()'s caller is still listening.
-                    reconcileThenResumeIfActive(continuation, Unit) {
-                        updatePrivacyState(consentInformation)
-                        _canRequestAds.value = consentInformation.canRequestAds()
-                        _status.value = consentInformationStatus(consentInformation)
+            val owned = prepareConsentConfig(config)
+            state.exclusiveOfForms(
+                presentsForm = true,
+                onFormPresenting = {
+                    ConsentStatus.Failed(
+                        AdError.message("gatherConsent() ignored: a consent form is already presenting.")
+                    )
+                },
+            ) {
+                val generation = state.beginOperation()
+                val activity = awaitHost(InitializationTimeouts.consentHost) { activityProvider() }
+                    ?: return@exclusiveOfForms failNoActivity(generation)
+                val consentInformation = UserMessagingPlatform.getConsentInformation(appContext)
+                // The acquired Activity is reused rather than calling the public
+                // requestConsentInfoUpdate, which would wait for a host a second time.
+                val update = updateWithActivity(activity, owned, consentInformation, generation)
+                if (update is ConsentStatus.Failed && !consentInformation.canRequestAds()) return@exclusiveOfForms update
+                suspendCancellableCoroutine<Unit> { continuation ->
+                    UserMessagingPlatform.loadAndShowConsentFormIfRequired(activity) { formError ->
+                        if (formError != null) {
+                            AdLogger.w("UMP consent form load/show failed: code=${formError.errorCode} message=${formError.message}")
+                        }
+                        // Reconciliation must not be conditional on the caller still being around —
+                        // see reconcileThenResumeIfActive's KDoc. The form was shown and the user's
+                        // decision (if any) is already persisted by UMP regardless of whether
+                        // gatherConsent()'s caller is still listening.
+                        reconcileThenResumeIfActive(continuation, Unit) {
+                            state.reconcileAndPublish(
+                                generation,
+                                privacyRequirement = privacyRequirementOf(consentInformation),
+                                canRequestAds = consentInformation.canRequestAds(),
+                                status = consentInformationStatus(consentInformation),
+                            )
+                        }
                     }
                 }
+                state.status.value
             }
-            _status.value
         }
 
     override suspend fun showPrivacyOptions(): Boolean =
         withContext(Dispatchers.Main.immediate) {
-            // Acquired inside the main hop, not before it -- matching requestConsentInfoUpdate
-            // and gatherConsent: this reads Activity lifecycle state, which is main-thread-owned
-            // (invariant 5).
-            val activity = activityProvider() ?: return@withContext false
-            val consentInformation = UserMessagingPlatform.getConsentInformation(appContext)
-            suspendCancellableCoroutine { continuation ->
-                UserMessagingPlatform.showPrivacyOptionsForm(activity) { formError ->
-                    // The user may have changed their choices in the form; refresh exposed
-                    // state so consumers don't read stale consent / canRequestAds values.
-                    // Must run even if the caller awaiting showPrivacyOptions() was
-                    // cancelled — the form already closed and UMP already persisted
-                    // whatever the user chose. See reconcileThenResumeIfActive's KDoc.
-                    reconcileThenResumeIfActive(continuation, formError == null) {
-                        updatePrivacyState(consentInformation)
-                        _canRequestAds.value = consentInformation.canRequestAds()
-                        _status.value = consentInformationStatus(consentInformation)
-                        // If the user granted consent from the privacy form after an
-                        // earlier denial, resume initialization — otherwise the SDK would
-                        // stay uninitialized forever. Launched on consentScope, not
-                        // awaited here: this callback (and the reconciliation above) must
-                        // complete regardless of whether the original caller is still
-                        // around to observe it.
-                        if (shouldResumeInitializationAfterPrivacyOptions(_canRequestAds.value, lastConfig)) {
-                            lastConfig?.let { config -> consentScope.launch { onCanRequestAds(config) } }
+            state.exclusiveOfForms(
+                presentsForm = true,
+                onFormPresenting = {
+                    AdLogger.w(
+                        "showPrivacyOptions() ignored: another consent form is already " +
+                            "presenting. Wait for it to dismiss before presenting privacy options."
+                    )
+                    false
+                },
+            ) {
+                val generation = state.beginOperation()
+                // Acquired inside the main hop, not before it -- matching requestConsentInfoUpdate
+                // and gatherConsent: this reads Activity lifecycle state, which is main-thread-owned
+                // (invariant 5).
+                val activity = activityProvider() ?: return@exclusiveOfForms false
+                val consentInformation = UserMessagingPlatform.getConsentInformation(appContext)
+                suspendCancellableCoroutine { continuation ->
+                    UserMessagingPlatform.showPrivacyOptionsForm(activity) { formError ->
+                        // The user may have changed their choices in the form; refresh exposed
+                        // state so consumers don't read stale consent / canRequestAds values.
+                        // Must run even if the caller awaiting showPrivacyOptions() was
+                        // cancelled — the form already closed and UMP already persisted
+                        // whatever the user chose. See reconcileThenResumeIfActive's KDoc.
+                        reconcileThenResumeIfActive(continuation, formError == null) {
+                            state.reconcileAndPublish(
+                                generation,
+                                privacyRequirement = privacyRequirementOf(consentInformation),
+                                canRequestAds = consentInformation.canRequestAds(),
+                                status = consentInformationStatus(consentInformation),
+                            )
+                            // If the user granted consent from the privacy form after an
+                            // earlier denial, resume initialization — otherwise the SDK would
+                            // stay uninitialized forever. Launched on consentScope, not
+                            // awaited here: this callback (and the reconciliation above) must
+                            // complete regardless of whether the original caller is still
+                            // around to observe it.
+                            if (shouldResumeInitializationAfterPrivacyOptions(state.canRequestAds.value, lastConfig)) {
+                                lastConfig?.let { config -> consentScope.launch { onCanRequestAds(config) } }
+                            }
                         }
                     }
                 }
             }
         }
 
-    override suspend fun resetConsentForDebug(): Boolean {
-        val activity = activityProvider() ?: return false
-        withContext(Dispatchers.Main.immediate) {
+    override suspend fun resetConsentForDebug(): Boolean = withContext(Dispatchers.Main.immediate) {
+        state.exclusiveOfForms(
+            presentsForm = false,
+            onFormPresenting = {
+                AdLogger.w(
+                    "resetConsentForDebug() ignored: a consent form is already presenting. " +
+                        "Wait for it to dismiss before resetting consent."
+                )
+                false
+            },
+        ) {
+            // Acquired inside the main hop, not before it -- this reads Activity lifecycle state,
+            // which is main-thread-owned (invariant 5), matching every other entry point here.
+            activityProvider() ?: return@exclusiveOfForms false
+            state.reset()
             UserMessagingPlatform.getConsentInformation(appContext).reset()
+            true
         }
-        _status.value = ConsentStatus.Unknown
-        _privacy.value = PrivacyOptionsRequirementStatus.Unknown
-        _canRequestAds.value = false
-        return true
     }
-
-    private fun fail(message: String): ConsentStatus =
-        ConsentStatus.Failed(AdError.message(message)).also { _status.value = it }
 
     /**
      * The host was absent for the whole `InitializationTimeouts.consentHost` window.
@@ -223,22 +287,24 @@ internal class AndroidConsentController(
      * [ConsentStatus.Failed] message stays byte-identical to what it has always been —
      * only the warning above it is new.
      */
-    private fun failNoActivity(): ConsentStatus {
+    private fun failNoActivity(generation: Long): ConsentStatus {
         AdLogger.w(
             "No usable Android Activity for UMP consent after waiting " +
                 "${InitializationTimeouts.consentHost}. Consent was not gathered on this attempt; " +
                 "the host app should retry."
         )
-        return fail("No current Android Activity for UMP consent.")
+        return state.publishOperationStatus(
+            generation,
+            ConsentStatus.Failed(AdError.message("No current Android Activity for UMP consent.")),
+        )
     }
 
-    private fun updatePrivacyState(consentInformation: ConsentInformation) {
-        _privacy.value = when (consentInformation.privacyOptionsRequirementStatus) {
+    private fun privacyRequirementOf(consentInformation: ConsentInformation): PrivacyOptionsRequirementStatus =
+        when (consentInformation.privacyOptionsRequirementStatus) {
             ConsentInformation.PrivacyOptionsRequirementStatus.REQUIRED -> PrivacyOptionsRequirementStatus.Required
             ConsentInformation.PrivacyOptionsRequirementStatus.NOT_REQUIRED -> PrivacyOptionsRequirementStatus.NotRequired
             else -> PrivacyOptionsRequirementStatus.Unknown
         }
-    }
 
     // Maps UMP's consent status (distinct from canRequestAds) so the public model
     // can surface NotRequired instead of collapsing everything to Obtained/Required.

--- a/admob-cmp-core/src/androidMain/kotlin/dev/avinya/ads/AndroidConsentController.kt
+++ b/admob-cmp-core/src/androidMain/kotlin/dev/avinya/ads/AndroidConsentController.kt
@@ -29,7 +29,8 @@ internal class AndroidConsentController(
     private val appContext: Context,
     private val onCanRequestAds: suspend (AdConfig) -> Unit
 ) : ConsentController {
-    // Regression Guard G2: state MUST be declared before the three overrides.
+    // Kotlin initializes properties in declaration order, so the holder must exist before the
+    // exposed flows delegate to it.
     private val state = ConsentStateHolder()
 
     override val status: StateFlow<ConsentStatus> = state.status
@@ -47,9 +48,9 @@ internal class AndroidConsentController(
     private val consentScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
 
     override suspend fun requestConsentInfoUpdate(config: AdConfig): ConsentStatus {
-        val ownedConfig = prepareConsentConfig(config)
         return withContext(Dispatchers.Main.immediate) {
             state.serialized {
+                val ownedConfig = prepareConsentConfig(config)
                 val generation = state.beginOperation()
                 val activity = awaitHost(InitializationTimeouts.consentHost) { activityProvider() }
                     ?: return@serialized failNoActivity(generation)
@@ -173,7 +174,6 @@ internal class AndroidConsentController(
 
     override suspend fun gatherConsent(config: AdConfig): ConsentStatus =
         withContext(Dispatchers.Main.immediate) {
-            val owned = prepareConsentConfig(config)
             state.exclusiveOfForms(
                 presentsForm = true,
                 onFormPresenting = {
@@ -182,6 +182,7 @@ internal class AndroidConsentController(
                     )
                 },
             ) {
+                val owned = prepareConsentConfig(config)
                 val generation = state.beginOperation()
                 val activity = awaitHost(InitializationTimeouts.consentHost) { activityProvider() }
                     ?: return@exclusiveOfForms failNoActivity(generation)
@@ -190,6 +191,10 @@ internal class AndroidConsentController(
                 // requestConsentInfoUpdate, which would wait for a host a second time.
                 val update = updateWithActivity(activity, owned, consentInformation, generation)
                 if (update is ConsentStatus.Failed && !consentInformation.canRequestAds()) return@exclusiveOfForms update
+                // The irreversible boundary, mirroring GoogleAdManagerBase's markHandoff: past this
+                // line UMP owns the form, and cancelling this coroutine no longer means the screen
+                // is free. Released in the callback below, not by this coroutine's fate.
+                state.markFormPresented(generation)
                 suspendCancellableCoroutine<Unit> { continuation ->
                     UserMessagingPlatform.loadAndShowConsentFormIfRequired(activity) { formError ->
                         if (formError != null) {
@@ -200,6 +205,7 @@ internal class AndroidConsentController(
                         // decision (if any) is already persisted by UMP regardless of whether
                         // gatherConsent()'s caller is still listening.
                         reconcileThenResumeIfActive(continuation, Unit) {
+                            state.releaseFormPresentation(generation)
                             state.reconcileAndPublish(
                                 generation,
                                 privacyRequirement = privacyRequirementOf(consentInformation),
@@ -231,6 +237,8 @@ internal class AndroidConsentController(
                 // (invariant 5).
                 val activity = activityProvider() ?: return@exclusiveOfForms false
                 val consentInformation = UserMessagingPlatform.getConsentInformation(appContext)
+                // See gatherConsent: the pin belongs to UMP from here, not to this coroutine.
+                state.markFormPresented(generation)
                 suspendCancellableCoroutine { continuation ->
                     UserMessagingPlatform.showPrivacyOptionsForm(activity) { formError ->
                         // The user may have changed their choices in the form; refresh exposed
@@ -239,6 +247,7 @@ internal class AndroidConsentController(
                         // cancelled — the form already closed and UMP already persisted
                         // whatever the user chose. See reconcileThenResumeIfActive's KDoc.
                         reconcileThenResumeIfActive(continuation, formError == null) {
+                            state.releaseFormPresentation(generation)
                             state.reconcileAndPublish(
                                 generation,
                                 privacyRequirement = privacyRequirementOf(consentInformation),

--- a/admob-cmp-core/src/androidMain/kotlin/dev/avinya/ads/AndroidGoogleAdManager.kt
+++ b/admob-cmp-core/src/androidMain/kotlin/dev/avinya/ads/AndroidGoogleAdManager.kt
@@ -95,11 +95,14 @@ internal class AndroidGoogleAdManager(
     // one) is Unknown, not Missing: it is not evidence the manifest lacks the key, so it must
     // never be reported as a configuration gap -- see DeclaredAppId's KDoc.
     internal override fun declaredAppId(): DeclaredAppId = try {
-        val value = appContext.packageManager
-            .getApplicationInfo(appContext.packageName, PackageManager.GET_META_DATA)
-            .metaData
-            ?.getString("com.google.android.gms.ads.APPLICATION_ID")
-        if (value != null) DeclaredAppId.Present(value) else DeclaredAppId.Missing
+        // A meta-data entry declared with an empty android:value is the same gap as an absent
+        // key -- UMP cannot resolve an application from it either way.
+        DeclaredAppId.ofDeclaredValue(
+            appContext.packageManager
+                .getApplicationInfo(appContext.packageName, PackageManager.GET_META_DATA)
+                .metaData
+                ?.getString("com.google.android.gms.ads.APPLICATION_ID")
+        )
     } catch (t: Throwable) {
         DeclaredAppId.Unknown
     }

--- a/admob-cmp-core/src/androidMain/kotlin/dev/avinya/ads/AndroidGoogleAdManager.kt
+++ b/admob-cmp-core/src/androidMain/kotlin/dev/avinya/ads/AndroidGoogleAdManager.kt
@@ -78,6 +78,9 @@ internal class AndroidGoogleAdManager(
     internal override val declaredAppIdSource: String =
         "AndroidManifest.xml meta-data \"com.google.android.gms.ads.APPLICATION_ID\""
 
+    // declaredAppIdRequiredByPlatformSdk defaults to false, which is correct on Android: GMA Next-Gen
+    // initializes from AdConfig.androidAppId directly; only UMP reads this manifest meta-data.
+
     // NOT what GMA Next-Gen itself uses -- see initializeMobileAdsNative below, which passes
     // config.androidAppId straight into InitializationConfig.Builder. This manifest value is
     // read by the User Messaging Platform SDK for its own consent-app resolution, so a mismatch
@@ -108,17 +111,23 @@ internal class AndroidGoogleAdManager(
     override suspend fun initializeMobileAdsNative(
         config: AdConfig,
         requestedIdentity: AdInitializationConfigIdentity,
+        markHandoff: suspend () -> Unit,
     ) {
         AdLogger.d("Android initializing MobileAds with global request configuration.")
         val initializationConfig = InitializationConfig.Builder(config.androidAppId)
             .setRequestConfiguration(requestedIdentity.globalRequestConfiguration.toAndroidRequestConfiguration())
             .build()
+        // The builder and request-configuration mapping can reject a malformed app ID;
+        // nothing is owned by GMA until MobileAds.initialize is actually called.
+        markHandoff()
         withContext(Dispatchers.IO) {
             // MUST stay bounded: GMA can accept the call and never invoke the callback, which
             // would leave initialize() suspended forever otherwise. A timeout is NOT a
-            // CancellationException (see awaitNativeCallback), so it reaches the catch below as
-            // a real failure and leaves the identity uncommitted — making a retry the correct
-            // next step.
+            // CancellationException (see awaitNativeCallback), so it reaches the catch below as a
+            // real failure. The requested identity is pinned as handed-off before this call
+            // regardless, so retrying the SAME configuration is still the correct next step, while
+            // a retry with a DIFFERENT one is refused deterministically instead of being
+            // reported as applied. See GoogleAdManagerBase.handedOffConfigIdentity.
             awaitNativeCallback(
                 operation = "MobileAds.initialize",
                 timeout = InitializationTimeouts.nativeInitialize

--- a/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/AdError.kt
+++ b/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/AdError.kt
@@ -52,7 +52,20 @@ public object AdErrorCode {
      * [SDK_NOT_READY] matters — that one means "wait and retry", this one means "fix the call".
      */
     public const val INITIALIZATION_CONFLICT: String = "initialization_conflict"
+
+    /**
+     * The platform app-ID declaration (`AndroidManifest.xml` meta-data, `Info.plist`) is missing
+     * or inconsistent with [AdConfig][dev.avinya.ads.AdConfig], so the preflight refused initialization
+     * before UMP or GMA was touched.
+     *
+     * Never retryable: the platform declaration is part of the application binary or manifest, so
+     * the same call will fail identically until the app bundle is fixed and rebuilt. Distinguishing
+     * this from [INITIALIZATION_CONFLICT] matters — that one means "restart the process and call
+     * initialize() once", this one means "fix the app bundle and rebuild".
+     */
+    public const val APP_ID_INVALID: String = "app_id_invalid"
 }
+
 
 /**
  * Shared retry classification for all platform load paths. Platform mappers

--- a/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/AdManager.kt
+++ b/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/AdManager.kt
@@ -143,20 +143,25 @@ public interface ConsentController {
      * Shows the privacy options form. Should only be called when [privacyOptionsRequirementStatus]
      * is [PrivacyOptionsRequirementStatus.Required].
      *
-     * Returns `false` when the form could not be shown, or when another UMP form is already
-     * presenting — two forms cannot stack. A bounded [requestConsentInfoUpdate] holding the SDK's
-     * consent slot is **not** a decline: this call waits for it. Only a live form, including the
-     * one an `initialize(…, GatherBeforeInitialize)` sequence may present, returns `false` here;
-     * retry once that form is dismissed rather than treating `false` as a permanent failure.
+     * Returns `false` when the form could not be shown, or when a form-presenting operation
+     * already holds the SDK's consent slot — two forms cannot stack. The slot is claimed when
+     * such an operation starts, not when UMP puts a form on screen, so this also covers the window
+     * in which a [gatherConsent] — including the one an `initialize(…, GatherBeforeInitialize)`
+     * sequence runs — is still waiting for a host and running its bounded info update, before
+     * anything is visible. A [requestConsentInfoUpdate] never claims the slot and is **not** a
+     * decline: this call waits for it. Retry once the in-flight operation finishes rather than
+     * treating `false` as a permanent failure.
      */
     public suspend fun showPrivacyOptions(): Boolean
 
     /**
      * Resets consent state for debug/testing purposes only.
      *
-     * Returns `false` when a UMP form is presenting — resetting consent out from under a form the
-     * user is reading is incoherent. A bounded [requestConsentInfoUpdate] is not a decline: this
-     * call waits for it. Retry once the form is dismissed.
+     * Returns `false` when a form-presenting operation holds the SDK's consent slot — resetting
+     * consent out from under a form the user is reading, or out from under a [gatherConsent] that
+     * is about to present one, is incoherent. A bounded [requestConsentInfoUpdate] never claims
+     * the slot and is not a decline: this call waits for it. Retry once the in-flight operation
+     * finishes.
      */
     public suspend fun resetConsentForDebug(): Boolean
 

--- a/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/AdManager.kt
+++ b/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/AdManager.kt
@@ -139,10 +139,27 @@ public interface ConsentController {
     public suspend fun requestConsentInfoUpdate(config: AdConfig): ConsentStatus
     /** Requests an update and shows the consent form if required. */
     public suspend fun gatherConsent(config: AdConfig): ConsentStatus
-    /** Shows the privacy options form. Should only be called when [privacyOptionsRequirementStatus] is [PrivacyOptionsRequirementStatus.Required]. */
+    /**
+     * Shows the privacy options form. Should only be called when [privacyOptionsRequirementStatus]
+     * is [PrivacyOptionsRequirementStatus.Required].
+     *
+     * Returns `false` when the form could not be shown, or when another UMP form is already
+     * presenting — two forms cannot stack. A bounded [requestConsentInfoUpdate] holding the SDK's
+     * consent slot is **not** a decline: this call waits for it. Only a live form, including the
+     * one an `initialize(…, GatherBeforeInitialize)` sequence may present, returns `false` here;
+     * retry once that form is dismissed rather than treating `false` as a permanent failure.
+     */
     public suspend fun showPrivacyOptions(): Boolean
-    /** Resets consent state for debug/testing purposes only. */
+
+    /**
+     * Resets consent state for debug/testing purposes only.
+     *
+     * Returns `false` when a UMP form is presenting — resetting consent out from under a form the
+     * user is reading is incoherent. A bounded [requestConsentInfoUpdate] is not a decline: this
+     * call waits for it. Retry once the form is dismissed.
+     */
     public suspend fun resetConsentForDebug(): Boolean
+
 }
 
 /**

--- a/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/AppIdVerification.kt
+++ b/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/AppIdVerification.kt
@@ -1,0 +1,57 @@
+package dev.avinya.ads
+
+/**
+ * How the SDK reacts when the app ID in [AdConfig] disagrees with the one declared in the
+ * platform's own configuration (`AndroidManifest.xml` meta-data, `Info.plist`).
+ *
+ * The two declarations are consumed by different SDKs, which is why the default is graduated
+ * rather than uniform:
+ *
+ * - On **iOS**, `Info.plist`'s `GADApplicationIdentifier` is what the native Google Mobile Ads
+ *   SDK itself resolves at startup. If it is absent, ads cannot work at all.
+ * - On **Android**, `AndroidManifest.xml`'s `com.google.android.gms.ads.APPLICATION_ID` is read
+ *   by the User Messaging Platform SDK. GMA Next-Gen initializes from
+ *   [AdConfig.androidAppId] directly and never reads it. A disagreement means consent and ads
+ *   may resolve two different applications — a real misconfiguration, but not one that stops
+ *   the SDK from serving.
+ */
+public enum class AppIdVerificationPolicy {
+
+    /**
+     * Log a warning and continue, whatever the finding.
+     *
+     * An escape hatch, not a recommendation: use it only if the SDK misreads your platform
+     * declaration (an embedded bundle, a restricted package manager) and you have verified the
+     * configuration is correct by other means.
+     */
+    WarnOnly,
+
+    /**
+     * Default. Fail initialization only when the platform's own SDK cannot function with the
+     * declaration as found — today, a missing iOS `GADApplicationIdentifier`. Everything else
+     * logs a warning and continues.
+     */
+    FailWhenUnusable,
+
+    /**
+     * Fail initialization on any missing or mismatched declaration, before UMP or GMA is
+     * touched. Recommended for new integrations, and the intended default from 3.0.0.
+     */
+    Strict,
+}
+
+/**
+ * Process-wide policy for the platform app-ID preflight check.
+ *
+ * **Threading:** an ordinary property with no synchronization, exactly like [AdLogger.sink].
+ * Set it once during application startup, before the first `initialize()`.
+ *
+ * The default is [AppIdVerificationPolicy.FailWhenUnusable]. It is scheduled to become
+ * [AppIdVerificationPolicy.Strict] in 3.0.0; set it explicitly now if you want the future
+ * behaviour, or [AppIdVerificationPolicy.WarnOnly] if you want to log warnings and continue
+ * whatever the finding.
+ */
+public object AdAppIdVerification {
+    /** The policy applied on every `initialize()` attempt. */
+    public var policy: AppIdVerificationPolicy = AppIdVerificationPolicy.FailWhenUnusable
+}

--- a/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/GoogleAdManagerBase.kt
+++ b/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/GoogleAdManagerBase.kt
@@ -7,10 +7,14 @@ import dev.avinya.ads.internal.AppliedConfigurationDecision
 import dev.avinya.ads.internal.ConsentSessionState
 import dev.avinya.ads.internal.FullScreenPresentationArbiter
 import dev.avinya.ads.internal.FullScreenStateLock
+import dev.avinya.ads.internal.AppIdVerdict
 import dev.avinya.ads.internal.DeclaredAppId
-import dev.avinya.ads.internal.appIdConfigurationWarningOrNull
+import dev.avinya.ads.internal.NativeHandoffDecision
+import dev.avinya.ads.internal.appIdPreflightError
+import dev.avinya.ads.internal.appIdVerdict
 import dev.avinya.ads.internal.appliedConfigurationDecision
 import dev.avinya.ads.internal.dispatchAfterInitializeHooks
+import dev.avinya.ads.internal.nativeHandoffDecision
 import dev.avinya.ads.internal.ownedSnapshot
 import dev.avinya.ads.nativead.NativeAdMemoryPolicy
 import kotlin.concurrent.Volatile
@@ -184,6 +188,16 @@ internal abstract class GoogleAdManagerBase : AdManager, FullScreenPresenceAware
     internal open val declaredAppIdConsumerDescription: String = ""
 
     /**
+     * Whether the platform's own ad SDK resolves its identity from [declaredAppId].
+     *
+     * True on iOS, where `GADMobileAds` reads `GADApplicationIdentifier` at startup and cannot
+     * initialize without it. False on Android, where GMA Next-Gen initializes from
+     * `AdConfig.androidAppId` and the manifest value belongs to UMP. This is the difference
+     * that makes a missing declaration fatal on one platform and a warning on the other.
+     */
+    internal open val declaredAppIdRequiredByPlatformSdk: Boolean = false
+
+    /**
      * Reads GMA's/GAD's version and adapter statuses onto the platform's diagnostics object.
      * MUST run on Main, immediately after [initializeMobileAdsNative] returns and before
      * [dev.avinya.ads.internal.dispatchAfterInitializeHooks] runs, so a publisher hook can read
@@ -198,10 +212,18 @@ internal abstract class GoogleAdManagerBase : AdManager, FullScreenPresenceAware
      * SDK reports completion or [dev.avinya.ads.internal.InitializationTimeouts.nativeInitialize]
      * elapses; a timeout must surface as a thrown failure, not a `CancellationException` (see
      * `awaitNativeCallback`), so a retry after a timeout is possible.
+     *
+     * [markHandoff] MUST be invoked exactly once, immediately before the FIRST irreversible touch of
+     * the process-global native SDK, and MUST NOT be invoked on any path that fails before that point.
+     * Everything an implementation does before that call is still undoable — building a config object,
+     * mapping a request configuration — and pinning ownership there would turn a fixable
+     * misconfiguration into a permanent, non-retryable conflict. Everything after it is owned by the
+     * process whether or not the callback ever arrives.
      */
     protected abstract suspend fun initializeMobileAdsNative(
         config: AdConfig,
         requestedIdentity: AdInitializationConfigIdentity,
+        markHandoff: suspend () -> Unit,
     )
 
     private data class InitializationAttempt(
@@ -280,6 +302,22 @@ internal abstract class GoogleAdManagerBase : AdManager, FullScreenPresenceAware
 
     @Volatile
     private var appliedConfigIdentity: AdInitializationConfigIdentity? = null
+    /**
+     * The identity handed to the process-global native SDK, pinned BEFORE the call and never
+     * cleared.
+     *
+     * Distinct from [appliedConfigIdentity], which is committed only once native initialization
+     * actually succeeds. The gap between the two is the whole point: `initializeMobileAdsNative`
+     * bounds how long the wrapper waits for GMA's callback, and a
+     * `NativeCallbackTimeoutException` means "the SDK accepted the call and never answered" — the
+     * handoff happened, only the confirmation is missing. Committing ownership only on success
+     * would let a retry with a DIFFERENT AdConfig sail past [appliedOutcome] and eventually
+     * publish Ready while the native singleton still owns the first configuration.
+     *
+     * A timeout stops one waiter. It cannot undo an irreversible native handoff.
+     */
+    @Volatile
+    private var handedOffConfigIdentity: AdInitializationConfigIdentity? = null
     @Volatile
     private var appliedTerminalStatus: AdManagerStatus? = null
 
@@ -310,6 +348,7 @@ internal abstract class GoogleAdManagerBase : AdManager, FullScreenPresenceAware
                 }
                 if (nativeCompletion != null) return@withLock null
                 appliedOutcome(requestedIdentity, ownedConfig.nativeAdMemoryPolicy)?.let { return it }
+                refusedByNativeHandoff(requestedIdentity)?.let { return it }
                 InitializationAttempt(
                     identity = requestedIdentity,
                     consentMode = consentMode,
@@ -360,15 +399,36 @@ internal abstract class GoogleAdManagerBase : AdManager, FullScreenPresenceAware
         // Checked before consent, not inside initializeMobileAds: on Android the value this
         // reads is what UMP (not GMA) resolves its identity from, so a mismatch is actionable
         // context for the consent gathering call right below, not just for GMA's own
-        // initialization later. Best-effort and non-fatal by design -- see
-        // appIdConfigurationWarningOrNull's KDoc. Checked on every initialize() attempt, not
-        // cached, matching testModeWarningOrNull's own cadence just above.
-        appIdConfigurationWarningOrNull(
-            appId(config),
-            declaredAppId(),
-            declaredAppIdSource,
-            declaredAppIdConsumerDescription,
-        )?.let(AdLogger::w)
+        // initialization later. The check is now enforcement, not just context -- fatal
+        // misconfigurations are rejected before consent or native SDK calls. Checked on every
+        // initialize() attempt, not cached, matching testModeWarningOrNull's own cadence just above.
+        when (
+            val verdict = appIdVerdict(
+                configuredAppId = appId(config),
+                declared = declaredAppId(),
+                declaredAppIdSource = declaredAppIdSource,
+                declaredAppIdConsumerDescription = declaredAppIdConsumerDescription,
+                requiredByPlatformSdk = declaredAppIdRequiredByPlatformSdk,
+                policy = AdAppIdVerification.policy,
+            )
+        ) {
+            AppIdVerdict.Ok -> Unit
+            is AppIdVerdict.Warn -> AdLogger.w(verdict.message)
+            is AppIdVerdict.Fail -> {
+                AdLogger.e(verdict.message)
+                // Stopped BEFORE consent and BEFORE any native call: a deterministic
+                // configuration invalidity must not become an opaque native failure, and
+                // gathering consent against the wrong application identity is worse than
+                // gathering none.
+                val result = AdManagerStatus.Failed(
+                    error = appIdPreflightError(verdict.message),
+                    retryable = false,
+                )
+                _status.value = result
+                completeAttempt(attempt, result)
+                return result
+            }
+        }
 
         val previousStatus = _status.value
         _status.value = AdManagerStatus.Initializing
@@ -473,6 +533,19 @@ internal abstract class GoogleAdManagerBase : AdManager, FullScreenPresenceAware
         }
     }
 
+    private suspend fun refusedByNativeHandoff(
+        requestedIdentity: AdInitializationConfigIdentity,
+    ): AdManagerStatus? = mobileAdsInitializationMutex.withLock {
+        when (val decision = nativeHandoffDecision(handedOffConfigIdentity, requestedIdentity)) {
+            NativeHandoffDecision.Proceed -> null
+            is NativeHandoffDecision.Refuse -> {
+                AdLogger.w("$platformTag MobileAds handoff conflict. ${decision.reason}")
+                // The rejection is deliberately NOT published -- see NativeHandoffDecision.Refuse.
+                decision.rejection
+            }
+        }
+    }
+
     /** The platform's own `nativeManager.configuredPolicyOrNull()` — see [onNativeConsentRevoked]. */
     protected abstract fun configuredNativePolicyOrNull(): NativeAdMemoryPolicy?
 
@@ -487,6 +560,9 @@ internal abstract class GoogleAdManagerBase : AdManager, FullScreenPresenceAware
     private suspend fun initializeMobileAds(config: AdConfig): AdManagerStatus {
         val requestedIdentity = config.initializationIdentity(appId(config))
         appliedOutcome(requestedIdentity, config.nativeAdMemoryPolicy)?.let { return it }
+        // The primary check is before consent in initialize(); this backstop covers a follower
+        // that loops after a leader's attempt settled and re-enters with its own identity.
+        refusedByNativeHandoff(requestedIdentity)?.let { return it }
 
         var operation = mobileAdsInitializationMutex.withLock { nativeInitialization }
         if (operation == null) {
@@ -537,7 +613,13 @@ internal abstract class GoogleAdManagerBase : AdManager, FullScreenPresenceAware
         // running — strictly better than desynchronizing the wrapper from native reality.
         val completion = nativeInitializationScope.async(start = CoroutineStart.LAZY) {
             val result = try {
-                initializeMobileAdsNative(config, requestedIdentity)
+                // The platform implementation decides when the mark is taken (via markHandoff):
+                // iOS mutates GADMobileAds.sharedInstance.requestConfiguration before start(), while
+                // Android builds its InitializationConfig first and only marks immediately before
+                // MobileAds.initialize. From that mark on, this identity is what the process owns.
+                initializeMobileAdsNative(config, requestedIdentity) {
+                    mobileAdsInitializationMutex.withLock { handedOffConfigIdentity = requestedIdentity }
+                }
                 // Captured after the native call returns so adapter statuses are populated, and
                 // before the After hook so a publisher hook can read them.
                 captureDiagnosticsSnapshotOnMain()

--- a/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/AppIdVerification.kt
+++ b/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/AppIdVerification.kt
@@ -1,5 +1,9 @@
 package dev.avinya.ads.internal
 
+import dev.avinya.ads.AdError
+import dev.avinya.ads.AdErrorCode
+import dev.avinya.ads.AppIdVerificationPolicy
+
 /**
  * The app ID declared in the platform's own configuration source (`AndroidManifest.xml`
  * meta-data, `Info.plist`), independent of [AdConfig][dev.avinya.ads.AdConfig].
@@ -70,3 +74,55 @@ internal fun appIdConfigurationWarningOrNull(
         }
     }
 }
+
+/**
+ * What the app-ID preflight decided.
+ *
+ * Split from [appIdConfigurationWarningOrNull] so the MESSAGE and the SEVERITY are separate
+ * concerns: the same text is emitted whether the finding warns or blocks, and only the policy
+ * decides which. Logging is observability; this type is enforcement.
+ */
+internal sealed interface AppIdVerdict {
+    data object Ok : AppIdVerdict
+    data class Warn(val message: String) : AppIdVerdict
+    data class Fail(val message: String) : AppIdVerdict
+}
+
+/**
+ * Applies [policy] to the platform declaration.
+ *
+ * @param requiredByPlatformSdk whether the platform's OWN ad SDK resolves its identity from
+ *   [declared]. True on iOS (`GADApplicationIdentifier`), false on Android (where the manifest
+ *   value is UMP's and GMA Next-Gen reads `AdConfig` instead). This is what makes a missing
+ *   declaration fatal on one platform and merely wrong on the other.
+ */
+internal fun appIdVerdict(
+    configuredAppId: String,
+    declared: DeclaredAppId,
+    declaredAppIdSource: String,
+    declaredAppIdConsumerDescription: String,
+    requiredByPlatformSdk: Boolean,
+    policy: AppIdVerificationPolicy,
+): AppIdVerdict {
+    val message = appIdConfigurationWarningOrNull(
+        configuredAppId,
+        declared,
+        declaredAppIdSource,
+        declaredAppIdConsumerDescription,
+    ) ?: return AppIdVerdict.Ok
+
+    val unusable = requiredByPlatformSdk && declared is DeclaredAppId.Missing
+    val fails = when (policy) {
+        AppIdVerificationPolicy.WarnOnly -> false
+        AppIdVerificationPolicy.FailWhenUnusable -> unusable
+        AppIdVerificationPolicy.Strict -> true
+    }
+    return if (fails) AppIdVerdict.Fail(message) else AppIdVerdict.Warn(message)
+}
+
+/** The typed error a failed preflight publishes. Never retryable: the configuration must change. */
+internal fun appIdPreflightError(message: String): AdError = AdError(
+    code = AdErrorCode.APP_ID_INVALID,
+    message = message,
+)
+

--- a/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/AppIdVerification.kt
+++ b/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/AppIdVerification.kt
@@ -15,15 +15,39 @@ import dev.avinya.ads.AppIdVerificationPolicy
  * misconfiguration and must never be reported as one. [Missing] and [Unknown] keep those apart.
  */
 internal sealed interface DeclaredAppId {
-    /** The declared value was read successfully. */
+    /**
+     * The declared value was read successfully. [value] is non-blank — build it through
+     * [ofDeclaredValue] rather than the constructor so that stays true.
+     */
     data class Present(val value: String) : DeclaredAppId
 
-    /** The read succeeded, but no value is set for the key — a real configuration gap. */
+    /** The read succeeded, but no usable value is set for the key — a real configuration gap. */
     data object Missing : DeclaredAppId
 
     /** The value could not be determined (read failure, unsupported environment). Never a warning. */
     data object Unknown : DeclaredAppId
+
+    companion object {
+        /**
+         * Classifies a raw platform value read from the manifest or plist.
+         *
+         * A key that is present but blank is the SAME configuration gap as an absent key: neither
+         * GMA nor UMP can resolve an application from it, so treating it as a mismatch would both
+         * understate the problem and print an empty redacted id at the reader.
+         */
+        fun ofDeclaredValue(value: String?): DeclaredAppId =
+            if (value.isNullOrBlank()) Missing else Present(value)
+    }
 }
+
+/**
+ * Collapses a blank [DeclaredAppId.Present] onto [DeclaredAppId.Missing].
+ *
+ * [DeclaredAppId.ofDeclaredValue] already keeps blanks out at every reader; this keeps the policy
+ * correct anyway, so a future reader that builds `Present` directly cannot quietly reopen the gap.
+ */
+private fun DeclaredAppId.normalized(): DeclaredAppId =
+    if (this is DeclaredAppId.Present && value.isBlank()) DeclaredAppId.Missing else this
 
 /**
  * Builds a warning message when [declared] does not agree with what
@@ -39,10 +63,9 @@ internal sealed interface DeclaredAppId {
  * iOS, `Info.plist`'s `GADApplicationIdentifier` really is what the native Google Mobile Ads
  * SDK itself resolves and uses at startup.
  *
- * This is a **warning, not a hard failure** in both the mismatch and the missing case: a
- * configuration gap caught here must not turn into an initialization outage for every ad
- * format. [DeclaredAppId.Unknown] is deliberately never a warning — an unreadable value is not
- * evidence of misconfiguration this check can usefully report on.
+ * This builds the MESSAGE only; [appIdVerdict] decides whether that message warns or blocks, so
+ * the text here stays severity-neutral. [DeclaredAppId.Unknown] is deliberately never reported —
+ * an unreadable value is not evidence of misconfiguration this check can usefully report on.
  *
  * IDs are redacted to their last 6 characters: full ad app IDs should not be written to logs
  * verbatim.
@@ -57,18 +80,18 @@ internal fun appIdConfigurationWarningOrNull(
     declared: DeclaredAppId,
     declaredAppIdSource: String,
     declaredAppIdConsumerDescription: String,
-): String? = when (declared) {
+): String? = when (val effective = declared.normalized()) {
     DeclaredAppId.Unknown -> null
     DeclaredAppId.Missing -> "AdConfig is configured with app ID (…${configuredAppId.takeLast(6)}), " +
         "but $declaredAppIdSource has no value set. $declaredAppIdConsumerDescription This is a " +
-        "configuration gap, not just a mismatch -- fix it even though the SDK does not fail " +
-        "initialization for it."
+        "configuration gap, not just a mismatch -- with no value declared there is no application " +
+        "to resolve."
     is DeclaredAppId.Present -> {
-        if (declared.value == configuredAppId) {
+        if (effective.value == configuredAppId) {
             null
         } else {
             "AdConfig's app ID (…${configuredAppId.takeLast(6)}) does not match the value declared " +
-                "in $declaredAppIdSource (…${declared.value.takeLast(6)}). " +
+                "in $declaredAppIdSource (…${effective.value.takeLast(6)}). " +
                 "$declaredAppIdConsumerDescription This usually means AdConfig and " +
                 "$declaredAppIdSource were updated independently."
         }
@@ -111,7 +134,7 @@ internal fun appIdVerdict(
         declaredAppIdConsumerDescription,
     ) ?: return AppIdVerdict.Ok
 
-    val unusable = requiredByPlatformSdk && declared is DeclaredAppId.Missing
+    val unusable = requiredByPlatformSdk && declared.normalized() is DeclaredAppId.Missing
     val fails = when (policy) {
         AppIdVerificationPolicy.WarnOnly -> false
         AppIdVerificationPolicy.FailWhenUnusable -> unusable
@@ -125,4 +148,3 @@ internal fun appIdPreflightError(message: String): AdError = AdError(
     code = AdErrorCode.APP_ID_INVALID,
     message = message,
 )
-

--- a/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/AppliedConfiguration.kt
+++ b/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/AppliedConfiguration.kt
@@ -161,4 +161,3 @@ internal fun nativeHandoffDecision(
         reason = reason,
     )
 }
-

--- a/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/AppliedConfiguration.kt
+++ b/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/AppliedConfiguration.kt
@@ -104,3 +104,61 @@ internal fun appliedConfigurationDecision(
     }
     return AppliedConfigurationDecision.Accepted(appliedTerminalStatus)
 }
+
+/**
+ * What a new native-initialization attempt should do, given what was already handed to the
+ * process-global ad SDK.
+ *
+ * Distinct from [appliedConfigurationDecision], which answers the same question for a
+ * *completed* initialization. This one covers the window in between: the native call has been
+ * accepted but its callback has not arrived — or never will. A wrapper timeout may release the
+ * waiter, but it cannot un-hand-off an irreversible call, so ownership must survive it.
+ */
+internal sealed interface NativeHandoffDecision {
+
+    /** Nothing was handed off yet, or the same configuration is being retried. */
+    data object Proceed : NativeHandoffDecision
+
+    /**
+     * A different configuration was already handed to the native singleton.
+     *
+     * @property rejection returned to **this** caller only. As with
+     *   [AppliedConfigurationDecision.Conflict], it must NOT be published as the manager's
+     *   status: `adRequestBlockedError()` blocks every ad request whenever the status is not
+     *   [AdManagerStatus.Ready], which would take down ad serving process-wide.
+     */
+    data class Refuse(
+        val rejection: AdManagerStatus.Failed,
+        val reason: String,
+    ) : NativeHandoffDecision
+}
+
+/**
+ * Decides whether a native initialization attempt may proceed.
+ *
+ * A same-identity retry is always permitted: when GMA accepts a call and never calls back, the
+ * documented recovery is to retry the same configuration, and both platform SDKs tolerate a
+ * repeated initialize.
+ */
+internal fun nativeHandoffDecision(
+    handedOffIdentity: AdInitializationConfigIdentity?,
+    requestedIdentity: AdInitializationConfigIdentity,
+): NativeHandoffDecision {
+    if (handedOffIdentity == null || handedOffIdentity == requestedIdentity) {
+        return NativeHandoffDecision.Proceed
+    }
+    val reason = if (handedOffIdentity.platformAppId != requestedIdentity.platformAppId) {
+        "The ad SDK was already started with app ID '${handedOffIdentity.platformAppId}', but " +
+            "'${requestedIdentity.platformAppId}' was requested."
+    } else {
+        "The ad SDK was already started with a different global request configuration."
+    }
+    return NativeHandoffDecision.Refuse(
+        rejection = AdManagerStatus.Failed(
+            error = initializationConflictError(reason),
+            retryable = false,
+        ),
+        reason = reason,
+    )
+}
+

--- a/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/ConsentOperationCoordinator.kt
+++ b/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/ConsentOperationCoordinator.kt
@@ -1,0 +1,86 @@
+package dev.avinya.ads.internal
+
+import kotlin.concurrent.Volatile
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Orders the wrapper's consent operations without pretending to order UMP's.
+ *
+ * Two different things were previously conflated, and separating them is the whole point of
+ * this class:
+ *
+ * 1. **Authoritative privacy state** — `canRequestAds` and the privacy-options requirement.
+ *    These are READ back off the UMP singleton at callback time, so they are never stale and
+ *    must be reconciled unconditionally, including from a callback that arrived after its
+ *    waiter timed out. A late callback can carry a revocation; dropping it leaves the ad
+ *    request gate open on stale privacy state until the next cold start.
+ * 2. **Operation status** — the `ConsentStatus` a *particular* call publishes, including the
+ *    synthesized `Failed(timeout)` one. This one IS ordered: a callback belonging to a
+ *    superseded operation must not overwrite a newer operation's result. That is what
+ *    [beginOperation]/[isCurrentOperation] enforce.
+ *
+ * [serialized] and [exclusiveOfForms] then make the concurrency contract explicit rather than
+ * delegating it to whatever the native UMP SDK happens to do about a second form. UMP
+ * rejecting an overlapping form does not make the wrapper's status ordering safe.
+ *
+ * **Threading:** every consent entry point already runs on `Dispatchers.Main.immediate`, and
+ * UMP delivers its callbacks on the main thread on both platforms, so [currentGeneration] is
+ * main-confined. `@Volatile` is for visibility only — matching `GoogleAdManagerBase`'s own
+ * `appliedConfigIdentity` — not a substitute for that confinement.
+ */
+internal class ConsentOperationCoordinator {
+
+    @Volatile
+    private var currentGeneration = 0L
+
+    @Volatile
+    private var presentingForm = false
+
+    /** Serializes the info-update / form sequences that may legitimately wait for each other. */
+    private val operationMutex = Mutex()
+
+    /**
+     * Claims the newest generation. Every consent entry point calls this once, up front —
+     * including `resetConsentForDebug`, so a reset invalidates every outstanding callback.
+     */
+    fun beginOperation(): Long = ++currentGeneration
+
+    /** Whether [generation] is still the newest operation and may therefore publish a status. */
+    fun isCurrentOperation(generation: Long): Boolean = generation == currentGeneration
+
+    /**
+     * Runs [block] with no other coordinated consent operation in flight, waiting if one is.
+     *
+     * For the info-update and consent-gathering paths, where a caller waiting a moment is
+     * strictly better than a duplicate UMP round trip.
+     */
+    suspend fun <T> serialized(block: suspend () -> T): T = operationMutex.withLock { block() }
+
+    /**
+     * Declines ONLY when a UMP form is already on screen -- two forms cannot stack. Anything else
+     * holding the slot is a bounded, non-interactive operation (a consent info update, at most
+     * InitializationTimeouts.consentInfoUpdate), and ordering behind it is not a reason to fail:
+     * the app UI stays interactive during that window, so a user who opens Settings during the
+     * launch-time refresh must get the form, not "unavailable". Callers surface the false return
+     * to a person -- see DiagnosticsTab, ProfileViewModel, PrivacyLabScreen -- so a spurious
+     * decline is a spurious error message.
+     */
+    suspend fun <T> exclusiveOfForms(
+        presentsForm: Boolean,
+        onFormPresenting: () -> T,
+        block: suspend () -> T,
+    ): T {
+        if (presentingForm) return onFormPresenting()
+        return operationMutex.withLock {
+            // No second check: presentingForm is only ever set inside this lock and restored in
+            // the finally below, so holding the lock already proves it is false here.
+            if (presentsForm) presentingForm = true
+            try {
+                block()
+            } finally {
+                presentingForm = false
+            }
+        }
+    }
+}

--- a/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/ConsentOperationCoordinator.kt
+++ b/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/ConsentOperationCoordinator.kt
@@ -1,6 +1,9 @@
 package dev.avinya.ads.internal
 
+import dev.avinya.ads.AdLogger
 import kotlin.concurrent.Volatile
+import kotlin.time.TimeMark
+import kotlin.time.TimeSource
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
@@ -24,21 +27,39 @@ import kotlinx.coroutines.sync.withLock
  * delegating it to whatever the native UMP SDK happens to do about a second form. UMP
  * rejecting an overlapping form does not make the wrapper's status ordering safe.
  *
+ * **Form ownership is two facts, not one.** [slotHoldsForm] covers the window between taking
+ * the slot and touching UMP — that is what stops a double tap. [nativeFormHandoff] covers the
+ * window UMP itself owns, and it deliberately OUTLIVES the coroutine that opened the form:
+ * cancelling a caller does not dismiss a form the user is looking at, so a cancelled waiter is
+ * not evidence that the screen is free. Only the form's own callback — via
+ * [releaseFormPresentation], which every UMP form callback reaches unconditionally through
+ * [reconcileThenResumeIfActive] — or the [InitializationTimeouts.formPresentationPin] backstop
+ * releases it.
+ *
  * **Threading:** every consent entry point already runs on `Dispatchers.Main.immediate`, and
- * UMP delivers its callbacks on the main thread on both platforms, so [currentGeneration] is
- * main-confined. `@Volatile` is for visibility only — matching `GoogleAdManagerBase`'s own
- * `appliedConfigIdentity` — not a substitute for that confinement.
+ * UMP delivers its callbacks on the main thread on both platforms, so [currentGeneration] and
+ * both form facts are main-confined. `@Volatile` is for visibility only — matching
+ * `GoogleAdManagerBase`'s own `appliedConfigIdentity` — not a substitute for that confinement.
  */
-internal class ConsentOperationCoordinator {
+internal class ConsentOperationCoordinator(
+    private val timeSource: TimeSource = TimeSource.Monotonic,
+) {
 
     @Volatile
     private var currentGeneration = 0L
 
+    /** Set for as long as an operation holds the slot in order to present a form. */
     @Volatile
-    private var presentingForm = false
+    private var slotHoldsForm = false
+
+    /** Set from the moment UMP is handed a form until that form's callback releases it. */
+    @Volatile
+    private var nativeFormHandoff: FormHandoff? = null
 
     /** Serializes the info-update / form sequences that may legitimately wait for each other. */
     private val operationMutex = Mutex()
+
+    private class FormHandoff(val generation: Long, val markedAt: TimeMark)
 
     /**
      * Claims the newest generation. Every consent entry point calls this once, up front —
@@ -50,6 +71,29 @@ internal class ConsentOperationCoordinator {
     fun isCurrentOperation(generation: Long): Boolean = generation == currentGeneration
 
     /**
+     * Records that UMP now owns a form on screen, on behalf of [generation].
+     *
+     * MUST be called immediately before the native present call and nowhere else: this is the
+     * irreversible boundary, the consent-form counterpart of `GoogleAdManagerBase`'s
+     * `markHandoff`. Past it, a cancelled or dead waiter no longer means "no form on screen",
+     * so the slot cannot be inferred free from the coroutine's fate.
+     */
+    fun markFormPresented(generation: Long) {
+        nativeFormHandoff = FormHandoff(generation, timeSource.markNow())
+    }
+
+    /**
+     * Releases the form [generation] presented, if it is still the one on screen.
+     *
+     * Generation-matched so a superseded form's late callback cannot free a newer form's slot.
+     * Call it from the native form callback — which runs whether or not the waiter survived —
+     * not from the calling coroutine, which may already be gone.
+     */
+    fun releaseFormPresentation(generation: Long) {
+        if (nativeFormHandoff?.generation == generation) nativeFormHandoff = null
+    }
+
+    /**
      * Runs [block] with no other coordinated consent operation in flight, waiting if one is.
      *
      * For the info-update and consent-gathering paths, where a caller waiting a moment is
@@ -58,8 +102,14 @@ internal class ConsentOperationCoordinator {
     suspend fun <T> serialized(block: suspend () -> T): T = operationMutex.withLock { block() }
 
     /**
-     * Declines ONLY when a UMP form is already on screen -- two forms cannot stack. Anything else
-     * holding the slot is a bounded, non-interactive operation (a consent info update, at most
+     * Declines when a form-presenting operation holds the slot -- two forms cannot stack. The slot
+     * is claimed by [presentsForm] on entry, NOT at the moment UMP puts a form on screen, so the
+     * decline window opens while a gatherConsent is still awaiting a host and running its bounded
+     * info update. That is deliberate: freeing the slot for that window would let a second caller
+     * reach markFormPresented first and race two presentations.
+     *
+     * An operation that does not present a form never claims the slot (presentsForm = false: a
+     * consent info update, at most
      * InitializationTimeouts.consentInfoUpdate), and ordering behind it is not a reason to fail:
      * the app UI stays interactive during that window, so a user who opens Settings during the
      * launch-time refresh must get the form, not "unavailable". Callers surface the false return
@@ -71,16 +121,42 @@ internal class ConsentOperationCoordinator {
         onFormPresenting: () -> T,
         block: suspend () -> T,
     ): T {
-        if (presentingForm) return onFormPresenting()
+        if (formIsLive()) return onFormPresenting()
         return operationMutex.withLock {
-            // No second check: presentingForm is only ever set inside this lock and restored in
-            // the finally below, so holding the lock already proves it is false here.
-            if (presentsForm) presentingForm = true
+            // The second check is REQUIRED: a cancelled operation releases this mutex while UMP
+            // is still presenting its form, so holding the lock no longer proves the screen is
+            // free. A waiter that queued behind such an operation must decline here rather than
+            // present a second form over the first.
+            if (liveHandoffOrNull() != null) return@withLock onFormPresenting()
+            if (presentsForm) slotHoldsForm = true
             try {
                 block()
             } finally {
-                presentingForm = false
+                // Only the slot fact unwinds with the coroutine. A handoff already made to UMP
+                // survives it and is released by the form's own callback.
+                slotHoldsForm = false
             }
         }
+    }
+
+    private fun formIsLive(): Boolean = slotHoldsForm || liveHandoffOrNull() != null
+
+    /**
+     * The handoff still believed to be on screen, or null once it has expired.
+     *
+     * UMP invoking a form callback is what normally frees the slot. Bounding the wait anyway is
+     * the same reasoning [InitializationTimeouts.formPresentationPin] carries: a callback that
+     * never arrives must not decline every consent operation for the rest of the process.
+     */
+    private fun liveHandoffOrNull(): FormHandoff? {
+        val handoff = nativeFormHandoff ?: return null
+        if (handoff.markedAt.elapsedNow() < InitializationTimeouts.formPresentationPin) return handoff
+        AdLogger.w(
+            "A UMP consent form was presented over ${InitializationTimeouts.formPresentationPin} ago " +
+                "and never reported back. Releasing the consent form slot; if that form is still on " +
+                "screen, a further consent operation may be refused by UMP itself."
+        )
+        nativeFormHandoff = null
+        return null
     }
 }

--- a/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/ConsentReconciliation.kt
+++ b/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/ConsentReconciliation.kt
@@ -16,6 +16,12 @@ import kotlinx.coroutines.CancellableContinuation
  * (navigation, rotation, process death). [reconcile] is exactly that state and must always
  * run. Only *resuming the waiter* is conditional: resuming an inactive continuation is a
  * no-op at best and an `IllegalStateException` at worst.
+ *
+ * The `isActive` check is an OPTIMIZATION, not a correctness mechanism.
+ * `CancellableContinuation` already resolves cancellation-versus-resume atomically, and
+ * resuming a cancelled continuation is a no-op. The check is kept because it makes the intent
+ * ("the waiter may be gone; the state must not be") obvious at the call site. Do not read it
+ * as the thing that makes this safe — [reconcile] running first is.
  */
 internal inline fun <T> reconcileThenResumeIfActive(
     continuation: CancellableContinuation<T>,

--- a/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/ConsentStateHolder.kt
+++ b/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/ConsentStateHolder.kt
@@ -2,6 +2,7 @@ package dev.avinya.ads.internal
 
 import dev.avinya.ads.ConsentStatus
 import dev.avinya.ads.PrivacyOptionsRequirementStatus
+import kotlin.time.TimeSource
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -20,20 +21,24 @@ import kotlinx.coroutines.flow.asStateFlow
  * UMP delivers its callbacks on the main thread on both platforms, so these writes are
  * main-confined.
  *
- * **Accepted limitation:** Cancelling `gatherConsent` while the UMP form is on screen releases the
- * coordinator slot even though UMP still owns the form; a newer operation can then suppress the
- * form's eventual status. This self-heals (`canRequestAds` still reconciles unconditionally, and the
- * newer operation republishes from the UMP singleton), and holding the slot across a cancelled,
- * unbounded form risks a permanent lock — a strictly worse failure.
+ * **Form ownership outlives the caller.** Cancelling `gatherConsent` or `showPrivacyOptions` does
+ * not dismiss the form the user is looking at, so the slot stays pinned to it — see
+ * [ConsentOperationCoordinator.markFormPresented]. Nothing else touches UMP until that form's own
+ * callback releases the pin, which it does whether or not the original waiter survived.
+ *
+ * **Accepted limitation:** a UMP form callback that never fires at all strands the pin, and every
+ * consent operation is refused until [InitializationTimeouts.formPresentationPin] expires. That
+ * window is the deliberate trade: an unbounded pin would refuse them for the life of the process,
+ * and no pin at all would let a reset run `UMPConsentInformation.reset()` under a live form.
  */
-internal class ConsentStateHolder {
+internal class ConsentStateHolder(timeSource: TimeSource = TimeSource.Monotonic) {
 
     private val _status = MutableStateFlow<ConsentStatus>(ConsentStatus.Unknown)
     private val _privacyOptionsRequirementStatus =
         MutableStateFlow(PrivacyOptionsRequirementStatus.Unknown)
     private val _canRequestAds = MutableStateFlow(false)
 
-    private val coordinator = ConsentOperationCoordinator()
+    private val coordinator = ConsentOperationCoordinator(timeSource)
 
     val status: StateFlow<ConsentStatus> = _status.asStateFlow()
     val privacyOptionsRequirementStatus: StateFlow<PrivacyOptionsRequirementStatus> =
@@ -49,6 +54,12 @@ internal class ConsentStateHolder {
         onFormPresenting: () -> T,
         block: suspend () -> T,
     ): T = coordinator.exclusiveOfForms(presentsForm, onFormPresenting, block)
+
+    /** See [ConsentOperationCoordinator.markFormPresented]. */
+    fun markFormPresented(generation: Long): Unit = coordinator.markFormPresented(generation)
+
+    /** See [ConsentOperationCoordinator.releaseFormPresentation]. */
+    fun releaseFormPresentation(generation: Long): Unit = coordinator.releaseFormPresentation(generation)
 
     /**
      * Reconciles authoritative privacy truth unconditionally and publishes [status] if [generation]

--- a/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/ConsentStateHolder.kt
+++ b/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/ConsentStateHolder.kt
@@ -1,0 +1,91 @@
+package dev.avinya.ads.internal
+
+import dev.avinya.ads.ConsentStatus
+import dev.avinya.ads.PrivacyOptionsRequirementStatus
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Single shared owner of consent state across Android and iOS.
+ *
+ * The mutable flows are private and there is deliberately no reconcile-only entry point.
+ * [reconcileAndPublish] is the ONLY way a native callback can update this state, so a platform
+ * cannot refresh privacy truth while silently skipping the status — which is exactly how the two
+ * controllers diverged when each owned its own copy of these helpers. Synthesized statuses that
+ * have no callback behind them (a wrapper timeout, an unavailable host) go through
+ * [publishOperationStatus]; there is no third way in.
+ *
+ * **Threading:** every consent entry point already runs on `Dispatchers.Main.immediate`, and
+ * UMP delivers its callbacks on the main thread on both platforms, so these writes are
+ * main-confined.
+ *
+ * **Accepted limitation:** Cancelling `gatherConsent` while the UMP form is on screen releases the
+ * coordinator slot even though UMP still owns the form; a newer operation can then suppress the
+ * form's eventual status. This self-heals (`canRequestAds` still reconciles unconditionally, and the
+ * newer operation republishes from the UMP singleton), and holding the slot across a cancelled,
+ * unbounded form risks a permanent lock — a strictly worse failure.
+ */
+internal class ConsentStateHolder {
+
+    private val _status = MutableStateFlow<ConsentStatus>(ConsentStatus.Unknown)
+    private val _privacyOptionsRequirementStatus =
+        MutableStateFlow(PrivacyOptionsRequirementStatus.Unknown)
+    private val _canRequestAds = MutableStateFlow(false)
+
+    private val coordinator = ConsentOperationCoordinator()
+
+    val status: StateFlow<ConsentStatus> = _status.asStateFlow()
+    val privacyOptionsRequirementStatus: StateFlow<PrivacyOptionsRequirementStatus> =
+        _privacyOptionsRequirementStatus.asStateFlow()
+    val canRequestAds: StateFlow<Boolean> = _canRequestAds.asStateFlow()
+
+    fun beginOperation(): Long = coordinator.beginOperation()
+
+    suspend fun <T> serialized(block: suspend () -> T): T = coordinator.serialized(block)
+
+    suspend fun <T> exclusiveOfForms(
+        presentsForm: Boolean,
+        onFormPresenting: () -> T,
+        block: suspend () -> T,
+    ): T = coordinator.exclusiveOfForms(presentsForm, onFormPresenting, block)
+
+    /**
+     * Reconciles authoritative privacy truth unconditionally and publishes [status] if [generation]
+     * is still the current operation. Returns the resulting [status] value.
+     */
+    fun reconcileAndPublish(
+        generation: Long,
+        privacyRequirement: PrivacyOptionsRequirementStatus,
+        canRequestAds: Boolean,
+        status: ConsentStatus,
+    ): ConsentStatus {
+        _privacyOptionsRequirementStatus.value = privacyRequirement
+        _canRequestAds.value = canRequestAds
+        if (coordinator.isCurrentOperation(generation)) {
+            _status.value = status
+        }
+        return _status.value
+    }
+
+    /**
+     * Publishes a synthesized status (e.g. timeout or missing host) under the generation gate.
+     * Returns the [status] passed in.
+     */
+    fun publishOperationStatus(generation: Long, status: ConsentStatus): ConsentStatus {
+        if (coordinator.isCurrentOperation(generation)) {
+            _status.value = status
+        }
+        return status
+    }
+
+    /**
+     * Invalidates all outstanding operations by claiming a new generation, and clears all three flows.
+     */
+    fun reset() {
+        coordinator.beginOperation()
+        _status.value = ConsentStatus.Unknown
+        _privacyOptionsRequirementStatus.value = PrivacyOptionsRequirementStatus.Unknown
+        _canRequestAds.value = false
+    }
+}

--- a/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/NativeCallbackTimeouts.kt
+++ b/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/NativeCallbackTimeouts.kt
@@ -2,6 +2,7 @@ package dev.avinya.ads.internal
 
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.withTimeoutOrNull
 
@@ -15,7 +16,8 @@ import kotlinx.coroutines.withTimeoutOrNull
  * Only *non-interactive* operations belong here. Anything that presents UI and waits for a person —
  * the UMP consent form, the privacy options form, the ad inspector — must stay unbounded, with
  * caller cancellation as its escape hatch. Timing out a form the user is still reading would be a
- * bug, not a safeguard.
+ * bug, not a safeguard. [formPresentationPin] is not an exception to that rule: it bounds how long
+ * the wrapper keeps BELIEVING a form is on screen, never the form itself.
  */
 internal object InitializationTimeouts {
     /** Native `MobileAds.initialize` / `GADMobileAds.start`. */
@@ -52,6 +54,19 @@ internal object InitializationTimeouts {
      * simply never fire in some states, and an unbounded wait here blocks initialize().
      */
     val attPrompt: Duration = 60.seconds
+
+    /**
+     * How long the consent-form slot stays pinned to a form UMP was handed but never reported
+     * back on.
+     *
+     * The form itself is not timed out — a person is reading it, and cancelling their caller does
+     * not dismiss it, which is exactly why the pin outlives the coroutine. What is bounded is the
+     * wrapper's belief. Five minutes because a user reading a consent notice and choosing vendors
+     * is comfortably inside it, while past it the app has almost certainly been backgrounded or
+     * the callback is never coming — and refusing every consent operation for the rest of the
+     * process is a worse outcome than the overlapping form the pin exists to prevent.
+     */
+    val formPresentationPin: Duration = 5.minutes
 }
 
 /**

--- a/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/AppIdPreflightTest.kt
+++ b/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/AppIdPreflightTest.kt
@@ -1,0 +1,160 @@
+package dev.avinya.ads
+
+import dev.avinya.ads.internal.AppIdVerdict
+import dev.avinya.ads.internal.DeclaredAppId
+import dev.avinya.ads.internal.appIdVerdict
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class AppIdPreflightTest {
+
+    private val configured = "ca-app-pub-1111111111111111"
+    private val source = "Info.plist key \"GADApplicationIdentifier\""
+    private val consumer = "The native Google Mobile Ads SDK resolves its application identity."
+
+    @AfterTest
+    fun restoreDefaultPolicy() {
+        AdAppIdVerification.policy = AppIdVerificationPolicy.FailWhenUnusable
+    }
+
+    private fun verdict(
+        declared: DeclaredAppId,
+        requiredByPlatformSdk: Boolean,
+        policy: AppIdVerificationPolicy = AppIdVerificationPolicy.FailWhenUnusable,
+    ) = appIdVerdict(
+        configuredAppId = configured,
+        declared = declared,
+        declaredAppIdSource = source,
+        declaredAppIdConsumerDescription = consumer,
+        requiredByPlatformSdk = requiredByPlatformSdk,
+        policy = policy,
+    )
+
+    @Test
+    fun `a matching declaration is silent under every policy`() {
+        AppIdVerificationPolicy.entries.forEach { policy ->
+            assertEquals(
+                AppIdVerdict.Ok,
+                verdict(DeclaredAppId.Present(configured), requiredByPlatformSdk = true, policy = policy),
+                "a correct configuration must never be reported under $policy",
+            )
+        }
+    }
+
+    @Test
+    fun `an unreadable declaration is never reported under any policy`() {
+        // DeclaredAppId.Unknown means the READ failed, which is not evidence of
+        // misconfiguration -- turning it into a failure would break test environments and
+        // restricted bundles for no correctness gain.
+        AppIdVerificationPolicy.entries.forEach { policy ->
+            assertEquals(
+                AppIdVerdict.Ok,
+                verdict(DeclaredAppId.Unknown, requiredByPlatformSdk = true, policy = policy),
+            )
+        }
+    }
+
+    @Test
+    fun `a missing declaration the platform SDK needs fails by default`() {
+        // iOS: GADMobileAds resolves its app ID from the plist, so there is nothing to serve
+        // ads with. Failing here turns an opaque native failure into a typed status.
+        val fail = assertIs<AppIdVerdict.Fail>(verdict(DeclaredAppId.Missing, requiredByPlatformSdk = true))
+        assertTrue(fail.message.contains(source))
+        assertTrue("ca-app-pub-1111111111111111" !in fail.message, "IDs stay redacted")
+    }
+
+    @Test
+    fun `a missing declaration the platform SDK does not need only warns by default`() {
+        // Android: the manifest value is UMP's, and GMA Next-Gen initializes from AdConfig.
+        // Apps that ship this way serve ads today; a minor release must not break them.
+        assertIs<AppIdVerdict.Warn>(verdict(DeclaredAppId.Missing, requiredByPlatformSdk = false))
+    }
+
+    @Test
+    fun `a mismatch only warns by default on both platforms`() {
+        val declared = DeclaredAppId.Present("ca-app-pub-2222222222222222")
+        assertIs<AppIdVerdict.Warn>(verdict(declared, requiredByPlatformSdk = true))
+        assertIs<AppIdVerdict.Warn>(verdict(declared, requiredByPlatformSdk = false))
+    }
+
+    @Test
+    fun `strict promotes every finding to a failure`() {
+        val strict = AppIdVerificationPolicy.Strict
+        assertIs<AppIdVerdict.Fail>(verdict(DeclaredAppId.Missing, false, strict))
+        assertIs<AppIdVerdict.Fail>(
+            verdict(DeclaredAppId.Present("ca-app-pub-2222222222222222"), false, strict),
+        )
+    }
+
+    @Test
+    fun `warnOnly demotes even an unusable declaration to a warning`() {
+        // The escape hatch: a consumer hitting a false Missing must not be locked out.
+        assertIs<AppIdVerdict.Warn>(
+            verdict(DeclaredAppId.Missing, requiredByPlatformSdk = true, policy = AppIdVerificationPolicy.WarnOnly),
+        )
+    }
+
+    @Test
+    fun `the default policy fails only what the platform cannot use`() {
+        assertEquals(AppIdVerificationPolicy.FailWhenUnusable, AdAppIdVerification.policy)
+    }
+
+    @Test
+    fun `a fatal preflight fails before consent and before any native call`() = runSlotTest {
+        AdAppIdVerification.policy = AppIdVerificationPolicy.FailWhenUnusable
+        val manager = FakeGoogleAdManager(requiresDeclaredAppId = true).apply {
+            declared = DeclaredAppIdForTest.Missing
+        }
+
+        val status = manager.initialize(
+            AdConfig(androidAppId = "ca-app-pub-A", iosAppId = "ca-app-pub-A"),
+            ConsentMode.GatherBeforeInitialize,
+        )
+
+        val failed = assertIs<AdManagerStatus.Failed>(status)
+        assertTrue(!failed.retryable, "the configuration must change; retrying cannot help")
+        assertTrue(
+            manager.nativeHandoffs.isEmpty(),
+            "a deterministic configuration failure must never reach the native SDK",
+        )
+    }
+
+    @Test
+    fun `a warning-level finding still initializes`() = runSlotTest {
+        AdAppIdVerification.policy = AppIdVerificationPolicy.FailWhenUnusable
+        val manager = FakeGoogleAdManager(requiresDeclaredAppId = false).apply {
+            declared = DeclaredAppIdForTest.Mismatched
+        }
+
+        val status = manager.initialize(
+            AdConfig(androidAppId = "ca-app-pub-A", iosAppId = "ca-app-pub-A"),
+            ConsentMode.SkipConsent,
+        )
+
+        // A mismatch is a misconfiguration, not an outage. Breaking a shipping app over it in a
+        // minor release is a worse failure than the mismatch.
+        assertEquals(AdManagerStatus.Ready, status)
+    }
+
+    @Test
+    fun `a fatal preflight is distinguishable from an initialization conflict`() = runSlotTest {
+        AdAppIdVerification.policy = AppIdVerificationPolicy.FailWhenUnusable
+        val manager = FakeGoogleAdManager(requiresDeclaredAppId = true).apply {
+            declared = DeclaredAppIdForTest.Missing
+        }
+
+        val status = manager.initialize(
+            AdConfig(androidAppId = "ca-app-pub-A", iosAppId = "ca-app-pub-A"),
+            ConsentMode.SkipConsent,
+        )
+
+        // The two failures have opposite remediations -- "restart the process and call initialize()
+        // once" versus "fix the app bundle and rebuild" -- so a host must be able to tell them apart.
+        val failed = assertIs<AdManagerStatus.Failed>(status)
+        assertEquals(AdErrorCode.APP_ID_INVALID, failed.error.code)
+    }
+}
+

--- a/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/AppIdPreflightTest.kt
+++ b/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/AppIdPreflightTest.kt
@@ -74,6 +74,29 @@ class AppIdPreflightTest {
     }
 
     @Test
+    fun `a blank declaration is unusable rather than a mismatch`() {
+        // A build setting that resolved to empty leaves <string></string> in the plist. GADMobileAds
+        // can no more resolve an app from that than from an absent key, so the default policy must
+        // fail rather than warn its way into a native crash.
+        listOf("", "   ").forEach { blank ->
+            val fail = assertIs<AppIdVerdict.Fail>(
+                verdict(DeclaredAppId.Present(blank), requiredByPlatformSdk = true),
+                "a blank declaration must fail like a missing one",
+            )
+            assertTrue(
+                fail.message.contains("has no value set"),
+                "a blank value is a configuration gap, not a mismatch against an empty id",
+            )
+        }
+    }
+
+    @Test
+    fun `a blank declaration the platform SDK does not need only warns by default`() {
+        // Android keeps the missing-declaration severity: GMA Next-Gen initializes from AdConfig.
+        assertIs<AppIdVerdict.Warn>(verdict(DeclaredAppId.Present(""), requiredByPlatformSdk = false))
+    }
+
+    @Test
     fun `a mismatch only warns by default on both platforms`() {
         val declared = DeclaredAppId.Present("ca-app-pub-2222222222222222")
         assertIs<AppIdVerdict.Warn>(verdict(declared, requiredByPlatformSdk = true))
@@ -123,6 +146,26 @@ class AppIdPreflightTest {
     }
 
     @Test
+    fun `a blank declaration fails the preflight like a missing one`() = runSlotTest {
+        AdAppIdVerification.policy = AppIdVerificationPolicy.FailWhenUnusable
+        val manager = FakeGoogleAdManager(requiresDeclaredAppId = true).apply {
+            declared = DeclaredAppIdForTest.Blank
+        }
+
+        val status = manager.initialize(
+            AdConfig(androidAppId = "ca-app-pub-A", iosAppId = "ca-app-pub-A"),
+            ConsentMode.SkipConsent,
+        )
+
+        val failed = assertIs<AdManagerStatus.Failed>(status)
+        assertEquals(AdErrorCode.APP_ID_INVALID, failed.error.code)
+        assertTrue(
+            manager.nativeHandoffs.isEmpty(),
+            "a blank declaration must never reach the native SDK",
+        )
+    }
+
+    @Test
     fun `a warning-level finding still initializes`() = runSlotTest {
         AdAppIdVerification.policy = AppIdVerificationPolicy.FailWhenUnusable
         val manager = FakeGoogleAdManager(requiresDeclaredAppId = false).apply {
@@ -157,4 +200,3 @@ class AppIdPreflightTest {
         assertEquals(AdErrorCode.APP_ID_INVALID, failed.error.code)
     }
 }
-

--- a/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/AppIdVerificationTest.kt
+++ b/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/AppIdVerificationTest.kt
@@ -3,6 +3,7 @@ package dev.avinya.ads
 import dev.avinya.ads.internal.DeclaredAppId
 import dev.avinya.ads.internal.appIdConfigurationWarningOrNull
 import kotlin.test.Test
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -72,5 +73,21 @@ class AppIdVerificationTest {
         )
 
         assertNull(warning)
+    }
+
+    @Test
+    fun `a blank declared value reads as a configuration gap`() {
+        // Present("") would otherwise print "does not match ... (…)" with an empty redacted id,
+        // which describes neither the problem nor its fix.
+        val warning = appIdConfigurationWarningOrNull(
+            configuredAppId = "ca-app-pub-1111111111111111",
+            declared = DeclaredAppId.Present(""),
+            declaredAppIdSource = source,
+            declaredAppIdConsumerDescription = consumer,
+        )
+
+        assertNotNull(warning)
+        assertTrue(warning.contains("has no value set"), "a blank value is the missing-value message")
+        assertTrue("does not match" !in warning, "a blank value must not be reported as a mismatch")
     }
 }

--- a/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/AppliedConfigurationDecisionTest.kt
+++ b/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/AppliedConfigurationDecisionTest.kt
@@ -1,7 +1,9 @@
 package dev.avinya.ads
 
 import dev.avinya.ads.internal.AppliedConfigurationDecision
+import dev.avinya.ads.internal.NativeHandoffDecision
 import dev.avinya.ads.internal.appliedConfigurationDecision
+import dev.avinya.ads.internal.nativeHandoffDecision
 import dev.avinya.ads.nativead.NativeAdMemoryPolicy
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -141,5 +143,47 @@ class AppliedConfigurationDecisionTest {
             )
         )
         assertEquals(true, global.reason.contains("global request configuration"))
+    }
+
+    // --- native handoff ownership -----------------------------------------------------------
+
+    private fun identity(appId: String) = AdInitializationConfigIdentity(
+        platformAppId = appId,
+        globalRequestConfiguration = GlobalRequestConfiguration(),
+    )
+
+    @Test
+    fun `no handoff yet permits initialization`() {
+        assertEquals(
+            NativeHandoffDecision.Proceed,
+            nativeHandoffDecision(handedOffIdentity = null, requestedIdentity = identity("A")),
+        )
+    }
+
+    @Test
+    fun `a same-identity retry after a timed-out handoff is permitted`() {
+        // The load-bearing case for a real GMA hang: the wrapper timed out, nothing was
+        // committed, and retrying the SAME configuration is the documented next step.
+        assertEquals(
+            NativeHandoffDecision.Proceed,
+            nativeHandoffDecision(handedOffIdentity = identity("A"), requestedIdentity = identity("A")),
+        )
+    }
+
+    @Test
+    fun `a different-identity retry after a handoff is refused not silently accepted`() {
+        val decision = nativeHandoffDecision(
+            handedOffIdentity = identity("A"),
+            requestedIdentity = identity("B"),
+        )
+
+        // Pins the invariant: a timeout releases the WAITER; it cannot undo an irreversible
+        // native handoff, so the wrapper must never let a second configuration claim ownership.
+        val refuse = assertIs<NativeHandoffDecision.Refuse>(decision)
+        assertEquals(AdErrorCode.INITIALIZATION_CONFLICT, refuse.rejection.error.code)
+        assertFalse(
+            refuse.rejection.retryable,
+            "the native singleton cannot be reconfigured, so retrying cannot help",
+        )
     }
 }

--- a/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/ConsentOperationCoordinatorTest.kt
+++ b/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/ConsentOperationCoordinatorTest.kt
@@ -1,0 +1,171 @@
+package dev.avinya.ads
+
+import dev.avinya.ads.internal.ConsentOperationCoordinator
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ConsentOperationCoordinatorTest {
+
+    @Test
+    fun `the newest operation is the current one`() {
+        val coordinator = ConsentOperationCoordinator()
+        val first = coordinator.beginOperation()
+        assertTrue(coordinator.isCurrentOperation(first))
+
+        val second = coordinator.beginOperation()
+        assertFalse(
+            coordinator.isCurrentOperation(first),
+            "a superseded operation must not be allowed to publish its status",
+        )
+        assertTrue(coordinator.isCurrentOperation(second))
+    }
+
+    @Test
+    fun `generations are never reused`() {
+        val coordinator = ConsentOperationCoordinator()
+        val seen = (1..50).map { coordinator.beginOperation() }
+        assertEquals(seen.size, seen.toSet().size, "generations must be monotonic and unique")
+    }
+
+    @Test
+    fun `serialized runs one block at a time`() = runTest {
+        val coordinator = ConsentOperationCoordinator()
+        val order = mutableListOf<String>()
+        val firstEntered = CompletableDeferred<Unit>()
+        val releaseFirst = CompletableDeferred<Unit>()
+
+        val first = launch {
+            coordinator.serialized {
+                order += "first-in"
+                firstEntered.complete(Unit)
+                releaseFirst.await()
+                order += "first-out"
+            }
+        }
+        firstEntered.await()
+        val second = launch { coordinator.serialized { order += "second-in" } }
+        advanceUntilIdle()
+
+        assertEquals(listOf("first-in"), order, "the second block must not overlap the first")
+        releaseFirst.complete(Unit)
+        first.join()
+        second.join()
+        assertEquals(listOf("first-in", "first-out", "second-in"), order)
+    }
+
+    @Test
+    fun `exclusiveOfForms declines when a form is presenting`() = runTest {
+        val coordinator = ConsentOperationCoordinator()
+        val firstEntered = CompletableDeferred<Unit>()
+        val releaseFirst = CompletableDeferred<Unit>()
+        var secondRan = false
+
+        val first = launch {
+            coordinator.exclusiveOfForms(presentsForm = true, onFormPresenting = { false }) {
+                firstEntered.complete(Unit)
+                releaseFirst.await()
+                true
+            }
+        }
+        firstEntered.await()
+
+        // A user double-tapping "Privacy options" must NOT be shown the form twice in a row.
+        val declined = coordinator.exclusiveOfForms(presentsForm = true, onFormPresenting = { false }) {
+            secondRan = true
+            true
+        }
+
+        assertFalse(declined, "an overlapping form presentation must decline")
+        assertFalse(secondRan, "the declined path must not run the block")
+        releaseFirst.complete(Unit)
+        first.join()
+    }
+
+    @Test
+    fun `exclusiveOfForms waits for a non-form operation and then runs`() = runTest {
+        val coordinator = ConsentOperationCoordinator()
+        val order = mutableListOf<String>()
+        val nonFormEntered = CompletableDeferred<Unit>()
+        val releaseNonForm = CompletableDeferred<Unit>()
+
+        val nonForm = launch {
+            coordinator.serialized {
+                order += "non-form-in"
+                nonFormEntered.complete(Unit)
+                releaseNonForm.await()
+                order += "non-form-out"
+            }
+        }
+        nonFormEntered.await()
+
+        val form = launch {
+            val ran = coordinator.exclusiveOfForms(presentsForm = true, onFormPresenting = { false }) {
+                order += "form-ran"
+                true
+            }
+            assertTrue(ran, "form must run after non-form operation finishes")
+        }
+        advanceUntilIdle()
+
+        assertEquals(listOf("non-form-in"), order, "form must wait for non-form operation rather than declining")
+        releaseNonForm.complete(Unit)
+        nonForm.join()
+        form.join()
+        assertEquals(listOf("non-form-in", "non-form-out", "form-ran"), order)
+    }
+
+    @Test
+    fun `exclusiveOfForms restores the form flag after normal completion`() = runTest {
+        val coordinator = ConsentOperationCoordinator()
+        assertTrue(coordinator.exclusiveOfForms(presentsForm = true, onFormPresenting = { false }) { true })
+        assertTrue(
+            coordinator.exclusiveOfForms(presentsForm = true, onFormPresenting = { false }) { true },
+            "a completed form operation must not leave the form flag stuck",
+        )
+    }
+
+    @Test
+    fun `exclusiveOfForms restores the form flag after a throw`() = runTest {
+        val coordinator = ConsentOperationCoordinator()
+        runCatching {
+            coordinator.exclusiveOfForms(presentsForm = true, onFormPresenting = { false }) {
+                error("form blew up")
+            }
+        }
+        assertTrue(
+            coordinator.exclusiveOfForms(presentsForm = true, onFormPresenting = { false }) { true },
+            "a throwing form operation must restore the form flag",
+        )
+    }
+
+    @Test
+    fun `exclusiveOfForms restores the form flag after cancellation`() = runTest {
+        val coordinator = ConsentOperationCoordinator()
+        val formEntered = CompletableDeferred<Unit>()
+        val neverRelease = CompletableDeferred<Unit>()
+
+        val job = launch {
+            coordinator.exclusiveOfForms(presentsForm = true, onFormPresenting = { false }) {
+                formEntered.complete(Unit)
+                neverRelease.await()
+                true
+            }
+        }
+        formEntered.await()
+        job.cancelAndJoin()
+
+        assertTrue(
+            coordinator.exclusiveOfForms(presentsForm = true, onFormPresenting = { false }) { true },
+            "cancellation must restore the form flag and unlock the mutex",
+        )
+    }
+}

--- a/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/ConsentOperationCoordinatorTest.kt
+++ b/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/ConsentOperationCoordinatorTest.kt
@@ -1,10 +1,14 @@
 package dev.avinya.ads
 
 import dev.avinya.ads.internal.ConsentOperationCoordinator
+import dev.avinya.ads.internal.InitializationTimeouts
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.ExperimentalTime
+import kotlin.time.TestTimeSource
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancelAndJoin
@@ -12,7 +16,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 
-@OptIn(ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalTime::class)
 class ConsentOperationCoordinatorTest {
 
     @Test
@@ -68,6 +72,7 @@ class ConsentOperationCoordinatorTest {
         val firstEntered = CompletableDeferred<Unit>()
         val releaseFirst = CompletableDeferred<Unit>()
         var secondRan = false
+        var retainedConfig = "accepted-config"
 
         val first = launch {
             coordinator.exclusiveOfForms(presentsForm = true, onFormPresenting = { false }) {
@@ -81,11 +86,17 @@ class ConsentOperationCoordinatorTest {
         // A user double-tapping "Privacy options" must NOT be shown the form twice in a row.
         val declined = coordinator.exclusiveOfForms(presentsForm = true, onFormPresenting = { false }) {
             secondRan = true
+            retainedConfig = "rejected-config"
             true
         }
 
         assertFalse(declined, "an overlapping form presentation must decline")
         assertFalse(secondRan, "the declined path must not run the block")
+        assertEquals(
+            "accepted-config",
+            retainedConfig,
+            "a declined form must not execute admitted config preparation",
+        )
         releaseFirst.complete(Unit)
         first.join()
     }
@@ -148,11 +159,13 @@ class ConsentOperationCoordinatorTest {
     }
 
     @Test
-    fun `exclusiveOfForms restores the form flag after cancellation`() = runTest {
+    fun `cancellation before the native boundary restores the form flag`() = runTest {
         val coordinator = ConsentOperationCoordinator()
         val formEntered = CompletableDeferred<Unit>()
         val neverRelease = CompletableDeferred<Unit>()
 
+        // No markFormPresented: this operation died while still waiting for a host, so UMP was
+        // never handed anything and nothing is on screen to protect.
         val job = launch {
             coordinator.exclusiveOfForms(presentsForm = true, onFormPresenting = { false }) {
                 formEntered.complete(Unit)
@@ -165,7 +178,75 @@ class ConsentOperationCoordinatorTest {
 
         assertTrue(
             coordinator.exclusiveOfForms(presentsForm = true, onFormPresenting = { false }) { true },
-            "cancellation must restore the form flag and unlock the mutex",
+            "cancellation short of the native boundary must restore the form flag and unlock the mutex",
+        )
+    }
+
+    @Test
+    fun `a cancelled caller keeps the form pinned until its callback releases it`() = runTest {
+        val coordinator = ConsentOperationCoordinator()
+        val formEntered = CompletableDeferred<Unit>()
+        val neverRelease = CompletableDeferred<Unit>()
+        var generation = 0L
+
+        val job = launch {
+            coordinator.exclusiveOfForms(presentsForm = true, onFormPresenting = { false }) {
+                generation = coordinator.beginOperation()
+                coordinator.markFormPresented(generation)
+                formEntered.complete(Unit)
+                neverRelease.await()
+                true
+            }
+        }
+        formEntered.await()
+        // Navigation, rotation, a dead viewModelScope: the waiter dies, the form does not.
+        job.cancelAndJoin()
+
+        assertFalse(
+            coordinator.exclusiveOfForms(presentsForm = true, onFormPresenting = { false }) { true },
+            "a cancelled caller must not free a form UMP is still presenting",
+        )
+
+        // UMP finally reports back, which is the only thing that means the screen is free.
+        coordinator.releaseFormPresentation(generation)
+
+        assertTrue(
+            coordinator.exclusiveOfForms(presentsForm = true, onFormPresenting = { false }) { true },
+            "the form callback must free the slot",
+        )
+    }
+
+    @Test
+    fun `a superseded generation cannot release a newer form pin`() = runTest {
+        val coordinator = ConsentOperationCoordinator()
+        val stale = coordinator.beginOperation()
+        val current = coordinator.beginOperation()
+        coordinator.markFormPresented(current)
+
+        coordinator.releaseFormPresentation(stale)
+
+        assertFalse(
+            coordinator.exclusiveOfForms(presentsForm = true, onFormPresenting = { false }) { true },
+            "a superseded form's late callback must not free the form on screen",
+        )
+    }
+
+    @Test
+    fun `a stranded form pin expires at the backstop instead of declining forever`() = runTest {
+        val timeSource = TestTimeSource()
+        val coordinator = ConsentOperationCoordinator(timeSource)
+        coordinator.markFormPresented(coordinator.beginOperation())
+
+        timeSource += InitializationTimeouts.formPresentationPin - 1.seconds
+        assertFalse(
+            coordinator.exclusiveOfForms(presentsForm = true, onFormPresenting = { false }) { true },
+            "the pin must hold for the whole backstop window",
+        )
+
+        timeSource += 1.seconds
+        assertTrue(
+            coordinator.exclusiveOfForms(presentsForm = true, onFormPresenting = { false }) { true },
+            "a callback that never arrives must not decline consent forms for the life of the process",
         )
     }
 }

--- a/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/ConsentStateHolderTest.kt
+++ b/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/ConsentStateHolderTest.kt
@@ -242,7 +242,7 @@ class ConsentStateHolderTest {
     }
 
     @Test
-    fun `exclusiveOfForms restores the form flag after cancellation`() = runTest {
+    fun `cancellation before the native boundary restores the form flag`() = runTest {
         val holder = ConsentStateHolder()
         val formEntered = CompletableDeferred<Unit>()
         val neverRelease = CompletableDeferred<Unit>()
@@ -259,22 +259,58 @@ class ConsentStateHolderTest {
 
         assertTrue(
             holder.exclusiveOfForms(presentsForm = true, onFormPresenting = { false }) { true },
-            "cancellation must restore the form flag and unlock the mutex",
+            "cancellation short of the native boundary must restore the form flag and unlock the mutex",
         )
     }
 
     /**
-     * Accepted limitation (see plan): Cancelling gatherConsent while the UMP form is on screen
-     * releases the coordinator slot even though UMP still owns the form; a newer operation can then
-     * suppress the form's eventual status. This self-heals (canRequestAds still reconciles unconditionally,
-     * and the newer operation republishes from the UMP singleton), and holding the slot across a
-     * cancelled, unbounded form risks a permanent lock — a strictly worse failure.
-     *
-     * This test pins that after beginOperation() twice the older generation can still reconcile
-     * privacy truth, but cannot publish its status over the newer operation.
+     * Cancelling gatherConsent does not dismiss the form the user is looking at, so the holder must
+     * keep the slot pinned to it: nothing else may touch UMP -- least of all a reset -- until that
+     * form's own callback reports back. This is the delegation the controllers depend on.
      */
     @Test
-    fun `a slot released by cancellation lets a newer operation supersede an in-flight form`() {
+    fun `a cancelled in-flight form keeps the slot until its callback releases it`() = runTest {
+        val holder = ConsentStateHolder()
+        val formEntered = CompletableDeferred<Unit>()
+        val neverRelease = CompletableDeferred<Unit>()
+        var formGeneration = 0L
+        var resetRan = false
+
+        val job = launch {
+            holder.exclusiveOfForms(presentsForm = true, onFormPresenting = { false }) {
+                formGeneration = holder.beginOperation()
+                holder.markFormPresented(formGeneration)
+                formEntered.complete(Unit)
+                neverRelease.await()
+                true
+            }
+        }
+        formEntered.await()
+        job.cancelAndJoin()
+
+        val resetResult = holder.exclusiveOfForms(presentsForm = false, onFormPresenting = { false }) {
+            resetRan = true
+            holder.reset()
+            true
+        }
+        assertFalse(resetResult, "a reset must not run under a form UMP is still presenting")
+        assertFalse(resetRan, "reset block must not execute when declined")
+
+        holder.releaseFormPresentation(formGeneration)
+
+        assertTrue(
+            holder.exclusiveOfForms(presentsForm = true, onFormPresenting = { false }) { true },
+            "the form callback must free the slot",
+        )
+    }
+
+    /**
+     * Status ordering is independent of the form slot and is unchanged: an older generation still
+     * reconciles authoritative privacy truth unconditionally, but cannot publish its status over a
+     * newer operation's.
+     */
+    @Test
+    fun `a superseded form callback reconciles privacy truth without publishing its status`() {
         val holder = ConsentStateHolder()
         val inFlightFormGen = holder.beginOperation()
         val newerOperationGen = holder.beginOperation()

--- a/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/ConsentStateHolderTest.kt
+++ b/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/ConsentStateHolderTest.kt
@@ -1,0 +1,410 @@
+package dev.avinya.ads
+
+import dev.avinya.ads.internal.ConsentStateHolder
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ConsentStateHolderTest {
+
+    @Test
+    fun `reconcileAndPublish updates all three flows for the current generation`() {
+        val holder = ConsentStateHolder()
+        val generation = holder.beginOperation()
+
+        val result = holder.reconcileAndPublish(
+            generation = generation,
+            privacyRequirement = PrivacyOptionsRequirementStatus.Required,
+            canRequestAds = true,
+            status = ConsentStatus.Required,
+        )
+
+        assertEquals(ConsentStatus.Required, result)
+        assertEquals(ConsentStatus.Required, holder.status.value)
+        assertEquals(PrivacyOptionsRequirementStatus.Required, holder.privacyOptionsRequirementStatus.value)
+        assertTrue(holder.canRequestAds.value)
+    }
+
+    @Test
+    fun `reconcileAndPublish updates privacy state for superseded generation while leaving status untouched`() {
+        val holder = ConsentStateHolder()
+        val stale = holder.beginOperation()
+        val current = holder.beginOperation()
+
+        holder.publishOperationStatus(current, ConsentStatus.Obtained)
+
+        // Reconciliation is NOT generation-gated: it reads the UMP singleton, so it is current
+        // no matter which operation's callback observed it. The STATUS is gated, so the stale
+        // callback must reconcile privacy state without republishing its own status.
+        val result = holder.reconcileAndPublish(
+            generation = stale,
+            privacyRequirement = PrivacyOptionsRequirementStatus.NotRequired,
+            canRequestAds = true,
+            status = ConsentStatus.Required,
+        )
+
+        assertEquals(ConsentStatus.Obtained, result, "result should be current status value")
+        assertEquals(ConsentStatus.Obtained, holder.status.value, "superseded status must not overwrite current status")
+        assertEquals(PrivacyOptionsRequirementStatus.NotRequired, holder.privacyOptionsRequirementStatus.value)
+        assertTrue(holder.canRequestAds.value)
+    }
+
+    @Test
+    fun `a late callback on the same still-current generation replaces a timeout status`() {
+        val holder = ConsentStateHolder()
+        val generation = holder.beginOperation()
+
+        // Waiter timed out and published Failed(timeout)...
+        holder.publishOperationStatus(generation, ConsentStatus.Failed(AdError.message("timed out")))
+        assertTrue(holder.status.value is ConsentStatus.Failed)
+
+        // ...and later the callback for the SAME still-current generation completes with Obtained.
+        val result = holder.reconcileAndPublish(
+            generation = generation,
+            privacyRequirement = PrivacyOptionsRequirementStatus.NotRequired,
+            canRequestAds = true,
+            status = ConsentStatus.Obtained,
+        )
+
+        assertEquals(ConsentStatus.Obtained, result)
+        assertEquals(ConsentStatus.Obtained, holder.status.value)
+        assertEquals(PrivacyOptionsRequirementStatus.NotRequired, holder.privacyOptionsRequirementStatus.value)
+        assertTrue(holder.canRequestAds.value)
+    }
+
+    @Test
+    fun `a revocation observed by reconcileAndPublish sets canRequestAds false regardless of generation`() {
+        val holder = ConsentStateHolder()
+        val initial = holder.beginOperation()
+        holder.reconcileAndPublish(
+            generation = initial,
+            privacyRequirement = PrivacyOptionsRequirementStatus.NotRequired,
+            canRequestAds = true,
+            status = ConsentStatus.Obtained,
+        )
+        assertTrue(holder.canRequestAds.value)
+
+        val stale = holder.beginOperation()
+        val current = holder.beginOperation()
+        holder.publishOperationStatus(current, ConsentStatus.Obtained)
+
+        // Stale callback observes revocation
+        holder.reconcileAndPublish(
+            generation = stale,
+            privacyRequirement = PrivacyOptionsRequirementStatus.Required,
+            canRequestAds = false,
+            status = ConsentStatus.Required,
+        )
+
+        assertFalse(holder.canRequestAds.value, "revocation must close ad request gate immediately")
+        assertEquals(PrivacyOptionsRequirementStatus.Required, holder.privacyOptionsRequirementStatus.value)
+        assertEquals(ConsentStatus.Obtained, holder.status.value, "superseded status must not overwrite current status")
+    }
+
+    @Test
+    fun `reset claims a fresh generation and clears all three flows`() {
+        val holder = ConsentStateHolder()
+        val outstanding = holder.beginOperation()
+        holder.reconcileAndPublish(
+            generation = outstanding,
+            privacyRequirement = PrivacyOptionsRequirementStatus.Required,
+            canRequestAds = true,
+            status = ConsentStatus.Obtained,
+        )
+
+        holder.reset()
+
+        assertEquals(ConsentStatus.Unknown, holder.status.value)
+        assertEquals(PrivacyOptionsRequirementStatus.Unknown, holder.privacyOptionsRequirementStatus.value)
+        assertFalse(holder.canRequestAds.value)
+
+        // A callback outstanding across a reset must not resurrect pre-reset status
+        holder.publishOperationStatus(outstanding, ConsentStatus.Obtained)
+        assertEquals(ConsentStatus.Unknown, holder.status.value)
+    }
+
+    @Test
+    fun `serialized orders two blocks`() = runTest {
+        val holder = ConsentStateHolder()
+        val order = mutableListOf<String>()
+        val firstEntered = CompletableDeferred<Unit>()
+        val releaseFirst = CompletableDeferred<Unit>()
+
+        val first = launch {
+            holder.serialized {
+                order += "first-in"
+                firstEntered.complete(Unit)
+                releaseFirst.await()
+                order += "first-out"
+            }
+        }
+        firstEntered.await()
+        val second = launch { holder.serialized { order += "second-in" } }
+        advanceUntilIdle()
+
+        assertEquals(listOf("first-in"), order, "the second block must not overlap the first")
+        releaseFirst.complete(Unit)
+        first.join()
+        second.join()
+        assertEquals(listOf("first-in", "first-out", "second-in"), order)
+    }
+
+    @Test
+    fun `exclusiveOfForms declines against a live form without running its block`() = runTest {
+        val holder = ConsentStateHolder()
+        val firstEntered = CompletableDeferred<Unit>()
+        val releaseFirst = CompletableDeferred<Unit>()
+        var secondRan = false
+
+        val first = launch {
+            holder.exclusiveOfForms(presentsForm = true, onFormPresenting = { false }) {
+                firstEntered.complete(Unit)
+                releaseFirst.await()
+                true
+            }
+        }
+        firstEntered.await()
+
+        val declined = holder.exclusiveOfForms(presentsForm = true, onFormPresenting = { false }) {
+            secondRan = true
+            true
+        }
+
+        assertFalse(declined, "an overlapping form presentation must decline")
+        assertFalse(secondRan, "the declined path must not run the block")
+        releaseFirst.complete(Unit)
+        first.join()
+    }
+
+    @Test
+    fun `exclusiveOfForms waits for a non-form holder and then runs`() = runTest {
+        val holder = ConsentStateHolder()
+        val order = mutableListOf<String>()
+        val nonFormEntered = CompletableDeferred<Unit>()
+        val releaseNonForm = CompletableDeferred<Unit>()
+
+        val nonForm = launch {
+            holder.serialized {
+                order += "non-form-in"
+                nonFormEntered.complete(Unit)
+                releaseNonForm.await()
+                order += "non-form-out"
+            }
+        }
+        nonFormEntered.await()
+
+        val form = launch {
+            val ran = holder.exclusiveOfForms(presentsForm = true, onFormPresenting = { false }) {
+                order += "form-ran"
+                true
+            }
+            assertTrue(ran, "form must run after non-form operation finishes")
+        }
+        advanceUntilIdle()
+
+        assertEquals(listOf("non-form-in"), order, "form must wait for non-form operation rather than declining")
+        releaseNonForm.complete(Unit)
+        nonForm.join()
+        form.join()
+        assertEquals(listOf("non-form-in", "non-form-out", "form-ran"), order)
+    }
+
+    @Test
+    fun `exclusiveOfForms restores the form flag after normal completion`() = runTest {
+        val holder = ConsentStateHolder()
+        assertTrue(holder.exclusiveOfForms(presentsForm = true, onFormPresenting = { false }) { true })
+        assertTrue(
+            holder.exclusiveOfForms(presentsForm = true, onFormPresenting = { false }) { true },
+            "a completed form operation must not leave the form flag stuck",
+        )
+    }
+
+    @Test
+    fun `exclusiveOfForms restores the form flag after a throw`() = runTest {
+        val holder = ConsentStateHolder()
+        runCatching {
+            holder.exclusiveOfForms(presentsForm = true, onFormPresenting = { false }) {
+                error("form blew up")
+            }
+        }
+        assertTrue(
+            holder.exclusiveOfForms(presentsForm = true, onFormPresenting = { false }) { true },
+            "a throwing form operation must restore the form flag",
+        )
+    }
+
+    @Test
+    fun `exclusiveOfForms restores the form flag after cancellation`() = runTest {
+        val holder = ConsentStateHolder()
+        val formEntered = CompletableDeferred<Unit>()
+        val neverRelease = CompletableDeferred<Unit>()
+
+        val job = launch {
+            holder.exclusiveOfForms(presentsForm = true, onFormPresenting = { false }) {
+                formEntered.complete(Unit)
+                neverRelease.await()
+                true
+            }
+        }
+        formEntered.await()
+        job.cancelAndJoin()
+
+        assertTrue(
+            holder.exclusiveOfForms(presentsForm = true, onFormPresenting = { false }) { true },
+            "cancellation must restore the form flag and unlock the mutex",
+        )
+    }
+
+    /**
+     * Accepted limitation (see plan): Cancelling gatherConsent while the UMP form is on screen
+     * releases the coordinator slot even though UMP still owns the form; a newer operation can then
+     * suppress the form's eventual status. This self-heals (canRequestAds still reconciles unconditionally,
+     * and the newer operation republishes from the UMP singleton), and holding the slot across a
+     * cancelled, unbounded form risks a permanent lock — a strictly worse failure.
+     *
+     * This test pins that after beginOperation() twice the older generation can still reconcile
+     * privacy truth, but cannot publish its status over the newer operation.
+     */
+    @Test
+    fun `a slot released by cancellation lets a newer operation supersede an in-flight form`() {
+        val holder = ConsentStateHolder()
+        val inFlightFormGen = holder.beginOperation()
+        val newerOperationGen = holder.beginOperation()
+
+        // Newer operation finishes first and sets status
+        holder.publishOperationStatus(newerOperationGen, ConsentStatus.NotRequired)
+
+        // In-flight form eventually calls back on its older generation
+        holder.reconcileAndPublish(
+            generation = inFlightFormGen,
+            privacyRequirement = PrivacyOptionsRequirementStatus.NotRequired,
+            canRequestAds = true,
+            status = ConsentStatus.Obtained,
+        )
+
+        // Privacy state updated
+        assertTrue(holder.canRequestAds.value)
+        assertEquals(PrivacyOptionsRequirementStatus.NotRequired, holder.privacyOptionsRequirementStatus.value)
+        // But status is NOT overwritten by the older form callback
+        assertEquals(
+            ConsentStatus.NotRequired,
+            holder.status.value,
+            "superseded form callback must not overwrite newer operation's status",
+        )
+    }
+
+    @Test
+    fun `reset declines while a form holds the slot`() = runTest {
+        val holder = ConsentStateHolder()
+        val formEntered = CompletableDeferred<Unit>()
+        val releaseForm = CompletableDeferred<Unit>()
+        var resetRan = false
+
+        val form = launch {
+            holder.exclusiveOfForms(presentsForm = true, onFormPresenting = { false }) {
+                formEntered.complete(Unit)
+                releaseForm.await()
+                true
+            }
+        }
+        formEntered.await()
+
+        val resetResult = holder.exclusiveOfForms(
+            presentsForm = false,
+            onFormPresenting = { false },
+        ) {
+            resetRan = true
+            holder.reset()
+            true
+        }
+
+        assertFalse(resetResult, "reset must decline while a form is presenting")
+        assertFalse(resetRan, "reset block must not execute when declined")
+
+        releaseForm.complete(Unit)
+        form.join()
+    }
+
+    @Test
+    fun `reset waits for a non-form holder and then runs`() = runTest {
+        val holder = ConsentStateHolder()
+        val order = mutableListOf<String>()
+        val nonFormEntered = CompletableDeferred<Unit>()
+        val releaseNonForm = CompletableDeferred<Unit>()
+
+        val nonForm = launch {
+            holder.serialized {
+                order += "non-form-in"
+                nonFormEntered.complete(Unit)
+                releaseNonForm.await()
+                order += "non-form-out"
+            }
+        }
+        nonFormEntered.await()
+
+        val reset = launch {
+            val ran = holder.exclusiveOfForms(
+                presentsForm = false,
+                onFormPresenting = { false },
+            ) {
+                order += "reset-ran"
+                holder.reset()
+                true
+            }
+            assertTrue(ran, "reset must run after non-form operation finishes")
+        }
+        advanceUntilIdle()
+
+        assertEquals(listOf("non-form-in"), order, "reset must wait for non-form operation rather than declining")
+        releaseNonForm.complete(Unit)
+        nonForm.join()
+        reset.join()
+        assertEquals(listOf("non-form-in", "non-form-out", "reset-ran"), order)
+        assertEquals(ConsentStatus.Unknown, holder.status.value)
+    }
+
+    @Test
+    fun `reset inside exclusiveOfForms still invalidates an outstanding generation`() = runTest {
+        val holder = ConsentStateHolder()
+        val outstanding = holder.beginOperation()
+        holder.reconcileAndPublish(
+            generation = outstanding,
+            privacyRequirement = PrivacyOptionsRequirementStatus.Required,
+            canRequestAds = true,
+            status = ConsentStatus.Obtained,
+        )
+
+        holder.exclusiveOfForms(
+            presentsForm = false,
+            onFormPresenting = { false },
+        ) {
+            holder.reset()
+            true
+        }
+
+        assertEquals(ConsentStatus.Unknown, holder.status.value)
+        assertEquals(PrivacyOptionsRequirementStatus.Unknown, holder.privacyOptionsRequirementStatus.value)
+        assertFalse(holder.canRequestAds.value)
+
+        // An outstanding generation cannot publish status after reset
+        holder.publishOperationStatus(outstanding, ConsentStatus.Obtained)
+        assertEquals(ConsentStatus.Unknown, holder.status.value)
+
+        // An outstanding generation reconcileAndPublish cannot overwrite Unknown status
+        holder.reconcileAndPublish(
+            generation = outstanding,
+            privacyRequirement = PrivacyOptionsRequirementStatus.NotRequired,
+            canRequestAds = true,
+            status = ConsentStatus.Obtained,
+        )
+        assertEquals(ConsentStatus.Unknown, holder.status.value)
+    }
+}

--- a/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/Fakes.kt
+++ b/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/Fakes.kt
@@ -229,13 +229,19 @@ internal class FakeAdManager : AdManager, FullScreenPresenceAware {
 }
 
 internal class FakeConsentController : ConsentController {
+    var gatherConsentCalls = 0
     private val _status: MutableStateFlow<ConsentStatus> = MutableStateFlow(ConsentStatus.Unknown)
     override val status: StateFlow<ConsentStatus> = _status
     override val privacyOptionsRequirementStatus: StateFlow<PrivacyOptionsRequirementStatus>
         get() = MutableStateFlow(PrivacyOptionsRequirementStatus.Unknown)
-    override val canRequestAds: StateFlow<Boolean> = MutableStateFlow(true)
+    private val _canRequestAds = MutableStateFlow(true)
+    override val canRequestAds: StateFlow<Boolean> = _canRequestAds
+    fun setCanRequestAds(value: Boolean) { _canRequestAds.value = value }
     override suspend fun requestConsentInfoUpdate(config: AdConfig): ConsentStatus = _status.value
-    override suspend fun gatherConsent(config: AdConfig): ConsentStatus = _status.value
+    override suspend fun gatherConsent(config: AdConfig): ConsentStatus {
+        gatherConsentCalls++
+        return _status.value
+    }
     override suspend fun showPrivacyOptions(): Boolean = false
     override suspend fun resetConsentForDebug(): Boolean = false
     fun setStatus(s: ConsentStatus) { _status.value = s }

--- a/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/GoogleAdManagerBaseFakes.kt
+++ b/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/GoogleAdManagerBaseFakes.kt
@@ -47,6 +47,8 @@ internal class FakeGoogleAdManager(
     override fun declaredAppId(): DeclaredAppId = when (declared) {
         DeclaredAppIdForTest.Unknown -> DeclaredAppId.Unknown
         DeclaredAppIdForTest.Missing -> DeclaredAppId.Missing
+        // Deliberately built through the factory, exactly as the platform readers do.
+        DeclaredAppIdForTest.Blank -> DeclaredAppId.ofDeclaredValue("")
         DeclaredAppIdForTest.Matching -> DeclaredAppId.Present("ca-app-pub-A")
         DeclaredAppIdForTest.Mismatched -> DeclaredAppId.Present("ca-app-pub-OTHER")
     }
@@ -84,4 +86,4 @@ internal class FakeGoogleAdManager(
 }
 
 /** Mirrors `DeclaredAppId` so a test reads as a scenario rather than a platform type. */
-internal enum class DeclaredAppIdForTest { Unknown, Missing, Matching, Mismatched }
+internal enum class DeclaredAppIdForTest { Unknown, Missing, Blank, Matching, Mismatched }

--- a/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/GoogleAdManagerBaseFakes.kt
+++ b/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/GoogleAdManagerBaseFakes.kt
@@ -1,0 +1,87 @@
+package dev.avinya.ads
+
+import dev.avinya.ads.internal.DeclaredAppId
+import dev.avinya.ads.internal.InitializationTimeouts
+import dev.avinya.ads.internal.awaitNativeCallback
+import dev.avinya.ads.nativead.NativeAdManager
+import dev.avinya.ads.nativead.NativeAdMemoryPolicy
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
+/**
+ * A `GoogleAdManagerBase` with the native boundary replaced by a scriptable lambda.
+ *
+ * Exists so the initialization state machine — the part that owns process-global native
+ * ownership — can be exercised in commonTest. The platform managers reach MobileAds/GADMobileAds
+ * through statics and cannot be driven end-to-end without a static-mocking dependency, which is
+ * exactly why this defect class was never covered.
+ */
+internal class FakeGoogleAdManager(
+    override val consent: ConsentController = FakeConsentController(),
+    /** True models iOS (`GADApplicationIdentifier`); false models Android. */
+    private val requiresDeclaredAppId: Boolean = false,
+    private val failBeforeHandoff: () -> Throwable? = { null },
+    private val nativeInitialize: suspend (AdConfig, AdInitializationConfigIdentity) -> Unit = { _, _ -> },
+) : GoogleAdManagerBase() {
+
+    override val platformTag: String = "Fake"
+    override val nativeInitializationDispatcher: CoroutineDispatcher = Dispatchers.Main.immediate
+    override val diagnostics: AdDiagnostics = FakeAdDiagnostics()
+    override val tracking: AdTrackingController = NoOpTrackingController
+    override val nativeAds: NativeAdManager get() = NoOpAdManager.nativeAds
+
+    /** Every identity this fake was actually asked to hand to the "native" SDK, in order. */
+    val nativeHandoffs = mutableListOf<AdInitializationConfigIdentity>()
+
+    val handoffMarks = mutableListOf<AdInitializationConfigIdentity>()
+
+    /** What the fake "platform manifest" declares. */
+    var declared: DeclaredAppIdForTest = DeclaredAppIdForTest.Unknown
+
+    override val declaredAppIdSource: String = "the fake platform manifest"
+    override val declaredAppIdConsumerDescription: String = "A fake consumer reads this value."
+    override val declaredAppIdRequiredByPlatformSdk: Boolean get() = requiresDeclaredAppId
+
+    // appId() returns config.androidAppId, so these agree or disagree with whatever AdConfig
+    // the test built.
+    override fun declaredAppId(): DeclaredAppId = when (declared) {
+        DeclaredAppIdForTest.Unknown -> DeclaredAppId.Unknown
+        DeclaredAppIdForTest.Missing -> DeclaredAppId.Missing
+        DeclaredAppIdForTest.Matching -> DeclaredAppId.Present("ca-app-pub-A")
+        DeclaredAppIdForTest.Mismatched -> DeclaredAppId.Present("ca-app-pub-OTHER")
+    }
+
+    init { startAdmissionTracking() }
+
+    override fun appId(config: AdConfig): String = config.androidAppId
+    internal override fun configureNativeAdsAfterAcceptedInitialization(config: AdConfig) = Unit
+    override fun configuredNativePolicyOrNull(): NativeAdMemoryPolicy? = null
+    override fun onNativeConsentRevoked() = Unit
+    override fun captureDiagnosticsSnapshotOnMain() = Unit
+
+    override suspend fun initializeMobileAdsNative(
+        config: AdConfig,
+        requestedIdentity: AdInitializationConfigIdentity,
+        markHandoff: suspend () -> Unit,
+    ) {
+        nativeHandoffs += requestedIdentity
+        failBeforeHandoff()?.let { throw it }
+        markHandoff()
+        handoffMarks += requestedIdentity
+        awaitNativeCallback("Fake MobileAds.initialize", InitializationTimeouts.nativeInitialize) {
+            nativeInitialize(config, requestedIdentity)
+        }
+    }
+
+    private fun unreachable(): Nothing =
+        throw UnsupportedOperationException("FakeGoogleAdManager exercises initialization only.")
+
+    override fun banner(placement: AdPlacement): BannerAdController = unreachable()
+    override fun interstitial(placement: AdPlacement): InterstitialAdController = unreachable()
+    override fun rewarded(placement: AdPlacement): RewardedAdController = unreachable()
+    override fun rewardedInterstitial(placement: AdPlacement): RewardedInterstitialAdController = unreachable()
+    override fun appOpen(placement: AdPlacement): AppOpenAdController = unreachable()
+}
+
+/** Mirrors `DeclaredAppId` so a test reads as a scenario rather than a platform type. */
+internal enum class DeclaredAppIdForTest { Unknown, Missing, Matching, Mismatched }

--- a/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/NativeInitializationOwnershipTest.kt
+++ b/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/NativeInitializationOwnershipTest.kt
@@ -163,4 +163,3 @@ class NativeInitializationOwnershipTest {
         )
     }
 }
-

--- a/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/NativeInitializationOwnershipTest.kt
+++ b/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/NativeInitializationOwnershipTest.kt
@@ -1,0 +1,166 @@
+package dev.avinya.ads
+
+import dev.avinya.ads.internal.InitializationTimeouts
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.awaitCancellation
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class NativeInitializationOwnershipTest {
+
+    private fun config(appId: String) = AdConfig(
+        androidAppId = appId,
+        iosAppId = appId,
+    )
+
+    @Test
+    fun `a config that never gets its native callback reports a retryable failure`() = runSlotTest {
+        val manager = FakeGoogleAdManager(nativeInitialize = { _, _ -> awaitCancellation() })
+
+        val status = manager.initialize(config("ca-app-pub-A"), ConsentMode.SkipConsent)
+
+        val failed = assertIs<AdManagerStatus.Failed>(status)
+        assertTrue(failed.retryable, "a hung GMA callback must leave a retry open")
+    }
+
+    @Test
+    fun `a different config after a timed-out handoff is refused not reported ready`() = runSlotTest {
+        var callbacksArrive = false
+        val manager = FakeGoogleAdManager(
+            nativeInitialize = { _, _ -> if (!callbacksArrive) awaitCancellation() },
+        )
+
+        // Config A is handed to the process-global SDK; its callback never arrives.
+        manager.initialize(config("ca-app-pub-A"), ConsentMode.SkipConsent)
+
+        // GMA starts answering again -- but it is still the singleton that accepted A.
+        callbacksArrive = true
+        val second = manager.initialize(config("ca-app-pub-B"), ConsentMode.SkipConsent)
+
+        val refused = assertIs<AdManagerStatus.Failed>(second)
+        assertEquals(AdErrorCode.INITIALIZATION_CONFLICT, refused.error.code)
+        assertFalse(refused.retryable, "the native singleton cannot be reconfigured")
+        assertNotEquals(
+            AdManagerStatus.Ready,
+            manager.status.value,
+            "the wrapper must never publish Ready for a configuration the process does not own",
+        )
+        assertEquals(
+            1,
+            manager.nativeHandoffs.size,
+            "the refused configuration must never reach the native SDK",
+        )
+    }
+
+    @Test
+    fun `the same config after a timed-out handoff may still retry to Ready`() = runSlotTest {
+        var callbacksArrive = false
+        val manager = FakeGoogleAdManager(
+            nativeInitialize = { _, _ -> if (!callbacksArrive) awaitCancellation() },
+        )
+
+        manager.initialize(config("ca-app-pub-A"), ConsentMode.SkipConsent)
+        callbacksArrive = true
+        val second = manager.initialize(config("ca-app-pub-A"), ConsentMode.SkipConsent)
+
+        // The documented recovery from a hung GMA callback must keep working.
+        assertEquals(AdManagerStatus.Ready, second)
+        assertEquals(2, manager.nativeHandoffs.size, "the same identity is allowed to retry")
+    }
+
+    @Test
+    fun `a refused handoff does not run publisher initialization hooks`() = runSlotTest {
+        val hook = object : AdInitializationHook {
+            var afterCount = 0
+            override suspend fun onPhase(phase: AdInitializationPhase, config: AdConfig) {
+                if (phase == AdInitializationPhase.BeforeMobileAdsInitialize) afterCount++
+            }
+        }
+        val manager = FakeGoogleAdManager(nativeInitialize = { _, _ -> awaitCancellation() })
+
+        manager.initialize(config("ca-app-pub-A"), ConsentMode.SkipConsent)
+        val before = hook.afterCount
+        manager.initialize(
+            AdConfig(
+                androidAppId = "ca-app-pub-B",
+                iosAppId = "ca-app-pub-B",
+                initializationHooks = listOf(hook),
+            ),
+            ConsentMode.SkipConsent,
+        )
+
+        assertEquals(before, hook.afterCount, "a refused configuration must not fire host hooks")
+    }
+
+    @Test
+    fun `a failure before the native handoff leaves a different config free to retry`() = runSlotTest {
+        var rejectAppId = true
+        val manager = FakeGoogleAdManager(
+            failBeforeHandoff = { if (rejectAppId) IllegalArgumentException("invalid app id") else null },
+        )
+
+        // AdAppIds validates only non-blank, so an ad-unit id reaches the platform builder and is
+        // rejected there -- before MobileAds.initialize is ever called.
+        val first = manager.initialize(
+            AdConfig(androidAppId = "ca-app-pub-1/2", iosAppId = "ca-app-pub-1/2"),
+            ConsentMode.SkipConsent,
+        )
+        assertIs<AdManagerStatus.Failed>(first)
+
+        // The host fixes the id and retries. Nothing was handed to native, so this MUST work.
+        rejectAppId = false
+        val second = manager.initialize(
+            AdConfig(androidAppId = "ca-app-pub-A", iosAppId = "ca-app-pub-A"),
+            ConsentMode.SkipConsent,
+        )
+
+        assertEquals(
+            AdManagerStatus.Ready,
+            second,
+            "a throw before the native handoff must not pin ownership the process does not have",
+        )
+    }
+
+    @Test
+    fun `the handoff mark is taken exactly once per native attempt`() = runSlotTest {
+        val manager = FakeGoogleAdManager()
+
+        manager.initialize(config("ca-app-pub-A"), ConsentMode.SkipConsent)
+
+        assertEquals(
+            listOf("ca-app-pub-A"),
+            manager.handoffMarks.map { it.platformAppId },
+            "each native attempt marks its handoff once, at the platform's own boundary",
+        )
+    }
+
+    @Test
+    fun `a configuration that will be refused never gathers consent`() = runSlotTest {
+        var callbacksArrive = false
+        val consent = FakeConsentController()
+        val manager = FakeGoogleAdManager(
+            consent = consent,
+            nativeInitialize = { _, _ -> if (!callbacksArrive) awaitCancellation() },
+        )
+
+        // Identity A is handed off and times out.
+        manager.initialize(config("ca-app-pub-A"), ConsentMode.SkipConsent)
+        callbacksArrive = true
+        val before = consent.gatherConsentCalls
+
+        val refused = manager.initialize(config("ca-app-pub-B"), ConsentMode.GatherBeforeInitialize)
+
+        assertIs<AdManagerStatus.Failed>(refused)
+        assertEquals(
+            before,
+            consent.gatherConsentCalls,
+            "a configuration the SDK already knows it will refuse must not put a consent form on screen",
+        )
+    }
+}
+

--- a/admob-cmp-core/src/iosMain/kotlin/dev/avinya/ads/IosConsentController.kt
+++ b/admob-cmp-core/src/iosMain/kotlin/dev/avinya/ads/IosConsentController.kt
@@ -16,16 +16,7 @@ import UserMessagingPlatform.UMPPrivacyOptionsRequirementStatus
 import UserMessagingPlatform.UMPPrivacyOptionsRequirementStatusNotRequired
 import UserMessagingPlatform.UMPPrivacyOptionsRequirementStatusRequired
 import UserMessagingPlatform.UMPRequestParameters
-import kotlin.coroutines.resume
-import kotlinx.cinterop.ExperimentalForeignApi
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.suspendCancellableCoroutine
-import kotlinx.coroutines.withContext
+import dev.avinya.ads.internal.ConsentStateHolder
 import dev.avinya.ads.internal.InitializationTimeouts
 import dev.avinya.ads.internal.NativeCallbackTimeoutException
 import dev.avinya.ads.internal.awaitHost
@@ -35,13 +26,26 @@ import dev.avinya.ads.internal.ownedSnapshot
 import dev.avinya.ads.internal.reconcileThenResumeIfActive
 import dev.avinya.ads.internal.resolveConsentInfoUpdateStatus
 import dev.avinya.ads.internal.shouldResumeInitializationAfterPrivacyOptions
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
 
 internal class IosConsentController(
     val onCanRequestAds: suspend (AdConfig) -> Unit
 ) : ConsentController {
-    private val _status = MutableStateFlow<ConsentStatus>(ConsentStatus.Unknown)
-    private val _privacy = MutableStateFlow(PrivacyOptionsRequirementStatus.Unknown)
-    private val _canRequestAds = MutableStateFlow(false)
+    // Regression Guard G2: state MUST be declared before the three overrides.
+    private val state = ConsentStateHolder()
+
+    override val status: StateFlow<ConsentStatus> = state.status
+    override val privacyOptionsRequirementStatus: StateFlow<PrivacyOptionsRequirementStatus> =
+        state.privacyOptionsRequirementStatus
+    override val canRequestAds: StateFlow<Boolean> = state.canRequestAds
+
     // Retained so showPrivacyOptions() can resume initialization if the user grants
     // consent from the privacy form after an earlier denial.
     private var lastConfig: AdConfig? = null
@@ -51,18 +55,33 @@ internal class IosConsentController(
     // runs. Same shape as GoogleAdManagerBase.admissionScope: process-wide, never cancelled.
     private val consentScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
 
-    override val status: StateFlow<ConsentStatus> = _status
-    override val privacyOptionsRequirementStatus: StateFlow<PrivacyOptionsRequirementStatus> = _privacy
-    override val canRequestAds: StateFlow<Boolean> = _canRequestAds
+    override suspend fun requestConsentInfoUpdate(config: AdConfig): ConsentStatus =
+        withContext(Dispatchers.Main.immediate) {
+            val owned = config.ownedSnapshot()
+            lastConfig = owned
+            owned.dispatchInitializationHooks(AdInitializationPhase.BeforeConsentRequest)
+            state.serialized {
+                performConsentInfoUpdate(
+                    owned,
+                    UMPConsentInformation.sharedInstance,
+                    state.beginOperation(),
+                )
+            }
+        }
 
-    override suspend fun requestConsentInfoUpdate(config: AdConfig): ConsentStatus = withContext(Dispatchers.Main.immediate) {
-        // Owned snapshot, matching AdManager.initialize(): lastConfig outlives this call and is
-        // reused if showPrivacyOptions() later resumes initialization, so retaining the caller's
-        // object let post-call mutation of its lists/hooks change UMP debug IDs and hook execution.
-        val config = config.ownedSnapshot()
-        lastConfig = config
-        config.dispatchInitializationHooks(AdInitializationPhase.BeforeConsentRequest)
-        val consentInformation = UMPConsentInformation.sharedInstance
+    /**
+     * The UMP info-update sequence, assuming the caller already holds the operation slot.
+     *
+     * Split out for the same reason Android's `updateWithActivity` is: [gatherConsent] must be
+     * able to run an update without re-acquiring a slot it already holds. `Mutex` is not
+     * reentrant, so routing [gatherConsent] back through the public [requestConsentInfoUpdate]
+     * would deadlock.
+     */
+    private suspend fun performConsentInfoUpdate(
+        config: AdConfig,
+        consentInformation: UMPConsentInformation,
+        generation: Long,
+    ): ConsentStatus {
         // MUST stay bounded: this is a non-interactive network round trip, and UMP can accept the
         // call and never call back, which hangs consent admission -- and therefore ad serving --
         // indefinitely.
@@ -83,122 +102,169 @@ internal class IosConsentController(
                 timeout = InitializationTimeouts.consentInfoUpdate
             ) {
                 suspendCancellableCoroutine<Unit> { continuation ->
+                    // Kept deliberately, matching IosAdDiagnostics.openAdInspector: these continuations are captured
+                    // by UMP ObjC completion blocks, and installing a cancellation handler is the established idiom
+                    // here for that shape. Removing it is not a change this fix set needs to make -- if it is provably
+                    // unnecessary, prove it and record the reason, do not delete it because the body looks empty.
                     continuation.invokeOnCancellation { }
                     consentInformation.requestConsentInfoUpdateWithParameters(buildParams(config)) { error ->
-                        // Deliberately still gated on isActive, NOT routed through
-                        // reconcileThenResumeIfActive: this is the bounded, non-interactive path
-                        // covered by the huge comment above -- canRequestAds/status must NOT be
-                        // reconciled from a callback that arrives after awaitNativeCallback's
-                        // internal withTimeoutOrNull has already cancelled this continuation and
-                        // published ConsentStatus.Failed(timeout) below. Doing so unconditionally
-                        // would let a late callback silently overwrite that terminal Failed status
-                        // with a stale success, diverging from AndroidConsentController's
-                        // equivalent path (updateWithActivity), which the comment above this
-                        // function requires stay identical.
-                        if (continuation.isActive) {
-                            updatePrivacyState(consentInformation)
-                            _canRequestAds.value = consentInformation.canRequestAds
-                            _status.value = resolveConsentInfoUpdateStatus(
-                                error = error?.let {
-                                    AdError(
-                                        code = (it.code ?: 0).toString(),
-                                        message = it.localizedDescription ?: "Consent info update failed.",
-                                    )
-                                },
-                                canRequestAds = consentInformation.canRequestAds,
-                                nativeStatus = consentInformationStatus(consentInformation),
+                        // Reconciliation is unconditional, matching the form paths below and
+                        // AndroidConsentController: this callback READS the UMP singleton, so a
+                        // callback that arrives after the waiter timed out still reports current
+                        // truth -- and it can carry a revocation. Only the STATUS is ordered, by
+                        // generation, which is what keeps a late success from overwriting a newer
+                        // operation's result. That ordering, not dropping the callback, is what
+                        // protects the terminal Failed(timeout) status.
+                        val mapped = error?.let {
+                            AdError(
+                                code = (it.code ?: 0).toString(),
+                                message = it.localizedDescription ?: "Consent info update failed.",
                             )
-                            continuation.resume(Unit)
+                        }
+                        reconcileThenResumeIfActive(continuation, Unit) {
+                            state.reconcileAndPublish(
+                                generation,
+                                privacyRequirement = privacyRequirementOf(consentInformation),
+                                canRequestAds = consentInformation.canRequestAds,
+                                status = resolveConsentInfoUpdateStatus(
+                                    error = mapped,
+                                    canRequestAds = consentInformation.canRequestAds,
+                                    nativeStatus = consentInformationStatus(consentInformation),
+                                ),
+                            )
                         }
                     }
                 }
             }
         } catch (timeout: NativeCallbackTimeoutException) {
             AdLogger.e("iOS UMP consent info update timed out.", timeout)
-            // canRequestAds is deliberately NOT reset here. See
-            // consentInfoUpdateTimeoutStatus's KDoc.
-            _status.value = consentInfoUpdateTimeoutStatus(timeout.message)
+            // canRequestAds is deliberately NOT reset here. See consentInfoUpdateTimeoutStatus's
+            // KDoc. The late callback above will still reconcile it if UMP ever answers.
+            state.publishOperationStatus(generation, consentInfoUpdateTimeoutStatus(timeout.message))
         }
-        _status.value
+        return state.status.value
     }
 
-    override suspend fun gatherConsent(config: AdConfig): ConsentStatus = withContext(Dispatchers.Main.immediate) {
-        val consentInformation = UMPConsentInformation.sharedInstance
-        // Unlike Android, this DOES route through the public requestConsentInfoUpdate. That is not
-        // an oversight and should not be "harmonised": the iOS info update goes through
-        // UMPConsentInformation.sharedInstance and needs no view controller, so there is no second
-        // host wait to eliminate. Only the consent FORM below needs one, and it is acquired once,
-        // there. On Android the equivalent call does need an Activity, which is why that platform
-        // hoists the acquisition instead.
-        val update = requestConsentInfoUpdate(config)
-        if (update is ConsentStatus.Failed && !consentInformation.canRequestAds) return@withContext update
-        // Waits rather than failing on the first null. topViewController() deliberately
-        // reports null while the top controller is mid-presentation or mid-dismissal, which
-        // is routine at launch — the host's Compose UIViewController is often still being
-        // presented when a startup effect first runs.
-        val rootVC = awaitHost(InitializationTimeouts.consentHost) { topViewController() }
-        if (rootVC == null) {
-            AdLogger.w(
-                "No usable iOS root view controller for the UMP consent form after waiting " +
-                    "${InitializationTimeouts.consentHost}. Consent was not gathered on this " +
-                    "attempt; the host " +
-                    "app should retry."
-            )
-            _status.value = ConsentStatus.Failed(AdError.message("No root view controller for consent form."))
-            return@withContext _status.value
-        }
-        suspendCancellableCoroutine { continuation ->
-            continuation.invokeOnCancellation { }
-            UMPConsentForm.loadAndPresentIfRequiredFromViewController(rootVC) {
-                // Reconciliation must not be conditional on the caller still being around —
-                // see reconcileThenResumeIfActive's KDoc. The form was shown and the user's
-                // decision (if any) is already persisted by UMP regardless of whether
-                // gatherConsent()'s caller is still listening.
-                reconcileThenResumeIfActive(continuation, Unit) {
-                    updatePrivacyState(consentInformation)
-                    _canRequestAds.value = consentInformation.canRequestAds
-                    _status.value = consentInformationStatus(consentInformation)
+    override suspend fun gatherConsent(config: AdConfig): ConsentStatus =
+        withContext(Dispatchers.Main.immediate) {
+            val owned = config.ownedSnapshot()
+            lastConfig = owned
+            owned.dispatchInitializationHooks(AdInitializationPhase.BeforeConsentRequest)
+            state.exclusiveOfForms(
+                presentsForm = true,
+                onFormPresenting = {
+                    ConsentStatus.Failed(
+                        AdError.message("gatherConsent() ignored: a consent form is already presenting.")
+                    )
+                },
+            ) {
+                val generation = state.beginOperation()
+                val consentInformation = UMPConsentInformation.sharedInstance
+                // Unlike Android, the iOS info update goes through UMPConsentInformation.sharedInstance
+                // and needs no view controller, so there is no second host wait to eliminate. Only
+                // the consent FORM below needs one, and it is acquired once, there. We call the
+                // private performConsentInfoUpdate step directly rather than routing through the public
+                // requestConsentInfoUpdate to avoid Mutex re-entrancy deadlocks on the operations slot.
+                val update = performConsentInfoUpdate(owned, consentInformation, generation)
+                if (update is ConsentStatus.Failed && !consentInformation.canRequestAds) return@exclusiveOfForms update
+                // Waits rather than failing on the first null. topViewController() deliberately
+                // reports null while the top controller is mid-presentation or mid-dismissal, which
+                // is routine at launch — the host's Compose UIViewController is often still being
+                // presented when a startup effect first runs.
+                val rootVC = awaitHost(InitializationTimeouts.consentHost) { topViewController() }
+                if (rootVC == null) {
+                    AdLogger.w(
+                        "No usable iOS root view controller for the UMP consent form after waiting " +
+                            "${InitializationTimeouts.consentHost}. Consent was not gathered on this " +
+                            "attempt; the host " +
+                            "app should retry."
+                    )
+                    return@exclusiveOfForms state.publishOperationStatus(
+                        generation,
+                        ConsentStatus.Failed(AdError.message("No root view controller for consent form."))
+                    )
                 }
+                suspendCancellableCoroutine<Unit> { continuation ->
+                    continuation.invokeOnCancellation { }
+                    UMPConsentForm.loadAndPresentIfRequiredFromViewController(rootVC) {
+                        // Reconciliation must not be conditional on the caller still being around —
+                        // see reconcileThenResumeIfActive's KDoc. The form was shown and the user's
+                        // decision (if any) is already persisted by UMP regardless of whether
+                        // gatherConsent()'s caller is still listening.
+                        reconcileThenResumeIfActive(continuation, Unit) {
+                            state.reconcileAndPublish(
+                                generation,
+                                privacyRequirement = privacyRequirementOf(consentInformation),
+                                canRequestAds = consentInformation.canRequestAds,
+                                status = consentInformationStatus(consentInformation),
+                            )
+                        }
+                    }
+                }
+                state.status.value
             }
         }
-        _status.value
-    }
 
-    override suspend fun showPrivacyOptions(): Boolean = withContext(Dispatchers.Main.immediate) {
-        val rootVC = topViewController() ?: return@withContext false
-        val consentInformation = UMPConsentInformation.sharedInstance
-        suspendCancellableCoroutine { continuation ->
-            continuation.invokeOnCancellation { }
-            UMPConsentForm.presentPrivacyOptionsFormFromViewController(rootVC) { error ->
-                // The user may have changed their choices; refresh exposed state so
-                // consumers don't read stale consent / canRequestAds values. Must run even
-                // if the caller awaiting showPrivacyOptions() was cancelled — the form
-                // already closed and UMP already persisted whatever the user chose. See
-                // reconcileThenResumeIfActive's KDoc.
-                reconcileThenResumeIfActive(continuation, error == null) {
-                    updatePrivacyState(consentInformation)
-                    _canRequestAds.value = consentInformation.canRequestAds
-                    _status.value = consentInformationStatus(consentInformation)
-                    // If the user granted consent from the privacy form after an earlier
-                    // denial, resume initialization — otherwise the SDK would stay
-                    // uninitialized forever. Launched on consentScope, not awaited here:
-                    // this callback (and the reconciliation above) must complete
-                    // regardless of whether the original caller is still around to
-                    // observe it.
-                    if (shouldResumeInitializationAfterPrivacyOptions(_canRequestAds.value, lastConfig)) {
-                        lastConfig?.let { config -> consentScope.launch { onCanRequestAds(config) } }
+    override suspend fun showPrivacyOptions(): Boolean =
+        withContext(Dispatchers.Main.immediate) {
+            state.exclusiveOfForms(
+                presentsForm = true,
+                onFormPresenting = {
+                    AdLogger.w(
+                        "showPrivacyOptions() ignored: another consent form is already " +
+                            "presenting. Wait for it to dismiss before presenting privacy options."
+                    )
+                    false
+                },
+            ) {
+                val generation = state.beginOperation()
+                val rootVC = topViewController() ?: return@exclusiveOfForms false
+                val consentInformation = UMPConsentInformation.sharedInstance
+                suspendCancellableCoroutine { continuation ->
+                    continuation.invokeOnCancellation { }
+                    UMPConsentForm.presentPrivacyOptionsFormFromViewController(rootVC) { error ->
+                        // The user may have changed their choices; refresh exposed state so
+                        // consumers don't read stale consent / canRequestAds values. Must run even
+                        // if the caller awaiting showPrivacyOptions() was cancelled — the form
+                        // already closed and UMP already persisted whatever the user chose. See
+                        // reconcileThenResumeIfActive's KDoc.
+                        reconcileThenResumeIfActive(continuation, error == null) {
+                            state.reconcileAndPublish(
+                                generation,
+                                privacyRequirement = privacyRequirementOf(consentInformation),
+                                canRequestAds = consentInformation.canRequestAds,
+                                status = consentInformationStatus(consentInformation),
+                            )
+                            // If the user granted consent from the privacy form after an earlier
+                            // denial, resume initialization — otherwise the SDK would stay
+                            // uninitialized forever. Launched on consentScope, not awaited here:
+                            // this callback (and the reconciliation above) must complete
+                            // regardless of whether the original caller is still around to
+                            // observe it.
+                            if (shouldResumeInitializationAfterPrivacyOptions(state.canRequestAds.value, lastConfig)) {
+                                lastConfig?.let { config -> consentScope.launch { onCanRequestAds(config) } }
+                            }
+                        }
                     }
                 }
             }
         }
-    }
 
     override suspend fun resetConsentForDebug(): Boolean = withContext(Dispatchers.Main.immediate) {
-        UMPConsentInformation.sharedInstance.reset()
-        _status.value = ConsentStatus.Unknown
-        _privacy.value = PrivacyOptionsRequirementStatus.Unknown
-        _canRequestAds.value = false
-        true
+        state.exclusiveOfForms(
+            presentsForm = false,
+            onFormPresenting = {
+                AdLogger.w(
+                    "resetConsentForDebug() ignored: a consent form is already presenting. " +
+                        "Wait for it to dismiss before resetting consent."
+                )
+                false
+            },
+        ) {
+            state.reset()
+            UMPConsentInformation.sharedInstance.reset()
+            true
+        }
     }
 
     private fun buildParams(config: AdConfig): UMPRequestParameters {
@@ -218,13 +284,12 @@ internal class IosConsentController(
         return params
     }
 
-    private fun updatePrivacyState(consentInformation: UMPConsentInformation) {
-        _privacy.value = when (consentInformation.privacyOptionsRequirementStatus) {
+    private fun privacyRequirementOf(consentInformation: UMPConsentInformation): PrivacyOptionsRequirementStatus =
+        when (consentInformation.privacyOptionsRequirementStatus) {
             UMPPrivacyOptionsRequirementStatusRequired -> PrivacyOptionsRequirementStatus.Required
             UMPPrivacyOptionsRequirementStatusNotRequired -> PrivacyOptionsRequirementStatus.NotRequired
             else -> PrivacyOptionsRequirementStatus.Unknown
         }
-    }
 
     // Maps UMP's consent status (distinct from canRequestAds) so the public model
     // can surface NotRequired instead of collapsing everything to Obtained/Required.

--- a/admob-cmp-core/src/iosMain/kotlin/dev/avinya/ads/IosConsentController.kt
+++ b/admob-cmp-core/src/iosMain/kotlin/dev/avinya/ads/IosConsentController.kt
@@ -38,7 +38,8 @@ import kotlinx.coroutines.withContext
 internal class IosConsentController(
     val onCanRequestAds: suspend (AdConfig) -> Unit
 ) : ConsentController {
-    // Regression Guard G2: state MUST be declared before the three overrides.
+    // Kotlin initializes properties in declaration order, so the holder must exist before the
+    // exposed flows delegate to it.
     private val state = ConsentStateHolder()
 
     override val status: StateFlow<ConsentStatus> = state.status
@@ -57,10 +58,8 @@ internal class IosConsentController(
 
     override suspend fun requestConsentInfoUpdate(config: AdConfig): ConsentStatus =
         withContext(Dispatchers.Main.immediate) {
-            val owned = config.ownedSnapshot()
-            lastConfig = owned
-            owned.dispatchInitializationHooks(AdInitializationPhase.BeforeConsentRequest)
             state.serialized {
+                val owned = prepareConsentConfig(config)
                 performConsentInfoUpdate(
                     owned,
                     UMPConsentInformation.sharedInstance,
@@ -68,6 +67,13 @@ internal class IosConsentController(
                 )
             }
         }
+
+    private suspend fun prepareConsentConfig(config: AdConfig): AdConfig {
+        val owned = config.ownedSnapshot()
+        lastConfig = owned
+        owned.dispatchInitializationHooks(AdInitializationPhase.BeforeConsentRequest)
+        return owned
+    }
 
     /**
      * The UMP info-update sequence, assuming the caller already holds the operation slot.
@@ -147,9 +153,6 @@ internal class IosConsentController(
 
     override suspend fun gatherConsent(config: AdConfig): ConsentStatus =
         withContext(Dispatchers.Main.immediate) {
-            val owned = config.ownedSnapshot()
-            lastConfig = owned
-            owned.dispatchInitializationHooks(AdInitializationPhase.BeforeConsentRequest)
             state.exclusiveOfForms(
                 presentsForm = true,
                 onFormPresenting = {
@@ -158,6 +161,7 @@ internal class IosConsentController(
                     )
                 },
             ) {
+                val owned = prepareConsentConfig(config)
                 val generation = state.beginOperation()
                 val consentInformation = UMPConsentInformation.sharedInstance
                 // Unlike Android, the iOS info update goes through UMPConsentInformation.sharedInstance
@@ -184,6 +188,10 @@ internal class IosConsentController(
                         ConsentStatus.Failed(AdError.message("No root view controller for consent form."))
                     )
                 }
+                // The irreversible boundary, mirroring GoogleAdManagerBase's markHandoff: past this
+                // line UMP owns the form, and cancelling this coroutine no longer means the screen
+                // is free. Released in the callback below, not by this coroutine's fate.
+                state.markFormPresented(generation)
                 suspendCancellableCoroutine<Unit> { continuation ->
                     continuation.invokeOnCancellation { }
                     UMPConsentForm.loadAndPresentIfRequiredFromViewController(rootVC) {
@@ -192,6 +200,7 @@ internal class IosConsentController(
                         // decision (if any) is already persisted by UMP regardless of whether
                         // gatherConsent()'s caller is still listening.
                         reconcileThenResumeIfActive(continuation, Unit) {
+                            state.releaseFormPresentation(generation)
                             state.reconcileAndPublish(
                                 generation,
                                 privacyRequirement = privacyRequirementOf(consentInformation),
@@ -220,6 +229,8 @@ internal class IosConsentController(
                 val generation = state.beginOperation()
                 val rootVC = topViewController() ?: return@exclusiveOfForms false
                 val consentInformation = UMPConsentInformation.sharedInstance
+                // See gatherConsent: the pin belongs to UMP from here, not to this coroutine.
+                state.markFormPresented(generation)
                 suspendCancellableCoroutine { continuation ->
                     continuation.invokeOnCancellation { }
                     UMPConsentForm.presentPrivacyOptionsFormFromViewController(rootVC) { error ->
@@ -229,6 +240,7 @@ internal class IosConsentController(
                         // already closed and UMP already persisted whatever the user chose. See
                         // reconcileThenResumeIfActive's KDoc.
                         reconcileThenResumeIfActive(continuation, error == null) {
+                            state.releaseFormPresentation(generation)
                             state.reconcileAndPublish(
                                 generation,
                                 privacyRequirement = privacyRequirementOf(consentInformation),

--- a/admob-cmp-core/src/iosMain/kotlin/dev/avinya/ads/IosGoogleAdManager.kt
+++ b/admob-cmp-core/src/iosMain/kotlin/dev/avinya/ads/IosGoogleAdManager.kt
@@ -82,6 +82,7 @@ internal class IosGoogleAdManager : GoogleAdManagerBase() {
     override fun appId(config: AdConfig): String = config.iosAppId
 
     internal override val declaredAppIdSource: String = "Info.plist key \"GADApplicationIdentifier\""
+    internal override val declaredAppIdRequiredByPlatformSdk: Boolean = true
 
     // GADMobileAds really does resolve its own app ID from this Info.plist key at startup,
     // independent of AdConfig -- unlike Android, where the manifest equivalent is read by UMP,
@@ -106,15 +107,21 @@ internal class IosGoogleAdManager : GoogleAdManagerBase() {
     override suspend fun initializeMobileAdsNative(
         config: AdConfig,
         requestedIdentity: AdInitializationConfigIdentity,
+        markHandoff: suspend () -> Unit,
     ) {
+        // Writing the request configuration onto the shared instance is already a process-global
+        // mutation, so iOS's boundary is earlier than Android's.
+        markHandoff()
         GADMobileAds.sharedInstance.requestConfiguration.let { requestConfig ->
             requestedIdentity.globalRequestConfiguration.applyTo(requestConfig)
         }
         // MUST stay bounded: GMA can accept start() and never invoke the handler, which would
         // leave initialize() suspended forever otherwise. A timeout is NOT a
         // CancellationException (see awaitNativeCallback), so it reaches the catch below as a
-        // real failure and leaves the identity uncommitted -- making a retry the correct next
-        // step.
+        // real failure. The requested identity is pinned as handed-off before this call
+        // regardless, so retrying the SAME configuration is still the correct next step, while
+        // a retry with a DIFFERENT one is refused deterministically instead of being
+        // reported as applied. See GoogleAdManagerBase.handedOffConfigIdentity.
         awaitNativeCallback(
             operation = "GADMobileAds.start",
             timeout = InitializationTimeouts.nativeInitialize

--- a/admob-cmp-core/src/iosMain/kotlin/dev/avinya/ads/IosGoogleAdManager.kt
+++ b/admob-cmp-core/src/iosMain/kotlin/dev/avinya/ads/IosGoogleAdManager.kt
@@ -92,12 +92,13 @@ internal class IosGoogleAdManager : GoogleAdManagerBase() {
             "Info.plist value at startup, independent of AdConfig."
 
     // infoDictionary itself is null only if the bundle could not be read at all (Unknown, never
-    // a warning); a present dictionary with no String value for this key is a genuine
-    // configuration gap (Missing) -- see DeclaredAppId's KDoc.
+    // a warning); a present dictionary with no usable String value for this key is a genuine
+    // configuration gap (Missing) -- see DeclaredAppId's KDoc. A key declared with an empty
+    // string is that same gap, not a mismatch: GADMobileAds cannot resolve an app from it and
+    // crashes at startup exactly as it does when the key is absent.
     internal override fun declaredAppId(): DeclaredAppId {
         val infoDictionary = NSBundle.mainBundle.infoDictionary ?: return DeclaredAppId.Unknown
-        val value = infoDictionary["GADApplicationIdentifier"] as? String
-        return if (value != null) DeclaredAppId.Present(value) else DeclaredAppId.Missing
+        return DeclaredAppId.ofDeclaredValue(infoDictionary["GADApplicationIdentifier"] as? String)
     }
 
     override fun captureDiagnosticsSnapshotOnMain() {

--- a/admob-cmp-gradle-plugin/src/main/kotlin/dev/avinya/ads/gradle/DoctorIosTask.kt
+++ b/admob-cmp-gradle-plugin/src/main/kotlin/dev/avinya/ads/gradle/DoctorIosTask.kt
@@ -84,13 +84,27 @@ public abstract class DoctorIosTask : DefaultTask() {
             logger.lifecycle("$skip skipped Info.plist check: none found near $projDir")
         } else {
             val content = plist.readText()
-            if (content.contains("GADApplicationIdentifier")) {
-                logger.lifecycle("$ok Info.plist declares GADApplicationIdentifier")
-                if (content.contains("ca-app-pub-3940256099942544~")) {
-                    logger.lifecycle("$skip   ...but it is still the Google sample app id — replace before release")
+            // The declared VALUE is read, not just the key: a key present with an empty string is
+            // the same configuration gap as an absent one, and matching on the key alone also
+            // matches a mention in a comment.
+            val declaredAppId = GAD_APPLICATION_IDENTIFIER
+                .find(content)
+                ?.groupValues
+                ?.get(1)
+                ?.trim()
+            when {
+                declaredAppId == null ->
+                    logger.lifecycle("$bad Info.plist is missing GADApplicationIdentifier — GMA crashes at startup without it")
+                declaredAppId.isEmpty() -> {
+                    logger.lifecycle("$bad Info.plist declares GADApplicationIdentifier with an empty value")
+                    logger.lifecycle("   GMA crashes at startup on it, and AdMob CMP's preflight fails initialize() with APP_ID_INVALID under the default FailWhenUnusable policy")
                 }
-            } else {
-                logger.lifecycle("$bad Info.plist is missing GADApplicationIdentifier — GMA crashes at startup without it")
+                else -> {
+                    logger.lifecycle("$ok Info.plist declares GADApplicationIdentifier")
+                    if (declaredAppId.startsWith("ca-app-pub-3940256099942544~")) {
+                        logger.lifecycle("$skip   ...but it is still the Google sample app id — replace before release")
+                    }
+                }
             }
             if (content.contains("SKAdNetworkItems")) {
                 logger.lifecycle("$ok Info.plist declares SKAdNetworkItems")
@@ -100,5 +114,12 @@ public abstract class DoctorIosTask : DefaultTask() {
         }
 
         logger.lifecycle("doctorIos is diagnostic only; it never fails the build.")
+    }
+
+    private companion object {
+        val GAD_APPLICATION_IDENTIFIER = Regex(
+            "<key>\\s*GADApplicationIdentifier\\s*</key>\\s*<string>(.*?)</string>",
+            RegexOption.DOT_MATCHES_ALL,
+        )
     }
 }

--- a/admob-cmp/AGENTS.md
+++ b/admob-cmp/AGENTS.md
@@ -209,6 +209,8 @@ then call `adManager.consent.showPrivacyOptions()`. Do NOT gate on
 > `AdPlacement.strictTestMode` is the safety guard: it **throws at construction** if the
 > placement points at a production ad unit. Turn it on in debug builds.
 
+- App-ID preflight: `AdAppIdVerification.policy` (`FailWhenUnusable` default, `Strict`, `WarnOnly`) — set before the first `initialize()` call.
+
 ## iOS setup (executable steps)
 
 1. Add SPM packages to the Xcode project (File → Add Package Dependencies):
@@ -262,6 +264,7 @@ Android has no ATT; `adManager.tracking` is a no-op there, always reporting
 | iOS link: `_OBJC_CLASS_$_GADMobileAds` undefined | GMA SPM package missing → step 1 above |
 | iOS link: `_OBJC_CLASS_$_JSContext` undefined | Add `-framework JavaScriptCore` → step 3 above |
 | Banner composable renders nothing | Manager not `Ready`, or `Manual` refresh policy with no `refresh()` call |
+| App ID mismatch / missing | Check manifest / Info.plist, or configure `AdAppIdVerification.policy` (`FailWhenUnusable`, `Strict`, `WarnOnly`) |
 
 ## KDoc style for data-class constructors
 

--- a/docs-site/src/content/docs/reference/changelog.mdx
+++ b/docs-site/src/content/docs/reference/changelog.mdx
@@ -30,20 +30,21 @@ Release details and release assets for all versions are published on the
 
 ## Unreleased
 
-A reliability release covering exception and cancellation behaviour on paths where several
-resources had already been committed. Four changes are observable from host code.
+A reliability release covering exception, timeout, and cancellation behaviour across consent,
+configuration, and ad presentation.
 
 ### `initialize()` now reports a refused configuration
 
-Calling `initialize()` a second time with a **different** effective configuration — a different app
-ID, `globalRequestConfiguration`, or `nativeAdMemoryPolicy` — previously logged a warning and
-returned the previously applied status, usually `Ready`. The caller received a success-shaped result
-while its configuration had been silently rejected, so ads continued serving under the *first* app
-ID.
+Once a configuration has been handed to the process-global ad SDK, a later `initialize()` with a
+*different* `AdConfig` (a different app ID, `globalRequestConfiguration`, or `nativeAdMemoryPolicy`)
+is refused deterministically rather than being reported as applied. Previously, a mismatched second
+call logged a warning and returned the previously applied status (usually `Ready`), masking the fact
+that its configuration was ignored and ads continued serving under the first app ID.
 
 Such a call now returns `AdManagerStatus.Failed` with `retryable = false` and the new
 `AdErrorCode.INITIALIZATION_CONFLICT`. Calling `initialize()` repeatedly with the *same* effective
-configuration is unaffected and remains idempotent.
+configuration — including retrying after a native initialization timeout — is unaffected and
+remains idempotent.
 
 <Aside type="caution" title="Behaviour change">
 If you branch on the result of a repeated `initialize()`, a configuration mismatch that used to look
@@ -51,6 +52,26 @@ like `Ready` now surfaces as a non-retryable failure. `AdManager.status` still r
 configuration that *was* accepted, so a rejected call never interrupts ad serving for the rest of
 the app.
 </Aside>
+
+### Consent operations are serialized
+
+Concurrent consent operations no longer interleave or corrupt in-flight UMP state:
+
+- `requestConsentInfoUpdate()` queues behind any active consent operation; `gatherConsent()` queues
+  behind a bounded update but returns a failed `ConsentStatus` if another form is already presenting.
+- `showPrivacyOptions()` and `resetConsentForDebug()` return `false` only when a UMP form is already
+  presenting — two forms cannot stack, and resetting under a live form is incoherent. They **wait** for
+  a bounded `requestConsentInfoUpdate()`, so a user opening privacy settings during the launch-time
+  consent refresh still gets the form rather than a spurious failure. Callers should retry once the
+  in-flight form is dismissed.
+
+### Late UMP consent callbacks reconcile privacy state
+
+A UMP consent-information callback arriving after the SDK's bounded timeout still reconciles
+`canRequestAds` and `privacyOptionsRequirementStatus` with the latest native truth. If a user's
+consent was revoked while a slow update was in flight, the late callback ensures the ad-request gate
+closes and cached inventory is purged, rather than leaving obsolete permission active until the next
+cold start.
 
 ### Per-presentation ad audio is restored more correctly
 
@@ -107,6 +128,19 @@ Two new members, both additive and source-compatible:
 
 `AdLogLevel` is now `public` (previously `internal`), since a caller needs it to compare against
 `minLevel` or implement `AdLogSink`.
+
+### App ID verification is now configurable
+
+A preflight check validates that the app ID configured in `AdConfig` agrees with the platform's declared ID (`Info.plist` on iOS, `AndroidManifest.xml` on Android) before touching UMP or GMA.
+
+`AdAppIdVerification.policy` controls how the check behaves:
+
+- `AppIdVerificationPolicy.FailWhenUnusable` (default) — fails initialization with `AdErrorCode.APP_ID_INVALID` only when the platform's native SDK cannot function with the declaration as found (a missing `GADApplicationIdentifier` on iOS, which crashes native GMA). Android manifest mismatches and omissions log a warning and continue, because GMA Next-Gen initializes from `AdConfig.androidAppId` directly while UMP reads the manifest.
+- `AppIdVerificationPolicy.Strict` — fails initialization immediately with `AdErrorCode.APP_ID_INVALID` on any missing or mismatched declaration. Recommended for new integrations, and the intended default starting in 3.0.0.
+- `AppIdVerificationPolicy.WarnOnly` — logs a warning and proceeds for every finding, serving as an escape hatch if the platform declaration is resolved dynamically or via custom bundle packaging.
+
+`AdAppIdVerification.policy` is a process-wide setting (like `AdLogger.sink`) and must be configured during app startup before the first `initialize()` call.
+
 
 ## What changed in 2.1.0?
 

--- a/docs-site/src/content/docs/reference/changelog.mdx
+++ b/docs-site/src/content/docs/reference/changelog.mdx
@@ -59,11 +59,17 @@ Concurrent consent operations no longer interleave or corrupt in-flight UMP stat
 
 - `requestConsentInfoUpdate()` queues behind any active consent operation; `gatherConsent()` queues
   behind a bounded update but returns a failed `ConsentStatus` if another form is already presenting.
-- `showPrivacyOptions()` and `resetConsentForDebug()` return `false` only when a UMP form is already
-  presenting — two forms cannot stack, and resetting under a live form is incoherent. They **wait** for
-  a bounded `requestConsentInfoUpdate()`, so a user opening privacy settings during the launch-time
-  consent refresh still gets the form rather than a spurious failure. Callers should retry once the
-  in-flight form is dismissed.
+- `showPrivacyOptions()` and `resetConsentForDebug()` return `false` when a form-presenting
+  operation holds the consent slot — two forms cannot stack, and resetting under a live form is
+  incoherent. The slot is claimed when such an operation starts, so this also covers the window in
+  which a `gatherConsent()` is still awaiting a host and running its bounded info update, before any
+  form is visible. A `requestConsentInfoUpdate()` never claims the slot: these calls **wait** for it,
+  so a user opening privacy settings during a launch-time consent *refresh* still gets the form
+  rather than a spurious failure. Callers should retry once the in-flight operation finishes.
+- Cancelling the coroutine that called `gatherConsent()` or `showPrivacyOptions()` no longer frees
+  the form slot. Cancellation does not dismiss a form the user is looking at, so other consent
+  operations — including `resetConsentForDebug()` — keep declining until that form's own UMP
+  callback reports back.
 
 ### Late UMP consent callbacks reconcile privacy state
 
@@ -135,7 +141,7 @@ A preflight check validates that the app ID configured in `AdConfig` agrees with
 
 `AdAppIdVerification.policy` controls how the check behaves:
 
-- `AppIdVerificationPolicy.FailWhenUnusable` (default) — fails initialization with `AdErrorCode.APP_ID_INVALID` only when the platform's native SDK cannot function with the declaration as found (a missing `GADApplicationIdentifier` on iOS, which crashes native GMA). Android manifest mismatches and omissions log a warning and continue, because GMA Next-Gen initializes from `AdConfig.androidAppId` directly while UMP reads the manifest.
+- `AppIdVerificationPolicy.FailWhenUnusable` (default) — fails initialization with `AdErrorCode.APP_ID_INVALID` only when the platform's native SDK cannot function with the declaration as found (a missing or blank `GADApplicationIdentifier` on iOS, which crashes native GMA). Android manifest mismatches and omissions log a warning and continue, because GMA Next-Gen initializes from `AdConfig.androidAppId` directly while UMP reads the manifest.
 - `AppIdVerificationPolicy.Strict` — fails initialization immediately with `AdErrorCode.APP_ID_INVALID` on any missing or mismatched declaration. Recommended for new integrations, and the intended default starting in 3.0.0.
 - `AppIdVerificationPolicy.WarnOnly` — logs a warning and proceeds for every finding, serving as an escape hatch if the platform declaration is resolved dynamically or via custom bundle packaging.
 

--- a/docs-site/src/content/docs/reference/troubleshooting.mdx
+++ b/docs-site/src/content/docs/reference/troubleshooting.mdx
@@ -110,6 +110,8 @@ The Google Mobile Ads SDK requires an AdMob application identifier declared in `
 
 Ensure the value is an AdMob **application ID** (containing a tilde `~`), not an ad unit identifier (which uses a forward slash `/`).
 
+AdMob CMP runs a preflight check during `initialize()` comparing `AdConfig` against the platform's declared ID (`AndroidManifest.xml` on Android, `Info.plist` on iOS). Configure verification strictness via `AdAppIdVerification.policy` (`FailWhenUnusable` default, `Strict`, `WarnOnly`).
+
 ## Banner rendering issues
 
 If a banner composable or view renders no content, check the following conditions:

--- a/docs-site/src/content/docs/start/android-setup.mdx
+++ b/docs-site/src/content/docs/start/android-setup.mdx
@@ -28,8 +28,8 @@ Google Mobile Ads requires an Application Identifier declared in your Android ap
 
 - **Metadata Location**: Place `<meta-data>` inside the `<application>` tag of the runnable Android application module (`androidApp`), not inside a shared Kotlin library module.
 - **Identifier Format**: Application IDs use a tilde separator (`ca-app-pub-XXXXXXXXXXXXXXXX~XXXXXXXXXX`). Providing an Ad Unit ID (which uses a slash separator) will cause initialisation failure or runtime crashes.
-- **Runtime Enforcement**: Omitting `com.google.android.gms.ads.APPLICATION_ID` causes the Google Mobile Ads SDK to crash upon app launch.
-- **App ID Preflight**: During `initialize()`, the SDK checks `AdConfig.androidAppId` against the manifest value. Control strictness with `AdAppIdVerification.policy` (`FailWhenUnusable` default, `Strict`, `WarnOnly`).
+- **Consent Identity**: UMP reads `com.google.android.gms.ads.APPLICATION_ID` from the manifest, while GMA Next-Gen initializes from `AdConfig.androidAppId`. Missing or mismatched metadata can make consent and ads resolve different applications and must be fixed.
+- **App ID Preflight**: During `initialize()`, the SDK checks `AdConfig.androidAppId` against the manifest value. `FailWhenUnusable` (the default) warns and continues on Android, `Strict` rejects before UMP or GMA is touched, and `WarnOnly` always warns and continues.
 
 ## Managing the AD_ID permission
 

--- a/docs-site/src/content/docs/start/android-setup.mdx
+++ b/docs-site/src/content/docs/start/android-setup.mdx
@@ -29,6 +29,7 @@ Google Mobile Ads requires an Application Identifier declared in your Android ap
 - **Metadata Location**: Place `<meta-data>` inside the `<application>` tag of the runnable Android application module (`androidApp`), not inside a shared Kotlin library module.
 - **Identifier Format**: Application IDs use a tilde separator (`ca-app-pub-XXXXXXXXXXXXXXXX~XXXXXXXXXX`). Providing an Ad Unit ID (which uses a slash separator) will cause initialisation failure or runtime crashes.
 - **Runtime Enforcement**: Omitting `com.google.android.gms.ads.APPLICATION_ID` causes the Google Mobile Ads SDK to crash upon app launch.
+- **App ID Preflight**: During `initialize()`, the SDK checks `AdConfig.androidAppId` against the manifest value. Control strictness with `AdAppIdVerification.policy` (`FailWhenUnusable` default, `Strict`, `WarnOnly`).
 
 ## Managing the AD_ID permission
 

--- a/docs-site/src/content/docs/start/ios-setup.mdx
+++ b/docs-site/src/content/docs/start/ios-setup.mdx
@@ -56,7 +56,7 @@ Configure your iOS application target's `Info.plist` with required metadata keys
 </array>
 ```
 
-- `GADApplicationIdentifier`: Application identifier with a tilde separator (`ca-app-pub-XXXXXXXXXXXXXXXX~XXXXXXXXXX`).
+- `GADApplicationIdentifier`: Application identifier with a tilde separator (`ca-app-pub-XXXXXXXXXXXXXXXX~XXXXXXXXXX`). Omitting this key crashes native GMA on launch. AdMob CMP validates it during `initialize()` preflight under `AdAppIdVerification.policy` (`FailWhenUnusable` default, `Strict`, `WarnOnly`).
 - `SKAdNetworkItems`: Array of ad network identifiers enabling privacy-preserving ad attribution.
 
 ## App Tracking Transparency (ATT) setup

--- a/docs-site/src/content/docs/start/ios-setup.mdx
+++ b/docs-site/src/content/docs/start/ios-setup.mdx
@@ -56,7 +56,7 @@ Configure your iOS application target's `Info.plist` with required metadata keys
 </array>
 ```
 
-- `GADApplicationIdentifier`: Application identifier with a tilde separator (`ca-app-pub-XXXXXXXXXXXXXXXX~XXXXXXXXXX`). Omitting this key crashes native GMA on launch. AdMob CMP validates it during `initialize()` preflight under `AdAppIdVerification.policy` (`FailWhenUnusable` default, `Strict`, `WarnOnly`).
+- `GADApplicationIdentifier`: Application identifier with a tilde separator (`ca-app-pub-XXXXXXXXXXXXXXXX~XXXXXXXXXX`). Omitting this key, or leaving its value empty, crashes native GMA on launch. AdMob CMP validates it during `initialize()` preflight under `AdAppIdVerification.policy` (`FailWhenUnusable` default, `Strict`, `WarnOnly`).
 - `SKAdNetworkItems`: Array of ad network identifiers enabling privacy-preserving ad attribution.
 
 ## App Tracking Transparency (ATT) setup

--- a/showcase/src/androidMain/kotlin/dev/avinya/admob/showcase/core/device/TestDeviceId.android.kt
+++ b/showcase/src/androidMain/kotlin/dev/avinya/admob/showcase/core/device/TestDeviceId.android.kt
@@ -1,0 +1,43 @@
+package dev.avinya.admob.showcase.core.device
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Both SDKs print the same id, in two different sentences:
+ *
+ * ```
+ * UserMessagingPlatform: Use new ConsentDebugSettings.Builder().addTestDeviceHashedId("<ID>") ...
+ * GoogleMobileAds: Use RequestConfiguration.Builder().setTestDeviceIds(Arrays.asList("<ID>")) ...
+ * ```
+ *
+ * Matching the quoted 32-hex payload catches either, so this keeps working if Google reworks the
+ * surrounding prose or drops one of the two lines.
+ */
+private val LOGGED_ID = Regex("""addTestDeviceHashedId\("([0-9A-F]{32})"\)|setTestDeviceIds\([^)]*"([0-9A-F]{32})"""")
+
+internal actual val supportsLoggedTestDeviceIdDetection: Boolean = true
+
+/**
+ * Reads the id out of this process's own log buffer.
+ *
+ * An app may run `logcat` for itself: since Jelly Bean the log daemon filters by uid, so this
+ * returns only entries this app emitted — which is exactly where the SDKs printed the id. No
+ * permission is required and no other app's logs are visible.
+ *
+ * `-d` dumps and exits rather than streaming, so this cannot hang. Failure of any kind — an OEM
+ * that blocks the binary, a truncated buffer, no id logged yet — collapses to `null` so the caller
+ * can tell the user where to look instead.
+ */
+internal actual suspend fun readLoggedTestDeviceId(): String? = withContext(Dispatchers.IO) {
+    runCatching {
+        val process = ProcessBuilder("logcat", "-d", "-v", "brief").redirectErrorStream(true).start()
+        val matched = process.inputStream.bufferedReader().useLines { lines ->
+            lines.mapNotNull { line ->
+                LOGGED_ID.find(line)?.let { it.groupValues[1].ifEmpty { it.groupValues[2] } }
+            }.lastOrNull()
+        }
+        process.destroy()
+        matched
+    }.getOrNull()
+}

--- a/showcase/src/commonMain/kotlin/dev/avinya/admob/showcase/ShowcaseAdConfig.kt
+++ b/showcase/src/commonMain/kotlin/dev/avinya/admob/showcase/ShowcaseAdConfig.kt
@@ -22,10 +22,14 @@ const val SHOWCASE_IOS_APP_ID: String = "ca-app-pub-3940256099942544~1458002511"
 fun showcaseAdConfig(
     trackingHook: AdInitializationHook,
     debugGeography: ConsentDebugGeography = ConsentDebugGeography.Disabled,
+    testDeviceIds: List<String> = emptyList(),
 ): AdConfig = AdConfig(
     androidAppId = SHOWCASE_ANDROID_APP_ID,
     iosAppId = SHOWCASE_IOS_APP_ID,
     testMode = true,
+    // Feeds BOTH systems: buildConsentParams concatenates consentTestDeviceIds + testDeviceIds,
+    // so one registered id makes the UMP debug geography apply AND forces GMA test ads.
+    testDeviceIds = testDeviceIds,
     debugGeography = debugGeography,
     initializationHooks = listOf(trackingHook),
 )

--- a/showcase/src/commonMain/kotlin/dev/avinya/admob/showcase/core/device/TestDeviceId.kt
+++ b/showcase/src/commonMain/kotlin/dev/avinya/admob/showcase/core/device/TestDeviceId.kt
@@ -1,0 +1,25 @@
+package dev.avinya.admob.showcase.core.device
+
+private val TEST_DEVICE_ID = Regex("[0-9A-F]{32}")
+
+/** Returns the canonical GMA/UMP test-device id, or null when [value] is not a 32-hex id. */
+internal fun normalizeTestDeviceId(value: String): String? =
+    value.trim().uppercase().takeIf(TEST_DEVICE_ID::matches)
+
+/** Whether this platform can read the SDK-generated id from its own process log. */
+internal expect val supportsLoggedTestDeviceIdDetection: Boolean
+
+/**
+ * Recovers this device's hashed test-device id from what GMA and UMP printed to the platform log.
+ *
+ * Deliberately NOT computed. Google documents reading this value off the console and never
+ * publishes the derivation, so reproducing it means reverse-engineering an undocumented scheme —
+ * and getting it wrong fails silently: UMP ignores an unregistered device without complaint, so a
+ * plausible-looking but wrong id presents exactly as "the debug geography does nothing", which is
+ * the bug this whole feature exists to remove. Reading the SDK's own output cannot drift from the
+ * SDK, and when it finds nothing it says so.
+ *
+ * Returns `null` when no id has been logged yet — the SDK only prints it once an ad request or a
+ * consent info update has actually run — or when the platform does not support reading it.
+ */
+internal expect suspend fun readLoggedTestDeviceId(): String?

--- a/showcase/src/commonMain/kotlin/dev/avinya/admob/showcase/data/prefs/SettingsRepository.kt
+++ b/showcase/src/commonMain/kotlin/dev/avinya/admob/showcase/data/prefs/SettingsRepository.kt
@@ -5,6 +5,7 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
+import dev.avinya.admob.showcase.core.device.normalizeTestDeviceId
 import dev.avinya.admob.showcase.ui.theme.ThemeMode
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -13,6 +14,7 @@ internal object SettingsKeys {
     val ThemeMode = stringPreferencesKey("theme_mode")
     val OnboardingComplete = booleanPreferencesKey("onboarding_complete")
     val ConsentDebugGeography = stringPreferencesKey("consent_debug_geography")
+    val ConsentTestDeviceId = stringPreferencesKey("consent_test_device_id")
     val InspectorEnabled = booleanPreferencesKey("inspector_enabled")
     val AdsMasterSwitch = booleanPreferencesKey("ads_master_switch")
 }
@@ -37,6 +39,16 @@ class SettingsRepository(private val dataStore: DataStore<Preferences>) {
     val consentDebugGeography: Flow<String?> =
         dataStore.data.map { it[SettingsKeys.ConsentDebugGeography] }
 
+    /**
+     * This device's hashed test-device id, once registered from the Privacy lab.
+     *
+     * Stored rather than hardcoded because the value identifies one physical device: committing
+     * it would put a personal advertising-id-derived hash into a public repository, and it would
+     * only ever work for whoever committed it. [consentDebugGeography] is inert without it.
+     */
+    val consentTestDeviceId: Flow<String?> =
+        dataStore.data.map { it[SettingsKeys.ConsentTestDeviceId] }
+
     val inspectorEnabled: Flow<Boolean> =
         dataStore.data.map { it[SettingsKeys.InspectorEnabled] ?: true }
 
@@ -55,6 +67,15 @@ class SettingsRepository(private val dataStore: DataStore<Preferences>) {
         dataStore.edit { prefs ->
             if (value == null) prefs.remove(SettingsKeys.ConsentDebugGeography)
             else prefs[SettingsKeys.ConsentDebugGeography] = value
+        }
+    }
+
+    suspend fun setConsentTestDeviceId(value: String?) {
+        val normalized = value?.let(::normalizeTestDeviceId)
+        require(value == null || normalized != null) { "Consent test-device id must be 32 hexadecimal characters." }
+        dataStore.edit { prefs ->
+            if (normalized == null) prefs.remove(SettingsKeys.ConsentTestDeviceId)
+            else prefs[SettingsKeys.ConsentTestDeviceId] = normalized
         }
     }
 

--- a/showcase/src/commonMain/kotlin/dev/avinya/admob/showcase/domain/ad/AdStartupController.kt
+++ b/showcase/src/commonMain/kotlin/dev/avinya/admob/showcase/domain/ad/AdStartupController.kt
@@ -59,13 +59,18 @@ class AdStartupController(
         return state.first { it.phase == AdStartupPhase.Complete }.startup
     }
 
+    /**
+     * Starts the UMP-aware startup sequence.
+     *
+     * UMP must be asked on every launch: it presents a form only when required,
+     * while one-time gathering can strand a user whose consent is now required.
+     */
     fun ensureStarted() {
         val manager = boundManager ?: return
         if (_state.value.running || _state.value.phase == AdStartupPhase.Complete || startupJob?.isActive == true) return
         _state.update { it.copy(running = true) }
         startupJob = scope.launch {
-            val isFirstRun = !settings.onboardingComplete.first()
-            runStartup(manager, gather = isFirstRun)
+            runStartup(manager, gather = true)
         }
     }
 
@@ -111,7 +116,12 @@ class AdStartupController(
                     )
                 }
             }
-            val config = showcaseAdConfig(trackingHook = hook, debugGeography = debugGeography)
+            val testDeviceIds = listOfNotNull(settings.consentTestDeviceId.first())
+            val config = showcaseAdConfig(
+                trackingHook = hook,
+                debugGeography = debugGeography,
+                testDeviceIds = testDeviceIds,
+            )
 
             if (gather) {
                 adManager.consent.gatherConsent(config)

--- a/showcase/src/commonMain/kotlin/dev/avinya/admob/showcase/feature/lab/DiagnosticsLabScreen.kt
+++ b/showcase/src/commonMain/kotlin/dev/avinya/admob/showcase/feature/lab/DiagnosticsLabScreen.kt
@@ -85,12 +85,13 @@ fun DiagnosticsLabScreen(
                                 label = "Startup",
                                 value = when (val current = startup.startup) {
                                     is StartupState.Failed -> "Failed (${current.message})"
+                                    StartupState.ConsentRequired -> "Consent required"
                                     else -> current.toString()
                                 },
-                                valueColor = if (startup.startup is StartupState.Failed) {
-                                    palette.danger
-                                } else {
-                                    palette.ink
+                                valueColor = when (startup.startup) {
+                                    is StartupState.Failed -> palette.danger
+                                    StartupState.ConsentRequired -> palette.accent
+                                    else -> palette.ink
                                 },
                             )
                         }

--- a/showcase/src/commonMain/kotlin/dev/avinya/admob/showcase/feature/lab/PrivacyLabScreen.kt
+++ b/showcase/src/commonMain/kotlin/dev/avinya/admob/showcase/feature/lab/PrivacyLabScreen.kt
@@ -2,16 +2,22 @@ package dev.avinya.admob.showcase.feature.lab
 
 import androidx.compose.material3.MaterialTheme
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -20,6 +26,13 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardType
+import dev.avinya.admob.showcase.core.device.normalizeTestDeviceId
+import dev.avinya.admob.showcase.core.device.readLoggedTestDeviceId
+import dev.avinya.admob.showcase.core.device.supportsLoggedTestDeviceIdDetection
 import dev.avinya.admob.showcase.di.LocalAppGraph
 import dev.avinya.admob.showcase.feature.profile.shouldShowPrivacyOptionsButton
 import dev.avinya.admob.showcase.ui.kit.ChoiceRow
@@ -28,6 +41,7 @@ import dev.avinya.admob.showcase.ui.kit.PrimaryButton
 import dev.avinya.admob.showcase.ui.kit.StatRow
 import dev.avinya.admob.showcase.ui.kit.SunkenPanel
 import dev.avinya.admob.showcase.ui.theme.ShowcaseType
+import dev.avinya.admob.showcase.ui.theme.ShowcaseShapes
 import dev.avinya.admob.showcase.ui.theme.Tokens
 import dev.avinya.admob.showcase.ui.theme.showcaseColors
 import dev.avinya.ads.AdTrackingAuthorization
@@ -59,6 +73,12 @@ fun PrivacyLabScreen(
     val storedGeography by graph.settings.consentDebugGeography.collectAsState(
         initial = ConsentDebugGeography.Disabled.name,
     )
+    val storedTestDeviceId by graph.settings.consentTestDeviceId.collectAsState(initial = null)
+    var testDeviceIdInput by remember { mutableStateOf("") }
+    LaunchedEffect(storedTestDeviceId) {
+        testDeviceIdInput = storedTestDeviceId.orEmpty()
+    }
+    val normalizedTestDeviceId = normalizeTestDeviceId(testDeviceIdInput)
     var tracking by remember { mutableStateOf(adManager.tracking.status()) }
     // Guards showPrivacyOptions/resetConsentForDebug/requestAuthorization
     // against a double-tap firing the SDK call twice concurrently — the
@@ -143,10 +163,106 @@ fun PrivacyLabScreen(
                 }
             }
 
+            item(key = "testDevice") {
+                LabSection(
+                    title = "Test device",
+                    description = "UMP applies the debug geography above ONLY to registered test " +
+                        "devices. On an unregistered physical device an EEA override silently does " +
+                        "nothing. Enter the 32-character id printed in logcat or the Xcode console.",
+                ) {
+                    Column(verticalArrangement = Arrangement.spacedBy(Tokens.Spacing.s8)) {
+                        Text(
+                            text = storedTestDeviceId
+                                ?.let { "Registered: $it" }
+                                ?: "Not registered — the debug geography above has no effect.",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = if (storedTestDeviceId == null) palette.inkMuted else palette.ink,
+                        )
+                        TestDeviceIdField(
+                            value = testDeviceIdInput,
+                            onValueChange = { testDeviceIdInput = it },
+                            enabled = !busy,
+                        )
+                        if (testDeviceIdInput.isNotBlank() && normalizedTestDeviceId == null) {
+                            Text(
+                                text = "Enter exactly 32 hexadecimal characters.",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = palette.danger,
+                            )
+                        }
+                        PrimaryButton(
+                            label = "Save test device ID",
+                            enabled = !busy && normalizedTestDeviceId != null &&
+                                normalizedTestDeviceId != storedTestDeviceId,
+                            modifier = Modifier.fillMaxWidth(),
+                            onClick = {
+                                busy = true
+                                scope.launch {
+                                    try {
+                                        val id = normalizedTestDeviceId ?: return@launch
+                                        graph.settings.setConsentTestDeviceId(id)
+                                        snackbar.showSnackbar("Registered — relaunch to apply")
+                                    } finally {
+                                        busy = false
+                                    }
+                                }
+                            },
+                        )
+                        if (storedTestDeviceId != null) {
+                            GhostButton(
+                                label = "Remove test device ID",
+                                enabled = !busy,
+                                modifier = Modifier.fillMaxWidth(),
+                                onClick = {
+                                    busy = true
+                                    scope.launch {
+                                        try {
+                                            graph.settings.setConsentTestDeviceId(null)
+                                            testDeviceIdInput = ""
+                                            snackbar.showSnackbar("Removed — relaunch to apply")
+                                        } finally {
+                                            busy = false
+                                        }
+                                    }
+                                },
+                            )
+                        }
+                        if (supportsLoggedTestDeviceIdDetection) {
+                            GhostButton(
+                                label = if (storedTestDeviceId == null) "Detect from SDK log" else "Re-detect",
+                                enabled = !busy,
+                                modifier = Modifier.fillMaxWidth(),
+                                onClick = {
+                                    busy = true
+                                    scope.launch {
+                                        try {
+                                            val resolved = readLoggedTestDeviceId()?.let(::normalizeTestDeviceId)
+                                            if (resolved == null) {
+                                                snackbar.showSnackbar(
+                                                    "No id logged yet. Load an ad or relaunch, then retry.",
+                                                )
+                                            } else {
+                                                graph.settings.setConsentTestDeviceId(resolved)
+                                                testDeviceIdInput = resolved
+                                                snackbar.showSnackbar("Registered — relaunch to apply")
+                                            }
+                                        } finally {
+                                            busy = false
+                                        }
+                                    }
+                                },
+                            )
+                        }
+                    }
+                }
+            }
+
             item(key = "reset") {
                 LabSection(
                     title = "Reset",
-                    description = "Clears the stored consent so the form appears again on relaunch.",
+                    description = "Clears stored UMP consent. On the next launch, startup gathers " +
+                        "again and UMP presents a form when required. Debug geography applies only " +
+                        "when a test-device ID is registered above.",
                 ) {
                     GhostButton(
                         label = "Reset consent state",
@@ -155,9 +271,18 @@ fun PrivacyLabScreen(
                         onClick = {
                             busy = true
                             scope.launch {
-                                adManager.consent.resetConsentForDebug()
-                                busy = false
-                                snackbar.showSnackbar("Consent reset — relaunch to see the form")
+                                try {
+                                    val reset = adManager.consent.resetConsentForDebug()
+                                    snackbar.showSnackbar(
+                                        if (reset) {
+                                            "Consent reset — relaunch to review consent"
+                                        } else {
+                                            "A consent form is open. Dismiss it, then retry."
+                                        },
+                                    )
+                                } finally {
+                                    busy = false
+                                }
                             }
                         },
                     )
@@ -215,5 +340,45 @@ fun PrivacyLabScreen(
         }
 
         SnackbarHost(hostState = snackbar, modifier = Modifier.align(Alignment.BottomCenter))
+    }
+}
+
+@Composable
+private fun TestDeviceIdField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    enabled: Boolean,
+) {
+    val palette = showcaseColors
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .heightIn(min = Tokens.touchTarget)
+            .clip(ShowcaseShapes.control)
+            .background(palette.surfaceSunken)
+            .border(Tokens.hairline, palette.hairline, ShowcaseShapes.control)
+            .padding(horizontal = Tokens.Spacing.s12, vertical = Tokens.Spacing.s12),
+        contentAlignment = Alignment.CenterStart,
+    ) {
+        if (value.isEmpty()) {
+            Text(
+                text = "32-character test-device ID",
+                style = MaterialTheme.typography.bodyMedium,
+                color = palette.inkFaint,
+            )
+        }
+        BasicTextField(
+            value = value,
+            onValueChange = onValueChange,
+            enabled = enabled,
+            singleLine = true,
+            textStyle = MaterialTheme.typography.bodyMedium.copy(color = palette.ink),
+            cursorBrush = SolidColor(palette.primary),
+            keyboardOptions = KeyboardOptions(
+                capitalization = KeyboardCapitalization.Characters,
+                keyboardType = KeyboardType.Ascii,
+            ),
+            modifier = Modifier.fillMaxWidth(),
+        )
     }
 }

--- a/showcase/src/commonMain/kotlin/dev/avinya/admob/showcase/feature/onboarding/OnboardingContract.kt
+++ b/showcase/src/commonMain/kotlin/dev/avinya/admob/showcase/feature/onboarding/OnboardingContract.kt
@@ -2,6 +2,7 @@ package dev.avinya.admob.showcase.feature.onboarding
 
 import dev.avinya.ads.AdTrackingAuthorization
 import dev.avinya.admob.showcase.StartupState
+import dev.avinya.admob.showcase.domain.ad.AdStartupPhase
 
 /**
  * The initialisation steps, in the only order that is correct.
@@ -16,12 +17,29 @@ enum class OnboardingStep {
     Initializing,
     Done,
     Failed,
+    ConsentRequired,
     ;
 
     companion object {
         /** The three steps the user actually progresses through. */
         fun orderedSteps(): List<OnboardingStep> = listOf(Consent, Tracking, Initializing)
     }
+}
+
+fun onboardingStepFor(phase: AdStartupPhase, startup: StartupState): OnboardingStep = when (phase) {
+    AdStartupPhase.Idle, AdStartupPhase.Consent -> OnboardingStep.Consent
+    AdStartupPhase.Tracking -> OnboardingStep.Tracking
+    AdStartupPhase.Initializing -> OnboardingStep.Initializing
+    AdStartupPhase.Complete -> when (startup) {
+        StartupState.ConsentRequired -> OnboardingStep.ConsentRequired
+        is StartupState.Failed -> OnboardingStep.Failed
+        else -> OnboardingStep.Done
+    }
+}
+
+fun shouldFinishOnboarding(startup: StartupState): Boolean = when (startup) {
+    StartupState.ConsentRequired, is StartupState.Failed -> false
+    else -> true
 }
 
 /**

--- a/showcase/src/commonMain/kotlin/dev/avinya/admob/showcase/feature/onboarding/OnboardingScreen.kt
+++ b/showcase/src/commonMain/kotlin/dev/avinya/admob/showcase/feature/onboarding/OnboardingScreen.kt
@@ -250,25 +250,48 @@ private fun PreparingPanel(
             )
         }
 
-        val startup = state.startup
-        if (state.step == OnboardingStep.Failed && startup is StartupState.Failed) {
-            Text(
-                text = startup.message,
-                style = MaterialTheme.typography.bodyMedium,
-                color = palette.danger,
-                modifier = Modifier.padding(top = Tokens.Spacing.s8),
-            )
-            PrimaryButton(
-                label = "Try again",
-                onClick = onRetry,
-                enabled = !state.busy,
-                modifier = Modifier.fillMaxWidth(),
-            )
-            GhostButton(
-                label = "Skip and read anyway",
-                onClick = onSkip,
-                modifier = Modifier.fillMaxWidth(),
-            )
+        when (val startup = state.startup) {
+            is StartupState.Failed -> if (state.step == OnboardingStep.Failed) {
+                Text(
+                    text = startup.message,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = palette.danger,
+                    modifier = Modifier.padding(top = Tokens.Spacing.s8),
+                )
+                PrimaryButton(
+                    label = "Try again",
+                    onClick = onRetry,
+                    enabled = !state.busy,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                GhostButton(
+                    label = "Skip and read anyway",
+                    onClick = onSkip,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+
+            StartupState.ConsentRequired -> if (state.step == OnboardingStep.ConsentRequired) {
+                Text(
+                    text = "Ads need your consent before they can load.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = palette.inkMuted,
+                    modifier = Modifier.padding(top = Tokens.Spacing.s8),
+                )
+                PrimaryButton(
+                    label = "Review consent",
+                    onClick = onRetry,
+                    enabled = !state.busy,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                GhostButton(
+                    label = "Continue without ads",
+                    onClick = onSkip,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+
+            else -> Unit
         }
     }
 }
@@ -354,6 +377,7 @@ private fun OnboardingStep.label(): String = when (this) {
     OnboardingStep.Initializing -> "Starting the ads SDK"
     OnboardingStep.Done -> "Ready"
     OnboardingStep.Failed -> "Failed"
+    OnboardingStep.ConsentRequired -> "Consent required"
 }
 
 private fun OnboardingStep.detail(state: OnboardingState): String = when (this) {
@@ -368,6 +392,7 @@ private fun OnboardingStep.detail(state: OnboardingState): String = when (this) 
     OnboardingStep.Initializing -> "Google Mobile Ads, after consent resolves"
     OnboardingStep.Done -> "Done"
     OnboardingStep.Failed -> "Failed"
+    OnboardingStep.ConsentRequired -> "Review your consent choice"
 }
 
 private fun OnboardingStep.statusFor(state: OnboardingState): StepStatus {

--- a/showcase/src/commonMain/kotlin/dev/avinya/admob/showcase/feature/onboarding/OnboardingViewModel.kt
+++ b/showcase/src/commonMain/kotlin/dev/avinya/admob/showcase/feature/onboarding/OnboardingViewModel.kt
@@ -1,11 +1,9 @@
 package dev.avinya.admob.showcase.feature.onboarding
 
 import androidx.lifecycle.viewModelScope
-import dev.avinya.admob.showcase.StartupState
 import dev.avinya.admob.showcase.core.mvi.MviViewModel
 import dev.avinya.admob.showcase.data.prefs.SettingsRepository
 import dev.avinya.admob.showcase.domain.ad.AdStartupController
-import dev.avinya.admob.showcase.domain.ad.AdStartupPhase
 import kotlinx.coroutines.launch
 
 /**
@@ -31,20 +29,10 @@ class OnboardingViewModel(
     init {
         viewModelScope.launch {
             startup.state.collect { snapshot ->
-                val step = when (snapshot.phase) {
-                    AdStartupPhase.Idle, AdStartupPhase.Consent -> OnboardingStep.Consent
-                    AdStartupPhase.Tracking -> OnboardingStep.Tracking
-                    AdStartupPhase.Initializing -> OnboardingStep.Initializing
-                    AdStartupPhase.Complete -> when (snapshot.startup) {
-                        is StartupState.Failed -> OnboardingStep.Failed
-                        else -> OnboardingStep.Done
-                    }
-                }
-
                 updateState {
                     copy(
                         busy = snapshot.running,
-                        step = step,
+                        step = onboardingStepFor(snapshot.phase, snapshot.startup),
                         startup = snapshot.startup,
                         tracking = trackingStepDisplay(snapshot.tracking),
                     )
@@ -69,9 +57,7 @@ class OnboardingViewModel(
                     // re-emit an unchanged value — which left this screen
                     // stuck on the spinner forever.
                     val result = startup.awaitComplete()
-                    // A failure keeps the panel up so the retry action is
-                    // reachable; anything else moves on.
-                    if (result !is StartupState.Failed) finish()
+                    if (shouldFinishOnboarding(result)) finish()
                 }
             }
 
@@ -86,7 +72,10 @@ class OnboardingViewModel(
                 }
             }
 
-            OnboardingIntent.Retry -> startup.retry()
+            OnboardingIntent.Retry -> viewModelScope.launch {
+                val result = startup.retryAwaiting()
+                if (shouldFinishOnboarding(result)) finish()
+            }
 
             OnboardingIntent.Finish -> finish()
         }

--- a/showcase/src/commonMain/kotlin/dev/avinya/admob/showcase/ui/ad/NativeAdLayoutCatalog.kt
+++ b/showcase/src/commonMain/kotlin/dev/avinya/admob/showcase/ui/ad/NativeAdLayoutCatalog.kt
@@ -1,0 +1,162 @@
+@file:Suppress("UnusedPrivateMember")
+
+package dev.avinya.admob.showcase.ui.ad
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import dev.avinya.admob.showcase.ui.theme.ShowcasePalette
+import dev.avinya.admob.showcase.ui.theme.ShowcaseTheme
+import dev.avinya.admob.showcase.ui.theme.ThemeMode
+import dev.avinya.admob.showcase.ui.theme.showcaseColors
+import dev.avinya.ads.nativead.layout.AdLayout
+import dev.avinya.ads.nativead.layout.AdLayoutPreview
+import dev.avinya.ads.nativead.layout.AdLayoutPreviewData
+import dev.avinya.ads.nativead.layout.AdTemplateColors
+import dev.avinya.ads.nativead.layout.AdTemplates
+
+/**
+ * Every native ad layout this app can render, in one enumerable list.
+ *
+ * The list exists for `NativeAdLayoutCatalogTest`, which asserts each layout passes
+ * [AdLayout.validation] in both palettes. An `@Preview` is a `private @Composable` no test can
+ * enumerate, so eyeballing a preview proves nothing on CI; this enum is what turns "the layout
+ * looked fine" into an assertion.
+ *
+ * Note the asymmetry with the previews below: all six layouts are catalogued, but only the three
+ * `AdTemplates` ones are previewed *here*. The three Fieldnotes layouts are previewed next to the
+ * composables that build them — see the `@Preview` functions at the bottom of `FeedAdLayout.kt`,
+ * `FeedRowAdLayout.kt` and `InlineAdLayout.kt` — which is where a preview belongs. Previewing them
+ * here as well would be a second definition of the same thing, free to drift from the first.
+ *
+ * `AdTemplates.compact`/`medium`/`feedCard` have no such home: they are `admob-cmp-compose` API,
+ * not showcase composables, so there is no local function for their previews to sit beside. That
+ * is the only reason this file carries previews at all.
+ */
+internal enum class ShowcaseNativeAdLayout(internal val label: String) {
+    Compact("Compact"),
+    Medium("Medium"),
+    FeedCard("Feed card"),
+    FieldnotesFeed("Fieldnotes feed"),
+    FieldnotesRow("Fieldnotes row"),
+    FieldnotesInline("Fieldnotes inline"),
+    ;
+
+    internal fun layout(
+        palette: ShowcasePalette,
+        headlineFamily: FontFamily,
+    ): AdLayout {
+        val templateColors = if (palette.isDark) AdTemplateColors.dark else AdTemplateColors.light
+        return when (this) {
+            Compact -> AdTemplates.compact(templateColors)
+            Medium -> AdTemplates.medium(templateColors)
+            FeedCard -> AdTemplates.feedCard(templateColors)
+            FieldnotesFeed -> feedAdLayout(palette, headlineFamily, palette.surface)
+            FieldnotesRow -> feedRowAdLayout(palette, headlineFamily, palette.canvas)
+            FieldnotesInline -> inlineAdLayout(palette, headlineFamily, palette.surface)
+        }
+    }
+}
+
+@Composable
+private fun NativeAdLayoutPreview(
+    layoutCase: ShowcaseNativeAdLayout,
+    themeMode: ThemeMode,
+) {
+    ShowcaseTheme(themeMode = themeMode) {
+        val palette = showcaseColors
+        val headlineFamily = MaterialTheme.typography.titleLarge.fontFamily ?: FontFamily.Serif
+        Surface(color = palette.canvas) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 16.dp),
+            ) {
+                AdLayoutPreview(
+                    layout = layoutCase.layout(palette, headlineFamily),
+                    modifier = Modifier.fillMaxWidth(),
+                    data = AdLayoutPreviewData.default,
+                )
+            }
+        }
+    }
+}
+
+@Preview(
+    name = "Compact - Light",
+    group = "Ad templates",
+    showBackground = true,
+    backgroundColor = 0xFFFBF9F5,
+    widthDp = 390,
+)
+@Composable
+private fun CompactLightPreview() {
+    NativeAdLayoutPreview(ShowcaseNativeAdLayout.Compact, ThemeMode.Light)
+}
+
+@Preview(
+    name = "Compact - Dark",
+    group = "Ad templates",
+    showBackground = true,
+    backgroundColor = 0xFF111110,
+    widthDp = 390,
+)
+@Composable
+private fun CompactDarkPreview() {
+    NativeAdLayoutPreview(ShowcaseNativeAdLayout.Compact, ThemeMode.Dark)
+}
+
+@Preview(
+    name = "Medium - Light",
+    group = "Ad templates",
+    showBackground = true,
+    backgroundColor = 0xFFFBF9F5,
+    widthDp = 390,
+)
+@Composable
+private fun MediumLightPreview() {
+    NativeAdLayoutPreview(ShowcaseNativeAdLayout.Medium, ThemeMode.Light)
+}
+
+@Preview(
+    name = "Medium - Dark",
+    group = "Ad templates",
+    showBackground = true,
+    backgroundColor = 0xFF111110,
+    widthDp = 390,
+)
+@Composable
+private fun MediumDarkPreview() {
+    NativeAdLayoutPreview(ShowcaseNativeAdLayout.Medium, ThemeMode.Dark)
+}
+
+@Preview(
+    name = "Feed card - Light",
+    group = "Ad templates",
+    showBackground = true,
+    backgroundColor = 0xFFFBF9F5,
+    widthDp = 390,
+)
+@Composable
+private fun FeedCardLightPreview() {
+    NativeAdLayoutPreview(ShowcaseNativeAdLayout.FeedCard, ThemeMode.Light)
+}
+
+@Preview(
+    name = "Feed card - Dark",
+    group = "Ad templates",
+    showBackground = true,
+    backgroundColor = 0xFF111110,
+    widthDp = 390,
+)
+@Composable
+private fun FeedCardDarkPreview() {
+    NativeAdLayoutPreview(ShowcaseNativeAdLayout.FeedCard, ThemeMode.Dark)
+}

--- a/showcase/src/commonTest/kotlin/dev/avinya/admob/showcase/ShowcaseAdConfigTest.kt
+++ b/showcase/src/commonTest/kotlin/dev/avinya/admob/showcase/ShowcaseAdConfigTest.kt
@@ -36,6 +36,18 @@ class ShowcaseAdConfigTest {
     }
 
     @Test
+    fun testDeviceIdsAreCarriedIntoTheConfig() {
+        val ids = listOf("1BFD804287B2C3AE94087F1138DDA00E")
+
+        val config = showcaseAdConfig(
+            trackingHook = TrackingAuthorizationHook { },
+            testDeviceIds = ids,
+        )
+
+        assertEquals(ids, config.testDeviceIds)
+    }
+
+    @Test
     fun mapsInitialisingStatusesToStarting() {
         assertEquals(StartupState.Starting, AdManagerStatus.Idle.toStartupState())
         assertEquals(StartupState.Starting, AdManagerStatus.Initializing.toStartupState())

--- a/showcase/src/commonTest/kotlin/dev/avinya/admob/showcase/core/device/TestDeviceIdTest.kt
+++ b/showcase/src/commonTest/kotlin/dev/avinya/admob/showcase/core/device/TestDeviceIdTest.kt
@@ -1,0 +1,31 @@
+package dev.avinya.admob.showcase.core.device
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class TestDeviceIdTest {
+
+    @Test
+    fun `uppercase test device id is accepted unchanged`() {
+        assertEquals(
+            "1BFD804287B2C3AE94087F1138DDA00E",
+            normalizeTestDeviceId("1BFD804287B2C3AE94087F1138DDA00E"),
+        )
+    }
+
+    @Test
+    fun `lowercase test device id is trimmed and normalized`() {
+        assertEquals(
+            "1BFD804287B2C3AE94087F1138DDA00E",
+            normalizeTestDeviceId("  1bfd804287b2c3ae94087f1138dda00e  "),
+        )
+    }
+
+    @Test
+    fun `wrong length and non hexadecimal ids are rejected`() {
+        assertNull(normalizeTestDeviceId("1BFD8042"))
+        assertNull(normalizeTestDeviceId("1BFD804287B2C3AE94087F1138DDA00Z"))
+        assertNull(normalizeTestDeviceId("   "))
+    }
+}

--- a/showcase/src/commonTest/kotlin/dev/avinya/admob/showcase/data/prefs/SettingsRepositoryTest.kt
+++ b/showcase/src/commonTest/kotlin/dev/avinya/admob/showcase/data/prefs/SettingsRepositoryTest.kt
@@ -39,6 +39,18 @@ class SettingsRepositoryTest {
     }
 
     @Test
+    fun persistsNormalizedConsentTestDeviceIdAndRemovesIt() = runTest {
+        val repo = SettingsRepository(inMemoryPreferencesDataStore())
+
+        assertEquals(null, repo.consentTestDeviceId.first())
+        repo.setConsentTestDeviceId("  1bfd804287b2c3ae94087f1138dda00e ")
+        assertEquals("1BFD804287B2C3AE94087F1138DDA00E", repo.consentTestDeviceId.first())
+
+        repo.setConsentTestDeviceId(null)
+        assertEquals(null, repo.consentTestDeviceId.first())
+    }
+
+    @Test
     fun anUnrecognisedStoredThemeFallsBackToTheDefault() = runTest {
         val store = inMemoryPreferencesDataStore()
         store.updateData { prefs ->

--- a/showcase/src/commonTest/kotlin/dev/avinya/admob/showcase/domain/ad/AdStartupControllerTest.kt
+++ b/showcase/src/commonTest/kotlin/dev/avinya/admob/showcase/domain/ad/AdStartupControllerTest.kt
@@ -47,6 +47,8 @@ class AdStartupControllerTest {
         var initializeCalls = 0
         var lastConfig: AdConfig? = null
         var lastConsentMode: ConsentMode? = null
+        val gatherConfigs = mutableListOf<AdConfig>()
+        val initializeConfigs = mutableListOf<AdConfig>()
 
         override val consent: ConsentController = object : ConsentController {
             override val status: StateFlow<ConsentStatus> = MutableStateFlow(ConsentStatus.Unknown)
@@ -57,6 +59,7 @@ class AdStartupControllerTest {
             override suspend fun gatherConsent(config: AdConfig): ConsentStatus {
                 gatherConsentCalls++
                 lastConfig = config
+                gatherConfigs += config
                 return ConsentStatus.Obtained
             }
             override suspend fun showPrivacyOptions(): Boolean = true
@@ -71,6 +74,7 @@ class AdStartupControllerTest {
         override suspend fun initialize(config: AdConfig, consentMode: ConsentMode): AdManagerStatus {
             initializeCalls++
             lastConfig = config
+            initializeConfigs += config
             lastConsentMode = consentMode
             config.initializationHooks.forEach {
                 it.onPhase(dev.avinya.ads.AdInitializationPhase.BeforeMobileAdsInitialize, config)
@@ -103,7 +107,7 @@ class AdStartupControllerTest {
     }
 
     @Test
-    fun `returning run skips gatherConsent but still initialises`() = runTest {
+    fun `returning run gathers consent before initialising`() = runTest {
         val settings = SettingsRepository(inMemoryPreferencesDataStore())
         settings.setOnboardingComplete(true)
         val controller = AdStartupController(settings, this)
@@ -112,7 +116,9 @@ class AdStartupControllerTest {
         controller.attach(manager)
         testScheduler.advanceUntilIdle()
 
-        assertEquals(0, manager.gatherConsentCalls)
+        // UMP decides whether a form is necessary; skipping the gather on a
+        // later launch can strand a user whose consent has become required.
+        assertEquals(1, manager.gatherConsentCalls)
         assertEquals(1, manager.initializeCalls)
         assertEquals(ConsentMode.InitializeOnlyIfAlreadyAllowed, manager.lastConsentMode)
         assertEquals(AdStartupPhase.Complete, controller.state.value.phase)
@@ -130,6 +136,21 @@ class AdStartupControllerTest {
         testScheduler.advanceUntilIdle()
 
         assertEquals(ConsentDebugGeography.Eea, manager.lastConfig?.debugOptions?.consentDebugGeography)
+    }
+
+    @Test
+    fun `persisted test device id reaches gathering and initialization`() = runTest {
+        val settings = SettingsRepository(inMemoryPreferencesDataStore())
+        val id = "1BFD804287B2C3AE94087F1138DDA00E"
+        settings.setConsentTestDeviceId(id)
+        val controller = AdStartupController(settings, this)
+        val manager = FakeAdManager()
+
+        controller.attach(manager)
+        testScheduler.advanceUntilIdle()
+
+        assertEquals(listOf(id), manager.gatherConfigs.single().testDeviceIds)
+        assertEquals(listOf(id), manager.initializeConfigs.single().testDeviceIds)
     }
 
     @Test
@@ -155,14 +176,14 @@ class AdStartupControllerTest {
         controller.attach(manager)
         testScheduler.advanceUntilIdle()
 
-        assertEquals(0, manager.gatherConsentCalls)
+        assertEquals(1, manager.gatherConsentCalls)
         assertEquals(1, manager.initializeCalls)
         assertEquals(StartupState.ConsentRequired, controller.state.value.startup)
 
         manager.initResult = AdManagerStatus.Ready
         val result = controller.retryAwaiting()
 
-        assertEquals(1, manager.gatherConsentCalls)
+        assertEquals(2, manager.gatherConsentCalls)
         assertEquals(2, manager.initializeCalls)
         assertEquals(StartupState.Ready, result)
         assertEquals(StartupState.Ready, controller.state.value.startup)

--- a/showcase/src/commonTest/kotlin/dev/avinya/admob/showcase/feature/onboarding/OnboardingOutcomeTest.kt
+++ b/showcase/src/commonTest/kotlin/dev/avinya/admob/showcase/feature/onboarding/OnboardingOutcomeTest.kt
@@ -1,0 +1,61 @@
+package dev.avinya.admob.showcase.feature.onboarding
+
+import dev.avinya.admob.showcase.StartupState
+import dev.avinya.admob.showcase.domain.ad.AdStartupPhase
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class OnboardingOutcomeTest {
+
+    @Test
+    fun `consent required and failed outcomes keep onboarding open`() {
+        assertFalse(shouldFinishOnboarding(StartupState.ConsentRequired))
+        assertFalse(shouldFinishOnboarding(StartupState.Failed("Network unavailable", retryable = true)))
+    }
+
+    @Test
+    fun `ready and starting outcomes finish onboarding`() {
+        assertTrue(shouldFinishOnboarding(StartupState.Ready))
+        assertTrue(shouldFinishOnboarding(StartupState.Starting))
+    }
+
+    @Test
+    fun `complete phase distinguishes consent required failed and ready outcomes`() {
+        assertEquals(
+            OnboardingStep.ConsentRequired,
+            onboardingStepFor(AdStartupPhase.Complete, StartupState.ConsentRequired),
+        )
+        assertEquals(
+            OnboardingStep.Failed,
+            onboardingStepFor(
+                AdStartupPhase.Complete,
+                StartupState.Failed("Startup failed", retryable = true),
+            ),
+        )
+        assertEquals(
+            OnboardingStep.Done,
+            onboardingStepFor(AdStartupPhase.Complete, StartupState.Ready),
+        )
+    }
+
+    @Test
+    fun `in progress phases retain their matching onboarding step`() {
+        assertEquals(OnboardingStep.Consent, onboardingStepFor(AdStartupPhase.Idle, StartupState.Starting))
+        assertEquals(OnboardingStep.Consent, onboardingStepFor(AdStartupPhase.Consent, StartupState.Starting))
+        assertEquals(OnboardingStep.Tracking, onboardingStepFor(AdStartupPhase.Tracking, StartupState.Starting))
+        assertEquals(
+            OnboardingStep.Initializing,
+            onboardingStepFor(AdStartupPhase.Initializing, StartupState.Starting),
+        )
+    }
+
+    @Test
+    fun `progress remains consent tracking and initializing only`() {
+        assertEquals(
+            listOf(OnboardingStep.Consent, OnboardingStep.Tracking, OnboardingStep.Initializing),
+            OnboardingStep.orderedSteps(),
+        )
+    }
+}

--- a/showcase/src/commonTest/kotlin/dev/avinya/admob/showcase/feature/onboarding/OnboardingViewModelTest.kt
+++ b/showcase/src/commonTest/kotlin/dev/avinya/admob/showcase/feature/onboarding/OnboardingViewModelTest.kt
@@ -1,0 +1,124 @@
+package dev.avinya.admob.showcase.feature.onboarding
+
+import dev.avinya.ads.AdConfig
+import dev.avinya.ads.AdDiagnostics
+import dev.avinya.ads.AdEvent
+import dev.avinya.ads.AdManager
+import dev.avinya.ads.AdManagerStatus
+import dev.avinya.ads.AdPlacement
+import dev.avinya.ads.AdTrackingAuthorization
+import dev.avinya.ads.AdTrackingController
+import dev.avinya.ads.AppOpenAdController
+import dev.avinya.ads.BannerAdController
+import dev.avinya.ads.ConsentController
+import dev.avinya.ads.ConsentMode
+import dev.avinya.ads.ConsentStatus
+import dev.avinya.ads.InterstitialAdController
+import dev.avinya.ads.NoOpAdManager
+import dev.avinya.ads.PrivacyOptionsRequirementStatus
+import dev.avinya.ads.RewardedAdController
+import dev.avinya.ads.RewardedInterstitialAdController
+import dev.avinya.ads.nativead.NativeAdManager
+import dev.avinya.admob.showcase.StartupState
+import dev.avinya.admob.showcase.data.prefs.SettingsRepository
+import dev.avinya.admob.showcase.data.prefs.inMemoryPreferencesDataStore
+import dev.avinya.admob.showcase.domain.ad.AdStartupController
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class OnboardingViewModelTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `retrying from consent required to ready finishes and persists onboarding`() = runTest(dispatcher) {
+        val settings = SettingsRepository(inMemoryPreferencesDataStore())
+        val controller = AdStartupController(settings, this)
+        val manager = ControllableAdManager(AdManagerStatus.ConsentRequired)
+        controller.attach(manager)
+        advanceUntilIdle()
+        assertEquals(StartupState.ConsentRequired, controller.state.value.startup)
+
+        val viewModel = OnboardingViewModel(controller, settings)
+        advanceUntilIdle()
+        manager.initResult = AdManagerStatus.Ready
+        val finished = async { viewModel.effects.first() }
+
+        viewModel.onIntent(OnboardingIntent.Retry)
+        advanceUntilIdle()
+
+        // This catches a fire-and-forget retry that reaches Ready but never
+        // calls finish(), leaving the preparing panel without a terminal action.
+        try {
+            assertTrue(finished.isCompleted, "A successful retry must emit Finished")
+            assertEquals(OnboardingEffect.Finished, finished.await())
+            assertTrue(settings.onboardingComplete.first())
+        } finally {
+            finished.cancel()
+        }
+    }
+
+    private class ControllableAdManager(
+        var initResult: AdManagerStatus,
+    ) : AdManager {
+        private val mutableStatus = MutableStateFlow<AdManagerStatus>(AdManagerStatus.Disabled("Disabled"))
+        override val status: StateFlow<AdManagerStatus> = mutableStatus.asStateFlow()
+        override val events: SharedFlow<AdEvent> get() = NoOpAdManager.events
+        override val diagnostics: AdDiagnostics get() = NoOpAdManager.diagnostics
+        override val nativeAds: NativeAdManager get() = NoOpAdManager.nativeAds
+
+        override val consent: ConsentController = object : ConsentController {
+            override val status: StateFlow<ConsentStatus> = MutableStateFlow(ConsentStatus.Unknown)
+            override val privacyOptionsRequirementStatus: StateFlow<PrivacyOptionsRequirementStatus> =
+                MutableStateFlow(PrivacyOptionsRequirementStatus.Unknown)
+            override val canRequestAds: StateFlow<Boolean> = MutableStateFlow(true)
+            override suspend fun requestConsentInfoUpdate(config: AdConfig): ConsentStatus = ConsentStatus.Obtained
+            override suspend fun gatherConsent(config: AdConfig): ConsentStatus = ConsentStatus.Obtained
+            override suspend fun showPrivacyOptions(): Boolean = true
+            override suspend fun resetConsentForDebug(): Boolean = true
+        }
+
+        override val tracking: AdTrackingController = object : AdTrackingController {
+            override fun status(): AdTrackingAuthorization = AdTrackingAuthorization.Authorized
+            override suspend fun requestAuthorization(): AdTrackingAuthorization = AdTrackingAuthorization.Authorized
+        }
+
+        override suspend fun initialize(config: AdConfig, consentMode: ConsentMode): AdManagerStatus =
+            initResult.also { mutableStatus.value = it }
+
+        override fun banner(placement: AdPlacement): BannerAdController = NoOpAdManager.banner(placement)
+        override fun interstitial(placement: AdPlacement): InterstitialAdController = NoOpAdManager.interstitial(placement)
+        override fun rewarded(placement: AdPlacement): RewardedAdController = NoOpAdManager.rewarded(placement)
+        override fun rewardedInterstitial(placement: AdPlacement): RewardedInterstitialAdController =
+            NoOpAdManager.rewardedInterstitial(placement)
+        override fun appOpen(placement: AdPlacement): AppOpenAdController = NoOpAdManager.appOpen(placement)
+    }
+}

--- a/showcase/src/commonTest/kotlin/dev/avinya/admob/showcase/ui/ad/NativeAdLayoutCatalogTest.kt
+++ b/showcase/src/commonTest/kotlin/dev/avinya/admob/showcase/ui/ad/NativeAdLayoutCatalogTest.kt
@@ -1,0 +1,38 @@
+package dev.avinya.admob.showcase.ui.ad
+
+import androidx.compose.ui.text.font.FontFamily
+import dev.avinya.admob.showcase.ui.theme.ShowcaseDarkPalette
+import dev.avinya.admob.showcase.ui.theme.ShowcaseLightPalette
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Covers every layout in [ShowcaseNativeAdLayout], including the three Fieldnotes ones whose
+ * `@Preview`s live beside their own composables. Policy compliance is asserted here rather than
+ * per-file precisely because a preview cannot assert anything.
+ */
+class NativeAdLayoutCatalogTest {
+
+    @Test
+    fun `catalog lists every native layout the showcase can render`() {
+        assertEquals(
+            listOf("Compact", "Medium", "Feed card", "Fieldnotes feed", "Fieldnotes row", "Fieldnotes inline"),
+            ShowcaseNativeAdLayout.entries.map { it.label },
+        )
+    }
+
+    @Test
+    fun `every catalogued layout is policy compliant in both themes`() {
+        listOf(ShowcaseLightPalette, ShowcaseDarkPalette).forEach { palette ->
+            ShowcaseNativeAdLayout.entries.forEach { layoutCase ->
+                val layout = layoutCase.layout(palette, FontFamily.Serif)
+
+                assertTrue(
+                    layout.validation.errors.isEmpty(),
+                    "${layoutCase.label} has validation errors: ${layout.validation.errors}",
+                )
+            }
+        }
+    }
+}

--- a/showcase/src/iosMain/kotlin/dev/avinya/admob/showcase/core/device/TestDeviceId.ios.kt
+++ b/showcase/src/iosMain/kotlin/dev/avinya/admob/showcase/core/device/TestDeviceId.ios.kt
@@ -1,0 +1,10 @@
+package dev.avinya.admob.showcase.core.device
+
+internal actual val supportsLoggedTestDeviceIdDetection: Boolean = false
+
+/**
+ * Not supported on iOS: there is no in-process equivalent of reading your own log buffer, so the
+ * id has to be copied out of the Xcode console and entered in the Privacy lab. Returning `null`
+ * keeps the unsupported platform boundary explicit.
+ */
+internal actual suspend fun readLoggedTestDeviceId(): String? = null


### PR DESCRIPTION
Two commits hardening consent-form ownership and app-id preflight, plus the showcase tooling that exercises them.

## Consent form ownership

The form slot is now handed to UMP at an irreversible boundary and released by UMP's own callback, so cancelling the calling coroutine no longer frees a slot whose form is still on screen.

- `markFormPresented` / `releaseFormPresentation` on `ConsentOperationCoordinator`, paired identically in `gatherConsent` and `showPrivacyOptions` on both platforms.
- `InitializationTimeouts.formPresentationPin` (5 min) backstops the handoff. A UMP callback that never fires would otherwise refuse every consent operation for the life of the process. The pin expires; the form itself stays unbounded, because timing out a form the user is reading would be a bug, not a safeguard.
- `ConsentStateHolder` and `ConsentOperationCoordinator` take an injectable `TimeSource`, so the backstop is tested with `TestTimeSource` rather than wall-clock.
- iOS `prepareConsentConfig` extraction removes the last hand-copied preamble, making the info-update policy genuinely shared rather than duplicated. The two controllers diverging is the historical failure this guards against.

## App id verification

- Blank declared values go through `DeclaredAppId.ofDeclaredValue`, with a defensive `normalized()` at both policy sites so a future direct `Present("")` cannot reopen the gap.
- Severity is graduated by `AppIdVerificationPolicy.requiredByPlatformSdk`: fatal on iOS where the platform SDK requires the id, a warning on Android — so a manifest mismatch does not take ad serving down in a minor release.
- `DoctorIosTask` matches `GAD_APPLICATION_IDENTIFIER` with a regex over the key/value pair instead of a substring match on the key name.

## Docs precision

`showPrivacyOptions()` and `resetConsentForDebug()` documented that only a *live form* returns `false`. That was not accurate: `exclusiveOfForms` claims the slot on entry via `presentsForm`, so the decline window opens while `gatherConsent` is still awaiting a host and running its bounded info update, before any form is visible.

The early claim is deliberate — freeing the slot for that window would let a second caller reach `markFormPresented` first and race two presentations — but the KDoc, the coordinator comment and the changelog all overstated it. All four sites now say "a form-presenting operation holds the slot".

## Showcase

- Consent is gathered on **every launch** instead of first run only, matching Google's documented UMP flow. UMP presents a form only when required, whereas one-time gathering strands a user whose consent becomes required later.
- `TestDeviceId` expect/actual reads the logged test device id per platform, normalizes it, persists it via `SettingsRepository` and feeds it into `AdConfig` — test ads without editing source.
- `NativeAdLayoutCatalog`, an expanded Privacy Lab, and an onboarding rework (`OnboardingPanel` / `TrackingStepDisplay` / `OnboardingOutcome`).

## Tests

- `ConsentStateHolderTest` replaces the two hand-copied platform reconciliation tests, which asserted against a duplicate of the helpers and so could not catch a mis-wired controller.
- New coverage: cancellation before vs after the handoff boundary, superseded-generation release, and pin expiry at the backstop.
- `AppIdPreflightTest` restores the process-wide policy var in `@AfterTest` — iOS `commonTest` runs in a single process.

## Verification

`./scripts/release-readiness.sh` — **`READINESS: PASS`**, exit 0. Full run, no flags, nothing skipped:

| # | Section |
|---|---|
| 1 | Version lockstep |
| 2 | Gradle plugin build + supply-chain policy |
| 3 | Static analysis and coverage |
| 4 | Android + ABI + publication metadata |
| 5 | Central task graph |
| 6 | iOS + klib ABI |
| 7 | Published-consumer round trip |
| 8 | Xcode consumer |
| 9 | Docs — Dokka + Astro + audit (`AUDIT OK — 30 pages`) |

`--skip-docs` was not eligible: this branch touches `admob-cmp-core/` and `docs-site/`.

Public ABI is additive only (`AppIdVerificationPolicy`, `AdAppIdVerification`, `AdErrorCode.APP_ID_INVALID`); `api/*.klib.api` dumps are in sync for both `admob-cmp-core` and `admob-cmp-compose`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)