### PR TITLE
chore(release): bump VERSION_NAME to 2.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Coming from a hand-rolled `expect class AdManager`? See the [migration guide](ht
 
 ```kotlin
 // commonMain
-implementation("dev.avinya.ads:admob-cmp:2.1.0")
+implementation("dev.avinya.ads:admob-cmp:2.2.0")
 ```
 
 > [!IMPORTANT]
@@ -33,7 +33,7 @@ implementation("dev.avinya.ads:admob-cmp:2.1.0")
 >
 > ```kotlin
 > plugins {
->     id("dev.avinya.ads.admob-cmp") version "2.1.0"
+>     id("dev.avinya.ads.admob-cmp") version "2.2.0"
 > }
 > ```
 
@@ -159,6 +159,7 @@ NativeAdView(session = session, slotKey = "after-article-3", placement = nativeP
 
 | admob-cmp | Kotlin | Compose Multiplatform | Android `minSdk` | iOS deployment target |
 |---|---|---|---|---|
+| 2.2.0 | 2.3.20 | 1.11.1 | 26 | 15.0 |
 | 2.1.0 | 2.3.20 | 1.11.1 | 26 | 15.0 |
 | 2.0.1 | 2.3.20 | 1.11.1 | 26 | 15.0 |
 | 2.0.0 | 2.3.20 | 1.11.1 | 26 | 15.0 |
@@ -167,7 +168,7 @@ NativeAdView(session = session, slotKey = "after-article-3", placement = nativeP
 | 1.0.2 | 2.3.20 | 1.11.1 | 26 | 15.0 |
 | 1.0.0 | 2.3.20 | 1.11.1 | 26 | 15.0 |
 
-Underlying Google SDKs bound by 2.1.0:
+Underlying Google SDKs bound by 2.2.0:
 
 | SDK | Version |
 |---|---|

--- a/admob-cmp-gradle-plugin/gradle.properties
+++ b/admob-cmp-gradle-plugin/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=dev.avinya.ads
-VERSION_NAME=2.1.0
+VERSION_NAME=2.2.0
 POM_ARTIFACT_ID=admob-cmp-gradle-plugin
 POM_NAME=AdMob CMP Gradle Plugin
 POM_DESCRIPTION=AdMob CMP Gradle plugin for Kotlin Multiplatform projects. Links Google Mobile Ads and UMP into Kotlin/Native iOS test executables, resolving GAD undefined-symbol linker errors. Not affiliated with or endorsed by Google. AdMob and Google Mobile Ads are trademarks of Google LLC.

--- a/docs-site/src/content/docs/index.mdx
+++ b/docs-site/src/content/docs/index.mdx
@@ -42,7 +42,7 @@ The SDK provides a single-coordinate facade (`dev.avinya.ads:admob-cmp`) for And
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            implementation("dev.avinya.ads:admob-cmp:2.1.0")
+            implementation("dev.avinya.ads:admob-cmp:2.2.0")
         }
     }
 }

--- a/docs-site/src/content/docs/reference/changelog.mdx
+++ b/docs-site/src/content/docs/reference/changelog.mdx
@@ -12,11 +12,12 @@ import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
 All published artifacts live under `dev.avinya.ads` on Maven Central:
 `admob-cmp`, `admob-cmp-core`, `admob-cmp-compose`, and the
 `dev.avinya.ads.admob-cmp.gradle.plugin` marker. The current
-release is **2.1.0**.
+release is **2.2.0**.
 
 | Version | Status | Highlights |
 |---|---|---|
-| 2.1.0 | Current | Native-ad renderer parity across Android, iOS, and preview; themeable templates |
+| 2.2.0 | Current | Non-retryable `initialize()` conflicts, serialized consent operations, bounded startup timeouts, constructor-time configuration validation, configurable `AdLogger` and app ID verification policy |
+| 2.1.0 | Superseded | Native-ad renderer parity across Android, iOS, and preview; themeable templates |
 | 2.0.1 | Superseded | Native-ad custom fonts, renderer parity, synchronous leases, and grid sessions |
 | 2.0.0 | Superseded | Release 2.0.0 |
 | 1.1.1 | Superseded | Banner and native state-machine fixes, main-thread confinement of SDK metadata reads, stricter test-mode warning |
@@ -28,7 +29,7 @@ release is **2.1.0**.
 Release details and release assets for all versions are published on the
 [GitHub releases page](https://github.com/Meet-Miyani/admob-compose-multiplatform/releases).
 
-## Unreleased
+## What changed in 2.2.0?
 
 A reliability release covering exception, timeout, and cancellation behaviour across consent,
 configuration, and ad presentation.

--- a/docs-site/src/content/docs/reference/compatibility.mdx
+++ b/docs-site/src/content/docs/reference/compatibility.mdx
@@ -14,6 +14,7 @@ Every row in the matrix reflects the exact toolchain and platform SDK bindings p
 
 | `admob-cmp` | Kotlin | Compose Multiplatform | Android `minSdk` | iOS deployment target |
 |---|---|---|---|---|
+| 2.2.0 | 2.3.20 | 1.11.1 | 26 | 15.0 |
 | 2.1.0 | 2.3.20 | 1.11.1 | 26 | 15.0 |
 | 2.0.1 | 2.3.20 | 1.11.1 | 26 | 15.0 |
 | 2.0.0 | 2.3.20 | 1.11.1 | 26 | 15.0 |

--- a/docs-site/src/content/docs/reference/troubleshooting.mdx
+++ b/docs-site/src/content/docs/reference/troubleshooting.mdx
@@ -25,7 +25,7 @@ Applying the `dev.avinya.ads.admob-cmp` Gradle plugin resolves this issue automa
 ```kotlin
 // shared/build.gradle.kts
 plugins {
-    id("dev.avinya.ads.admob-cmp") version "2.1.0"
+    id("dev.avinya.ads.admob-cmp") version "2.2.0"
 }
 ```
 

--- a/docs-site/src/content/docs/start/android-setup.mdx
+++ b/docs-site/src/content/docs/start/android-setup.mdx
@@ -56,7 +56,7 @@ Removing `AD_ID` disables access to the device advertising identifier on Android
 
 ## Android build requirements
 
-AdMob CMP 2.1.0 is built and tested against the following toolchain specifications:
+AdMob CMP 2.2.0 is built and tested against the following toolchain specifications:
 
 | Setting | Tested Version / Specification |
 |---|---|

--- a/docs-site/src/content/docs/start/installation.mdx
+++ b/docs-site/src/content/docs/start/installation.mdx
@@ -38,7 +38,7 @@ Most Compose Multiplatform applications should depend on the umbrella coordinate
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            implementation("dev.avinya.ads:admob-cmp:2.1.0")
+            implementation("dev.avinya.ads:admob-cmp:2.2.0")
         }
     }
 }
@@ -50,8 +50,8 @@ The umbrella artifact includes both `admob-cmp-core` and `admob-cmp-compose`.
 
 For projects that do not use Compose Multiplatform or require decoupled architectures, the underlying modules can be imported individually:
 
-- `dev.avinya.ads:admob-cmp-core:2.1.0`: Contains core controllers (`AdManager`, `BannerAdController`, `InterstitialAdController`), lifecycle state machines, ad caching, retry policies, and platform adapters. Has no Compose Multiplatform dependencies.
-- `dev.avinya.ads:admob-cmp-compose:2.1.0`: Contains Compose Multiplatform composables (`rememberAdManager()`, `BannerAdView`, `NativeAdView`). Depends on `admob-cmp-core`.
+- `dev.avinya.ads:admob-cmp-core:2.2.0`: Contains core controllers (`AdManager`, `BannerAdController`, `InterstitialAdController`), lifecycle state machines, ad caching, retry policies, and platform adapters. Has no Compose Multiplatform dependencies.
+- `dev.avinya.ads:admob-cmp-compose:2.2.0`: Contains Compose Multiplatform composables (`rememberAdManager()`, `BannerAdView`, `NativeAdView`). Depends on `admob-cmp-core`.
 
 ## Version catalog configuration
 
@@ -60,7 +60,7 @@ For multi-module Gradle projects, manage library dependencies and plugin definit
 ```toml
 # gradle/libs.versions.toml
 [versions]
-admob-cmp = "2.1.0"
+admob-cmp = "2.2.0"
 
 [libraries]
 admob-cmp = { module = "dev.avinya.ads:admob-cmp", version.ref = "admob-cmp" }
@@ -95,7 +95,7 @@ To resolve Kotlin/Native test linking, apply the `dev.avinya.ads.admob-cmp` Grad
 ```kotlin
 // shared/build.gradle.kts
 plugins {
-    id("dev.avinya.ads.admob-cmp") version "2.1.0"
+    id("dev.avinya.ads.admob-cmp") version "2.2.0"
 }
 ```
 

--- a/docs-site/src/content/docs/start/ios-setup.mdx
+++ b/docs-site/src/content/docs/start/ios-setup.mdx
@@ -20,10 +20,10 @@ AdMob CMP distributes Objective-C cinterop bindings in its Kotlin Multiplatform 
 1. In Xcode, open your iOS project and select **File → Add Package Dependencies...**
 2. Enter the Google Mobile Ads SPM repository URL:
    `https://github.com/googleads/swift-package-manager-google-mobile-ads.git`
-   Select the **GoogleMobileAds** product and specify version rule **Up to Next Major** with **13.x** (AdMob CMP 2.1.0 binds GMA iOS 13.7.0).
+   Select the **GoogleMobileAds** product and specify version rule **Up to Next Major** with **13.x** (AdMob CMP 2.2.0 binds GMA iOS 13.7.0).
 3. Enter the User Messaging Platform SPM repository URL:
    `https://github.com/googleads/swift-package-manager-google-user-messaging-platform.git`
-   Select the **GoogleUserMessagingPlatform** product and specify version rule **Up to Next Major** with **3.x** (AdMob CMP 2.1.0 binds UMP iOS 3.1.0).
+   Select the **GoogleUserMessagingPlatform** product and specify version rule **Up to Next Major** with **3.x** (AdMob CMP 2.2.0 binds UMP iOS 3.1.0).
 
 </Steps>
 
@@ -109,7 +109,7 @@ Executing Kotlin/Native test tasks (such as `./gradlew :shared:iosSimulatorArm64
 ```kotlin
 // shared/build.gradle.kts
 plugins {
-    id("dev.avinya.ads.admob-cmp") version "2.1.0"
+    id("dev.avinya.ads.admob-cmp") version "2.2.0"
 }
 ```
 

--- a/docs-site/src/content/docs/start/quickstart.mdx
+++ b/docs-site/src/content/docs/start/quickstart.mdx
@@ -19,7 +19,7 @@ First, add the core AdMob CMP library to your shared Kotlin module.
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            implementation("dev.avinya.ads:admob-cmp:2.1.0")
+            implementation("dev.avinya.ads:admob-cmp:2.2.0")
         }
     }
 }
@@ -32,7 +32,7 @@ If your project runs Kotlin/Native unit tests (`:shared:iosSimulatorArm64Test`),
 ```kotlin
 // shared/build.gradle.kts
 plugins {
-    id("dev.avinya.ads.admob-cmp") version "2.1.0"
+    id("dev.avinya.ads.admob-cmp") version "2.2.0"
 }
 ```
 

--- a/docs-site/src/content/docs/start/what-is-admob-cmp.mdx
+++ b/docs-site/src/content/docs/start/what-is-admob-cmp.mdx
@@ -12,7 +12,7 @@ import PlatformMatrix from '../../../components/diagrams/PlatformMatrix.astro';
 
 AdMob CMP is an open-source Kotlin Multiplatform (KMP) SDK for Google AdMob in Compose Multiplatform applications. It provides one shared Kotlin API for Google Mobile Ads (GMA), User Messaging Platform (UMP) consent state, ad loading, presentation, and revenue events on Android and iOS.
 
-Instead of maintaining separate Android and iOS ad abstractions, add `dev.avinya.ads:admob-cmp:2.1.0` and call the same controllers from `commonMain`. Native application IDs, store disclosures, consent configuration, and iOS package setup remain the application's responsibility.
+Instead of maintaining separate Android and iOS ad abstractions, add `dev.avinya.ads:admob-cmp:2.2.0` and call the same controllers from `commonMain`. Native application IDs, store disclosures, consent configuration, and iOS package setup remain the application's responsibility.
 
 ## Why use AdMob CMP?
 

--- a/docs-site/src/data/landing.ts
+++ b/docs-site/src/data/landing.ts
@@ -120,8 +120,8 @@ export interface LandingMeta {
 }
 
 export const landingMeta: LandingMeta = {
-  mavenCoordinate: 'dev.avinya.ads:admob-cmp:2.1.0',
-  gradlePlugin: 'dev.avinya.ads.admob-cmp:2.1.0',
+  mavenCoordinate: 'dev.avinya.ads:admob-cmp:2.2.0',
+  gradlePlugin: 'dev.avinya.ads.admob-cmp:2.2.0',
   kotlinVersion: '2.3.20',
   composeMultiplatformVersion: '1.11.1',
   androidMinSdk: 26,

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ umpIosHeadersSha256=02b6b1925be8a6cfc294478c1a6bb1dd4de70cd9e4f31cbbfb789ab4de7b
 
 # Publishing metadata shared by all published artifacts.
 GROUP=dev.avinya.ads
-VERSION_NAME=2.1.0
+VERSION_NAME=2.2.0
 POM_NAME=AdMob CMP
 POM_DESCRIPTION=Open-source Kotlin Multiplatform and Compose Multiplatform SDK for Google AdMob on Android and iOS, published as dev.avinya.ads:admob-cmp. Not affiliated with or endorsed by Google. AdMob and Google Mobile Ads are trademarks of Google LLC.
 POM_URL=https://github.com/Meet-Miyani/admob-compose-multiplatform


### PR DESCRIPTION
## Version bump: 2.1.0 → 2.2.0

Minor bump. The public klib ABI is purely additive since 2.1.0 — nothing
was removed, renamed, or had its signature/visibility changed:

- `AdLogLevel`, `AdLogSink`, `AdLogger.minLevel` / `AdLogger.sink`
- `AppIdVerificationPolicy`, `AdAppIdVerification`
- `AdErrorCode.APP_ID_INVALID`, `AdErrorCode.INITIALIZATION_CONFLICT`
- `NativeAdMemoryPolicy.Companion` constants

The accumulated behaviour fixes since 2.1.0 (non-retryable `initialize()`
conflict reporting, serialized consent operations, late-UMP reconciliation,
corrected audio restore, bounded startup timeouts, constructor-time
configuration validation) are corrections to previously-wrong runtime
behaviour, not intentional breaking changes — matching the "Unreleased"
notes already written in the changelog for this cycle.

`AppIdVerificationPolicy.Strict` is explicitly documented as becoming the
default in 3.0.0 — reserving that major bump for the deliberate breaking
change already planned, rather than spending it here.

### What changed in this PR

- `gradle.properties` and `admob-cmp-gradle-plugin/gradle.properties`:
  `VERSION_NAME` bumped in lockstep (2.1.0 → 2.2.0).
- `README.md` and `docs-site/`: every install snippet, Gradle plugin
  version, and compatibility-matrix row updated to 2.2.0 — new 2.2.0 rows
  added ahead of the existing 2.1.0 rows rather than overwriting history.
- `docs-site/src/data/landing.ts`: `mavenCoordinate` / `gradlePlugin` bumped.
- Changelog (`docs-site/src/content/docs/reference/changelog.mdx`):
  "current release" updated to 2.2.0, 2.1.0 marked Superseded, and the
  already-written `## Unreleased` section renamed to
  `## What changed in 2.2.0?` with a new highlights row in the
  published-versions table.

### Not touched

The release tag and GitHub release body are fully automated by
`.github/workflows/release.yml` — it tags off `VERSION_NAME` on push to
`master` and generates the release notes itself
(`gh release create ... --generate-notes`). Nothing to hand-edit there.

### Verification

Full `./scripts/release-readiness.sh` run (no `--skip-docs`, since this
touches `gradle.properties` and `docs-site/`) — **`READINESS: PASS`**,
all 9 sections clean, no failures:

1. Version lockstep — library and plugin both at 2.2.0
2. Gradle plugin build + supply-chain policy
3. Static analysis and coverage (Detekt, Kover)
4. Android + ABI + publication metadata
5. Central task graph
6. iOS + klib ABI (`checkKotlinAbi`, iOS simulator tests)
7. Published-consumer round trip (Maven Local + consumer round trip)
8. Xcode consumer build
9. Docs — Dokka + Astro build + full 30-page audit (canonical links, OG
   images, JSON-LD, no stale repo URLs, Pagefind index)

Also ran the `docs-site` vitest suite directly (251/251 passing), including
`discoverability.test.ts` and `landing.test.ts`, which assert README and
`landing.ts` agree with `gradle.properties`'s `VERSION_NAME`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
