### PR TITLE
fix(consent): initialization publication, native UMP serialization, and the form slot

### DIFF
--- a/admob-cmp-core/src/androidMain/kotlin/dev/avinya/ads/AndroidConsentController.kt
+++ b/admob-cmp-core/src/androidMain/kotlin/dev/avinya/ads/AndroidConsentController.kt
@@ -172,7 +172,7 @@ internal class AndroidConsentController(
                 presentsForm = true,
                 onFormPresenting = {
                     ConsentStatus.Failed(
-                        AdError.message("gatherConsent() ignored: a consent form is already presenting.")
+                        AdError.message("gatherConsent() ignored: another consent form operation is already in progress.")
                     )
                 },
             ) {
@@ -220,8 +220,8 @@ internal class AndroidConsentController(
                 presentsForm = true,
                 onFormPresenting = {
                     AdLogger.w(
-                        "showPrivacyOptions() ignored: another consent form is already " +
-                            "presenting. Wait for it to dismiss before presenting privacy options."
+                        "showPrivacyOptions() ignored: another consent form operation is " +
+                            "already in progress. Wait for it to finish before presenting privacy options."
                     )
                     false
                 },

--- a/admob-cmp-core/src/androidMain/kotlin/dev/avinya/ads/AndroidConsentController.kt
+++ b/admob-cmp-core/src/androidMain/kotlin/dev/avinya/ads/AndroidConsentController.kt
@@ -2,6 +2,7 @@ package dev.avinya.ads
 
 import android.app.Activity
 import android.content.Context
+import dev.avinya.ads.internal.ConsentInfoUpdateOutcome
 import dev.avinya.ads.internal.ConsentStateHolder
 import dev.avinya.ads.internal.InitializationTimeouts
 import dev.avinya.ads.internal.NativeCallbackTimeoutException
@@ -49,17 +50,25 @@ internal class AndroidConsentController(
 
     override suspend fun requestConsentInfoUpdate(config: AdConfig): ConsentStatus {
         return withContext(Dispatchers.Main.immediate) {
-            state.serialized {
+            state.serializedExclusiveOfNativeConsentOperations(
+                onBusy = {
+                    ConsentStatus.Failed(
+                        AdError.message("requestConsentInfoUpdate() ignored: another native consent operation is already in progress.")
+                    )
+                }
+            ) {
                 val ownedConfig = prepareConsentConfig(config)
                 val generation = state.beginOperation()
                 val activity = awaitHost(InitializationTimeouts.consentHost) { activityProvider() }
-                    ?: return@serialized failNoActivity(generation)
-                updateWithActivity(
+                    ?: return@serializedExclusiveOfNativeConsentOperations failNoActivity(generation)
+
+                val outcome = updateWithActivity(
                     activity,
                     ownedConfig,
                     UserMessagingPlatform.getConsentInformation(appContext),
                     generation,
                 )
+                outcome.status
             }
         }
     }
@@ -97,28 +106,10 @@ internal class AndroidConsentController(
         config: AdConfig,
         consentInformation: ConsentInformation,
         generation: Long,
-    ): ConsentStatus {
+    ): ConsentInfoUpdateOutcome {
         val params = buildConsentParams(activity, config)
-        // MUST stay bounded: this is a non-interactive network round trip, and UMP can accept
-        // the call and never call back, which hangs consent admission — and therefore ad
-        // serving — indefinitely.
-        //
-        // On timeout the status becomes Failed, but [canRequestAds] is deliberately NOT reset: it
-        // keeps whatever the last COMPLETED refresh established. On a first run that is false, so a
-        // cold start still admits nothing on an unknown consent state. On a later run it may be a
-        // previously granted true, and a dropped network round trip is not evidence that consent
-        // was withdrawn — revoking admission on a blip would stop ad serving until the next
-        // successful refresh, for no gain in consent correctness. Consent itself has not changed;
-        // only our ability to re-confirm it has, and UMP has already persisted the user's choice.
-        //
-        // State ordering and reconciliation parity is enforced structurally by ConsentStateHolder;
-        // platform controllers only map native UMP types.
-        //
-        // The consent FORM and privacy options form below stay unbounded on purpose; a person is
-        // reading those.
-        //
-        // The callback below reconciles privacy state even when this waiter has already timed out,
-        // because a late callback can carry a revocation.
+
+        state.markInfoUpdateStarted(generation)
         try {
             awaitNativeCallback(
                 operation = "UMP requestConsentInfoUpdate",
@@ -129,14 +120,19 @@ internal class AndroidConsentController(
                         activity,
                         params,
                         {
+                            // Resume with Unit, never with a status read here: the resumed value
+                            // is evaluated BEFORE reconcileThenResumeIfActive runs its block, so
+                            // anything read at this point is the PRE-reconciliation status. The
+                            // outcome is built from state.status.value after the await returns.
                             reconcileThenResumeIfActive(continuation, Unit) {
+                                // Released from the callback, not the waiter: a cancelled or
+                                // timed-out caller does not end the native operation.
+                                state.releaseInfoUpdate(generation)
                                 state.reconcileAndPublish(
-                                    generation,
                                     privacyRequirement = privacyRequirementOf(consentInformation),
                                     canRequestAds = consentInformation.canRequestAds(),
                                     status = resolveConsentInfoUpdateStatus(
                                         error = null,
-                                        canRequestAds = consentInformation.canRequestAds(),
                                         nativeStatus = consentInformationStatus(consentInformation),
                                     ),
                                 )
@@ -148,13 +144,12 @@ internal class AndroidConsentController(
                                 message = formError.message,
                             )
                             reconcileThenResumeIfActive(continuation, Unit) {
+                                state.releaseInfoUpdate(generation)
                                 state.reconcileAndPublish(
-                                    generation,
                                     privacyRequirement = privacyRequirementOf(consentInformation),
                                     canRequestAds = consentInformation.canRequestAds(),
                                     status = resolveConsentInfoUpdateStatus(
                                         error = mapped,
-                                        canRequestAds = consentInformation.canRequestAds(),
                                         nativeStatus = consentInformationStatus(consentInformation),
                                     ),
                                 )
@@ -165,11 +160,10 @@ internal class AndroidConsentController(
             }
         } catch (timeout: NativeCallbackTimeoutException) {
             AdLogger.e("Android UMP consent info update timed out.", timeout)
-            // canRequestAds is deliberately NOT reset here. See consentInfoUpdateTimeoutStatus's
-            // KDoc. The late callback above will still reconcile it if UMP ever answers.
-            return state.publishOperationStatus(generation, consentInfoUpdateTimeoutStatus(timeout.message))
+            val status = state.publishOperationStatus(generation, consentInfoUpdateTimeoutStatus(timeout.message))
+            return ConsentInfoUpdateOutcome.TimedOut(status)
         }
-        return state.status.value
+        return ConsentInfoUpdateOutcome.Completed(state.status.value)
     }
 
     override suspend fun gatherConsent(config: AdConfig): ConsentStatus =
@@ -190,24 +184,25 @@ internal class AndroidConsentController(
                 // The acquired Activity is reused rather than calling the public
                 // requestConsentInfoUpdate, which would wait for a host a second time.
                 val update = updateWithActivity(activity, owned, consentInformation, generation)
-                if (update is ConsentStatus.Failed && !consentInformation.canRequestAds()) return@exclusiveOfForms update
+                if (update is ConsentInfoUpdateOutcome.TimedOut) return@exclusiveOfForms update.status
                 // The irreversible boundary, mirroring GoogleAdManagerBase's markHandoff: past this
                 // line UMP owns the form, and cancelling this coroutine no longer means the screen
                 // is free. Released in the callback below, not by this coroutine's fate.
                 state.markFormPresented(generation)
-                suspendCancellableCoroutine<Unit> { continuation ->
+                val formStatus = suspendCancellableCoroutine<ConsentStatus?> { continuation ->
                     UserMessagingPlatform.loadAndShowConsentFormIfRequired(activity) { formError ->
-                        if (formError != null) {
+                        val errorStatus = if (formError != null) {
                             AdLogger.w("UMP consent form load/show failed: code=${formError.errorCode} message=${formError.message}")
-                        }
+                            ConsentStatus.Failed(AdError(code = formError.errorCode.toString(), message = formError.message))
+                        } else null
+
                         // Reconciliation must not be conditional on the caller still being around —
                         // see reconcileThenResumeIfActive's KDoc. The form was shown and the user's
                         // decision (if any) is already persisted by UMP regardless of whether
                         // gatherConsent()'s caller is still listening.
-                        reconcileThenResumeIfActive(continuation, Unit) {
+                        reconcileThenResumeIfActive(continuation, errorStatus) {
                             state.releaseFormPresentation(generation)
                             state.reconcileAndPublish(
-                                generation,
                                 privacyRequirement = privacyRequirementOf(consentInformation),
                                 canRequestAds = consentInformation.canRequestAds(),
                                 status = consentInformationStatus(consentInformation),
@@ -215,7 +210,7 @@ internal class AndroidConsentController(
                         }
                     }
                 }
-                state.status.value
+                formStatus ?: state.status.value
             }
         }
 
@@ -249,7 +244,6 @@ internal class AndroidConsentController(
                         reconcileThenResumeIfActive(continuation, formError == null) {
                             state.releaseFormPresentation(generation)
                             state.reconcileAndPublish(
-                                generation,
                                 privacyRequirement = privacyRequirementOf(consentInformation),
                                 canRequestAds = consentInformation.canRequestAds(),
                                 status = consentInformationStatus(consentInformation),
@@ -270,19 +264,18 @@ internal class AndroidConsentController(
         }
 
     override suspend fun resetConsentForDebug(): Boolean = withContext(Dispatchers.Main.immediate) {
-        state.exclusiveOfForms(
-            presentsForm = false,
-            onFormPresenting = {
+        state.serializedExclusiveOfNativeConsentOperations(
+            onBusy = {
                 AdLogger.w(
-                    "resetConsentForDebug() ignored: a consent form is already presenting. " +
-                        "Wait for it to dismiss before resetting consent."
+                    "resetConsentForDebug() ignored: a native consent operation is already in progress. " +
+                        "Wait for it to finish before resetting consent."
                 )
                 false
             },
         ) {
             // Acquired inside the main hop, not before it -- this reads Activity lifecycle state,
             // which is main-thread-owned (invariant 5), matching every other entry point here.
-            activityProvider() ?: return@exclusiveOfForms false
+            activityProvider() ?: return@serializedExclusiveOfNativeConsentOperations false
             state.reset()
             UserMessagingPlatform.getConsentInformation(appContext).reset()
             true

--- a/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/AdError.kt
+++ b/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/AdError.kt
@@ -55,8 +55,12 @@ public object AdErrorCode {
 
     /**
      * The platform app-ID declaration (`AndroidManifest.xml` meta-data, `Info.plist`) is missing
-     * or inconsistent with [AdConfig][dev.avinya.ads.AdConfig], so the preflight refused initialization
-     * before UMP or GMA was touched.
+     * or inconsistent with [AdConfig][dev.avinya.ads.AdConfig]. This error is emitted when the
+     * selected [AppIdVerificationPolicy] rejects the finding. The default
+     * [FailWhenUnusable][AppIdVerificationPolicy.FailWhenUnusable] rejects only declarations the
+     * platform's own SDK cannot function with (a missing or blank iOS `GADApplicationIdentifier`).
+     * [Strict][AppIdVerificationPolicy.Strict] rejects any missing or mismatched declaration, and
+     * [WarnOnly][AppIdVerificationPolicy.WarnOnly] never rejects.
      *
      * Never retryable: the platform declaration is part of the application binary or manifest, so
      * the same call will fail identically until the app bundle is fixed and rebuilt. Distinguishing

--- a/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/AdState.kt
+++ b/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/AdState.kt
@@ -13,7 +13,12 @@ public sealed interface AdManagerStatus {
     public data object ConsentRequired : AdManagerStatus
     /** SDK is in the process of initializing. */
     public data object Initializing : AdManagerStatus
-    /** SDK is fully initialized and ready to serve ads. */
+    /**
+     * SDK publishes [Ready] after the platform's initialization callback reports.
+     * On Android, this means mediation adapters have finished initializing, so every
+     * configured network can participate in the first request. A slow adapter delays
+     * [Ready] up to `InitializationTimeouts.nativeInitialize`.
+     */
     public data object Ready : AdManagerStatus
     /** SDK is disabled with a [reason] message. */
     public data class Disabled(val reason: String) : AdManagerStatus

--- a/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/GoogleAdManagerBase.kt
+++ b/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/GoogleAdManagerBase.kt
@@ -375,9 +375,9 @@ internal abstract class GoogleAdManagerBase : AdManager, FullScreenPresenceAware
                 admittedAttempt.identity == requestedIdentity && admittedAttempt.consentMode == consentMode
             val result = try {
                 admittedAttempt.completion.await()
-            } catch (leaderCancellation: CancellationException) {
+            } catch (attemptCancellation: CancellationException) {
                 currentCoroutineContext().ensureActive()
-                if (equivalentAttempt) throw leaderCancellation
+                // An active follower must not inherit the leader's cancellation.
                 continue
             }
             if (equivalentAttempt) return result
@@ -651,10 +651,31 @@ internal abstract class GoogleAdManagerBase : AdManager, FullScreenPresenceAware
             withContext(NonCancellable) {
                 mobileAdsInitializationMutex.withLock {
                     if (nativeInitialization?.generation == generation) nativeInitialization = null
-                    if (result is NativeInitializationResult.Failed && appliedConfigIdentity == requestedIdentity) {
-                        val failed = failedInitializationStatus(result.failure)
-                        appliedTerminalStatus = failed
-                        publishAppliedTerminalLocked(failed)
+                    // Terminal publication is owned by this operation because no waiter is
+                    // guaranteed to exist. A caller cancelled after handoff leaves nobody to
+                    // publish, and the manager would otherwise sit at its pre-attempt status --
+                    // blocking every ad request through adRequestBlockedError() -- while the
+                    // process-global native SDK is already initialized (or already, terminally,
+                    // failed). Both outcomes publish; only the guard differs.
+                    when (result) {
+                        // The success path assigned appliedConfigIdentity just above, so this
+                        // guard confirms THIS operation is the one that committed.
+                        is NativeInitializationResult.Applied ->
+                            if (appliedConfigIdentity == requestedIdentity) {
+                                appliedTerminalStatus?.let { publishAppliedTerminalLocked(it) }
+                            }
+                        // A failure never assigns appliedConfigIdentity, so it must not be
+                        // required to match: requiring it made this branch unreachable for a
+                        // genuine native failure. What must hold is that no OTHER configuration
+                        // owns the process -- publishing this failure over a configuration that
+                        // was actually applied would take down ad serving for the caller whose
+                        // configuration succeeded.
+                        is NativeInitializationResult.Failed ->
+                            if (appliedConfigIdentity == null || appliedConfigIdentity == requestedIdentity) {
+                                val failed = failedInitializationStatus(result.failure)
+                                appliedTerminalStatus = failed
+                                publishAppliedTerminalLocked(failed)
+                            }
                     }
                 }
             }

--- a/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/ConsentInfoUpdatePolicy.kt
+++ b/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/ConsentInfoUpdatePolicy.kt
@@ -5,30 +5,27 @@ import dev.avinya.ads.AdError
 import dev.avinya.ads.ConsentStatus
 
 /**
- * The status both platforms publish after a UMP `requestConsentInfoUpdate`
- * round trip.
+ * The outcome of a native UMP `requestConsentInfoUpdate` operation.
+ */
+internal sealed class ConsentInfoUpdateOutcome {
+    abstract val status: ConsentStatus
+
+    class Completed(override val status: ConsentStatus) : ConsentInfoUpdateOutcome()
+    class TimedOut(override val status: ConsentStatus) : ConsentInfoUpdateOutcome()
+}
+
+/**
+ * The status both platforms derive from a UMP `requestConsentInfoUpdate` callback.
  *
- * Android's `updateWithActivity` and iOS's `requestConsentInfoUpdate` carried
- * this three-branch decision separately, each with a comment requiring it stay
- * byte-identical to the other because "a consent-admission divergence between
- * the platforms is the kind of thing that is only discovered in production".
- * Nothing enforced that. It lives here now so the parity is structural.
- *
- * The middle branch is the load-bearing one: UMP can fail a refresh while the
- * user's previously persisted decision still permits ad serving. A dropped
- * network round trip is not evidence that consent was withdrawn, so admission
- * keeps whatever the last COMPLETED refresh established rather than collapsing
- * to [ConsentStatus.Failed].
+ * If the platform reports an error (e.g. no network connection), the status is ALWAYS
+ * [ConsentStatus.Failed]. Note that this does NOT reset `canRequestAds`: UMP keeps
+ * whatever the last COMPLETED refresh established, so a network drop does not revoke
+ * an already-persisted consent choice. The status merely describes this specific operation.
  */
 internal fun resolveConsentInfoUpdateStatus(
     error: AdError?,
-    canRequestAds: Boolean,
     nativeStatus: ConsentStatus,
-): ConsentStatus = when {
-    error == null -> nativeStatus
-    canRequestAds -> nativeStatus
-    else -> ConsentStatus.Failed(error)
-}
+): ConsentStatus = if (error == null) nativeStatus else ConsentStatus.Failed(error)
 
 /**
  * The status both platforms publish when the bounded info-update round trip

--- a/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/ConsentOperationCoordinator.kt
+++ b/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/ConsentOperationCoordinator.kt
@@ -23,22 +23,23 @@ import kotlinx.coroutines.sync.withLock
  *    superseded operation must not overwrite a newer operation's result. That is what
  *    [beginOperation]/[isCurrentOperation] enforce.
  *
- * [serialized] and [exclusiveOfForms] then make the concurrency contract explicit rather than
- * delegating it to whatever the native UMP SDK happens to do about a second form. UMP
- * rejecting an overlapping form does not make the wrapper's status ordering safe.
+ * [serializedExclusiveOfNativeConsentOperations] and [exclusiveOfForms] make the concurrency
+ * contract explicit rather than delegating it to whatever the native UMP SDK happens to do about
+ * a second form. UMP rejecting an overlapping form does not make the wrapper's status ordering safe.
  *
  * **Form ownership is two facts, not one.** [slotHoldsForm] covers the window between taking
  * the slot and touching UMP — that is what stops a double tap. [nativeFormHandoff] covers the
- * window UMP itself owns, and it deliberately OUTLIVES the coroutine that opened the form:
- * cancelling a caller does not dismiss a form the user is looking at, so a cancelled waiter is
- * not evidence that the screen is free. Only the form's own callback — via
- * [releaseFormPresentation], which every UMP form callback reaches unconditionally through
- * [reconcileThenResumeIfActive] — or the [InitializationTimeouts.formPresentationPin] backstop
- * releases it.
+ * window UMP itself owns.
+ *
+ * **Native operations have two pins:** [nativeFormHandoff] (for forms) and [nativeInfoUpdate]
+ * (for info updates). These pins outlive their calling coroutines: cancelling a caller does not
+ * cancel the in-flight native UMP call, so a cancelled waiter is not evidence that the platform
+ * is free. Only the operation's own callback — which every UMP callback reaches unconditionally
+ * through [reconcileThenResumeIfActive] — or the backstop timeouts release them.
  *
  * **Threading:** every consent entry point already runs on `Dispatchers.Main.immediate`, and
  * UMP delivers its callbacks on the main thread on both platforms, so [currentGeneration] and
- * both form facts are main-confined. `@Volatile` is for visibility only — matching
+ * the pins are main-confined. `@Volatile` is for visibility only — matching
  * `GoogleAdManagerBase`'s own `appliedConfigIdentity` — not a substitute for that confinement.
  */
 internal class ConsentOperationCoordinator(
@@ -56,10 +57,15 @@ internal class ConsentOperationCoordinator(
     @Volatile
     private var nativeFormHandoff: FormHandoff? = null
 
+    /** Set from the moment a native info update starts until its callback releases it. */
+    @Volatile
+    private var nativeInfoUpdate: InfoUpdate? = null
+
     /** Serializes the info-update / form sequences that may legitimately wait for each other. */
     private val operationMutex = Mutex()
 
     private class FormHandoff(val generation: Long, val markedAt: TimeMark)
+    private class InfoUpdate(val generation: Long, val markedAt: TimeMark)
 
     /**
      * Claims the newest generation. Every consent entry point calls this once, up front —
@@ -94,12 +100,51 @@ internal class ConsentOperationCoordinator(
     }
 
     /**
+     * Records that a native info update has started, on behalf of [generation].
+     */
+    fun markInfoUpdateStarted(generation: Long) {
+        nativeInfoUpdate = InfoUpdate(generation, timeSource.markNow())
+    }
+
+    /**
+     * Releases the info update [generation] started.
+     */
+    fun releaseInfoUpdate(generation: Long) {
+        if (nativeInfoUpdate?.generation == generation) nativeInfoUpdate = null
+    }
+
+    /**
      * Runs [block] with no other coordinated consent operation in flight, waiting if one is.
      *
      * For the info-update and consent-gathering paths, where a caller waiting a moment is
      * strictly better than a duplicate UMP round trip.
      */
-    suspend fun <T> serialized(block: suspend () -> T): T = operationMutex.withLock { block() }
+    private suspend fun <T> serialized(block: suspend () -> T): T = operationMutex.withLock { block() }
+
+    /**
+     * Serialized execution that declines via [onBusy] if a native consent operation (form or info
+     * update) is already in progress and has outlived its coroutine.
+     */
+    suspend fun <T> serializedExclusiveOfNativeConsentOperations(
+        onBusy: () -> T,
+        block: suspend () -> T,
+    ): T {
+        // Pre-lock, decline ONLY on a native form handoff -- a form can be on screen with no
+        // mutex holder, so waiting for the lock would be waiting for nothing. Deliberately NOT
+        // formIsLive(): slotHoldsForm means a gatherConsent holds the slot but has not presented
+        // anything yet, and that operation still holds the mutex, so an info update must queue
+        // behind it exactly as it always has rather than fail.
+        if (liveHandoffOrNull() != null) return onBusy()
+
+        return serialized {
+            // Post-lock, re-check BOTH pins. A pin still live once the mutex has been acquired
+            // can only belong to an operation whose waiter is gone (timed out or cancelled) while
+            // UMP is still working -- the abandoned case, and the only one that declines. Two live
+            // concurrent callers never reach here together, so they still queue and both run.
+            if (liveHandoffOrNull() != null || liveInfoUpdateOrNull() != null) return@serialized onBusy()
+            block()
+        }
+    }
 
     /**
      * Declines when a form-presenting operation holds the slot -- two forms cannot stack. The slot
@@ -157,6 +202,17 @@ internal class ConsentOperationCoordinator(
                 "screen, a further consent operation may be refused by UMP itself."
         )
         nativeFormHandoff = null
+        return null
+    }
+
+    private fun liveInfoUpdateOrNull(): InfoUpdate? {
+        val infoUpdate = nativeInfoUpdate ?: return null
+        if (infoUpdate.markedAt.elapsedNow() < InitializationTimeouts.infoUpdatePin) return infoUpdate
+        AdLogger.w(
+            "A native consent info update started over ${InitializationTimeouts.infoUpdatePin} ago " +
+                "and never reported back. Releasing the info update slot."
+        )
+        nativeInfoUpdate = null
         return null
     }
 }

--- a/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/ConsentOperationCoordinator.kt
+++ b/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/ConsentOperationCoordinator.kt
@@ -28,8 +28,8 @@ import kotlinx.coroutines.sync.withLock
  * a second form. UMP rejecting an overlapping form does not make the wrapper's status ordering safe.
  *
  * **Form ownership is two facts, not one.** [slotHoldsForm] covers the window between taking
- * the slot and touching UMP — that is what stops a double tap. [nativeFormHandoff] covers the
- * window UMP itself owns.
+ * the slot — on entry, before any wait for [operationMutex] — and touching UMP; that is what stops
+ * a double tap. [nativeFormHandoff] covers the window UMP itself owns.
  *
  * **Native operations have two pins:** [nativeFormHandoff] (for forms) and [nativeInfoUpdate]
  * (for info updates). These pins outlive their calling coroutines: cancelling a caller does not
@@ -131,9 +131,9 @@ internal class ConsentOperationCoordinator(
     ): T {
         // Pre-lock, decline ONLY on a native form handoff -- a form can be on screen with no
         // mutex holder, so waiting for the lock would be waiting for nothing. Deliberately NOT
-        // formIsLive(): slotHoldsForm means a gatherConsent holds the slot but has not presented
-        // anything yet, and that operation still holds the mutex, so an info update must queue
-        // behind it exactly as it always has rather than fail.
+        // formIsLive(): slotHoldsForm means a form operation has claimed the slot but has not
+        // presented anything yet -- it may hold the mutex, or may still be queued for it -- and
+        // either way an info update must queue behind it exactly as it always has rather than fail.
         if (liveHandoffOrNull() != null) return onBusy()
 
         return serialized {
@@ -153,6 +153,10 @@ internal class ConsentOperationCoordinator(
      * info update. That is deliberate: freeing the slot for that window would let a second caller
      * reach markFormPresented first and race two presentations.
      *
+     * Entry means this method's first lines, BEFORE the wait on [operationMutex]. A form caller
+     * that is merely queued has already claimed the slot, so a second form caller declines instead
+     * of joining the queue behind it and presenting the moment the first form dismisses.
+     *
      * An operation that does not present a form never claims the slot (presentsForm = false: a
      * consent info update, at most
      * InitializationTimeouts.consentInfoUpdate), and ordering behind it is not a reason to fail:
@@ -167,20 +171,36 @@ internal class ConsentOperationCoordinator(
         block: suspend () -> T,
     ): T {
         if (formIsLive()) return onFormPresenting()
-        return operationMutex.withLock {
-            // The second check is REQUIRED: a cancelled operation releases this mutex while UMP
-            // is still presenting its form, so holding the lock no longer proves the screen is
-            // free. A waiter that queued behind such an operation must decline here rather than
-            // present a second form over the first.
-            if (liveHandoffOrNull() != null) return@withLock onFormPresenting()
-            if (presentsForm) slotHoldsForm = true
-            try {
+        // Claimed HERE, before the mutex wait, and NOT once the mutex has been acquired. Waiting in
+        // the queue is part of the operation: while a non-form operation holds the mutex nothing
+        // has claimed the slot, so two form callers could both pass the check above and queue. The
+        // first would present, the user would dismiss, its callback would release the handoff --
+        // and the second would then find a free slot and present into a preload slot UMP has just
+        // consumed. Both platforms document that as an error rather than a second form (iOS
+        // UMPFormErrorCodeAlreadyUsed / Unavailable, Android FormError INVALID_OPERATION), so the
+        // user dismisses the form they asked for and is handed a failure for the tap that opened it.
+        //
+        // There is no suspension point between formIsLive() above and this assignment, and both are
+        // main-confined, so check-and-claim is atomic. That is the same argument that already made
+        // an uncontended double tap safe; claiming here extends it to cover the queue.
+        if (presentsForm) slotHoldsForm = true
+        try {
+            return operationMutex.withLock {
+                // The second check is REQUIRED: a cancelled operation releases this mutex while UMP
+                // is still presenting its form, so holding the lock no longer proves the screen is
+                // free. A waiter that queued behind such an operation must decline here rather than
+                // present a second form over the first.
+                if (liveHandoffOrNull() != null) return@withLock onFormPresenting()
                 block()
-            } finally {
-                // Only the slot fact unwinds with the coroutine. A handoff already made to UMP
-                // survives it and is released by the form's own callback.
-                slotHoldsForm = false
             }
+        } finally {
+            // Guarded by presentsForm, which is load-bearing now that the claim outlives the mutex:
+            // a non-form operation running inside the lock must not clear the claim of a form
+            // caller still queued behind it.
+            //
+            // Only the slot fact unwinds with the coroutine. A handoff already made to UMP survives
+            // it and is released by the form's own callback.
+            if (presentsForm) slotHoldsForm = false
         }
     }
 

--- a/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/ConsentOperationCoordinator.kt
+++ b/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/ConsentOperationCoordinator.kt
@@ -101,8 +101,23 @@ internal class ConsentOperationCoordinator(
 
     /**
      * Records that a native info update has started, on behalf of [generation].
+     *
+     * Warns when it takes over a pin that is still live. Reaching here under a live pin means the
+     * caller did not come through [serializedExclusiveOfNativeConsentOperations], which declines
+     * exactly that case -- today that is `gatherConsent`, deliberately, for the reason recorded on
+     * [exclusiveOfForms]. The overlap is not defined by UMP either way, so it is worth saying out
+     * loud in the log rather than leaving a consumer to infer it from two interleaved round trips.
      */
     fun markInfoUpdateStarted(generation: Long) {
+        if (liveInfoUpdateOrNull() != null) {
+            AdLogger.w(
+                "Starting a UMP consent info update while an earlier one has not reported back. " +
+                    "The earlier call was abandoned by its caller (timed out or cancelled) and UMP " +
+                    "may still be working on it. Overlapping info updates are not defined by UMP; " +
+                    "the wrapper's own state stays coherent because the abandoned call's callback " +
+                    "can no longer publish over this one."
+            )
+        }
         nativeInfoUpdate = InfoUpdate(generation, timeSource.markNow())
     }
 
@@ -164,6 +179,17 @@ internal class ConsentOperationCoordinator(
      * launch-time refresh must get the form, not "unavailable". Callers surface the false return
      * to a person -- see DiagnosticsTab, ProfileViewModel, PrivacyLabScreen -- so a spurious
      * decline is a spurious error message.
+     *
+     * **This gate deliberately does NOT consult [nativeInfoUpdate], which is why `gatherConsent`
+     * can start a native info update while an abandoned one is still outstanding.** That asymmetry
+     * with [serializedExclusiveOfNativeConsentOperations] is a decision, not an oversight.
+     * `gatherConsent` is the launch path: declining it because a pin whose operation nobody is
+     * waiting on is still live would fail the app's whole consent flow for as long as
+     * [InitializationTimeouts.infoUpdatePin], and the pin outlives its coroutine precisely because
+     * the wrapper cannot know the native call finished. That is a real, reproducible launch
+     * failure traded against an overlap UMP does not define -- neither platform documents
+     * concurrent `requestConsentInfoUpdate` calls, and neither exposes an error code for one.
+     * [markInfoUpdateStarted] logs the overlap so it stays diagnosable in the field.
      */
     suspend fun <T> exclusiveOfForms(
         presentsForm: Boolean,

--- a/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/ConsentStateHolder.kt
+++ b/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/ConsentStateHolder.kt
@@ -47,7 +47,10 @@ internal class ConsentStateHolder(timeSource: TimeSource = TimeSource.Monotonic)
 
     fun beginOperation(): Long = coordinator.beginOperation()
 
-    suspend fun <T> serialized(block: suspend () -> T): T = coordinator.serialized(block)
+    suspend fun <T> serializedExclusiveOfNativeConsentOperations(
+        onBusy: () -> T,
+        block: suspend () -> T,
+    ): T = coordinator.serializedExclusiveOfNativeConsentOperations(onBusy, block)
 
     suspend fun <T> exclusiveOfForms(
         presentsForm: Boolean,
@@ -61,22 +64,30 @@ internal class ConsentStateHolder(timeSource: TimeSource = TimeSource.Monotonic)
     /** See [ConsentOperationCoordinator.releaseFormPresentation]. */
     fun releaseFormPresentation(generation: Long): Unit = coordinator.releaseFormPresentation(generation)
 
+    /** See [ConsentOperationCoordinator.markInfoUpdateStarted]. */
+    fun markInfoUpdateStarted(generation: Long): Unit = coordinator.markInfoUpdateStarted(generation)
+
+    /** See [ConsentOperationCoordinator.releaseInfoUpdate]. */
+    fun releaseInfoUpdate(generation: Long): Unit = coordinator.releaseInfoUpdate(generation)
+
     /**
-     * Reconciles authoritative privacy truth unconditionally and publishes [status] if [generation]
-     * is still the current operation. Returns the resulting [status] value.
+     * Reconciles authoritative privacy truth and publishes [status] unconditionally.
+     * Returns the [status] passed in.
+     *
+     * A callback that reports a privacy state must ALWAYS publish the status it carries,
+     * even if it arrived late (superseded by a newer operation). If a late callback carries
+     * a revocation, dropping it leaves the gate open on stale truth; dropping the status
+     * while accepting the truth leaves the flows out of sync.
      */
     fun reconcileAndPublish(
-        generation: Long,
         privacyRequirement: PrivacyOptionsRequirementStatus,
         canRequestAds: Boolean,
         status: ConsentStatus,
     ): ConsentStatus {
         _privacyOptionsRequirementStatus.value = privacyRequirement
         _canRequestAds.value = canRequestAds
-        if (coordinator.isCurrentOperation(generation)) {
-            _status.value = status
-        }
-        return _status.value
+        _status.value = status
+        return status
     }
 
     /**

--- a/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/NativeCallbackTimeouts.kt
+++ b/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/NativeCallbackTimeouts.kt
@@ -23,6 +23,14 @@ internal object InitializationTimeouts {
     /** Native `MobileAds.initialize` / `GADMobileAds.start`. */
     val nativeInitialize: Duration = 30.seconds
 
+    /**
+     * GMA iOS documents that `startWithCompletionHandler` fires after setup completes *or* after
+     * its own ~30-second internal bound, so an outer watchdog set to the same nominal value can
+     * win the race and report a false failure for a slow mediation setup — exactly the case the
+     * native fallback exists to resolve.
+     */
+    val nativeInitializeIos: Duration = 40.seconds
+
     /** UMP `requestConsentInfoUpdate` — a network round trip with no user interaction. */
     val consentInfoUpdate: Duration = 20.seconds
 
@@ -67,6 +75,11 @@ internal object InitializationTimeouts {
      * process is a worse outcome than the overlapping form the pin exists to prevent.
      */
     val formPresentationPin: Duration = 5.minutes
+
+    /**
+     * How long the native info update stays pinned.
+     */
+    val infoUpdatePin: Duration = 30.seconds
 }
 
 /**

--- a/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/ConsentInfoUpdatePolicyTest.kt
+++ b/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/ConsentInfoUpdatePolicyTest.kt
@@ -27,7 +27,6 @@ class ConsentInfoUpdatePolicyTest {
     fun `a successful update publishes the native status`() {
         val status = resolveConsentInfoUpdateStatus(
             error = null,
-            canRequestAds = true,
             nativeStatus = ConsentStatus.Obtained,
         )
 
@@ -35,10 +34,9 @@ class ConsentInfoUpdatePolicyTest {
     }
 
     @Test
-    fun `a successful update publishes NotRequired without collapsing it to Obtained`() {
+    fun `completed success maps to native status when not required`() {
         val status = resolveConsentInfoUpdateStatus(
             error = null,
-            canRequestAds = true,
             nativeStatus = ConsentStatus.NotRequired,
         )
 
@@ -46,54 +44,25 @@ class ConsentInfoUpdatePolicyTest {
     }
 
     @Test
-    fun `an error while ads remain servable keeps the native status not Failed`() {
-        // UMP can fail a refresh while the previously persisted decision still
-        // permits ad serving. Publishing Failed here would block admission on a
-        // network blip, for no gain in consent correctness.
-        val status = resolveConsentInfoUpdateStatus(
+    fun `completed error maps to Failed regardless of canRequestAds`() {
+        val networkError = AdError.message("Network dropped")
+        val statusWithTrue = resolveConsentInfoUpdateStatus(
             error = networkError,
-            canRequestAds = true,
             nativeStatus = ConsentStatus.Obtained,
         )
-
-        assertEquals(ConsentStatus.Obtained, status)
-    }
-
-    @Test
-    fun `an error with no servable consent publishes Failed carrying that error`() {
-        val status = resolveConsentInfoUpdateStatus(
+        val statusWithFalse = resolveConsentInfoUpdateStatus(
             error = networkError,
-            canRequestAds = false,
             nativeStatus = ConsentStatus.Unknown,
         )
 
-        val failed = assertIs<ConsentStatus.Failed>(status)
-        assertEquals("3", failed.error.code)
-        assertEquals("network error", failed.error.message)
-    }
+        // The point of the branch is that the NATIVE status no longer decides the outcome: a
+        // completed-with-error refresh reports the error either way, and carries it through
+        // unchanged so the caller can act on the real cause.
+        val failedTrue = assertIs<ConsentStatus.Failed>(statusWithTrue)
+        assertEquals(networkError, failedTrue.error)
 
-    @Test
-    fun `the resolution never reports Failed while ads are servable`() {
-        // The admission-preserving invariant, stated directly: whatever the
-        // error, a true canRequestAds must not produce Failed on either platform.
-        val statuses = listOf(
-            ConsentStatus.Unknown,
-            ConsentStatus.Required,
-            ConsentStatus.NotRequired,
-            ConsentStatus.Obtained,
-        )
-
-        for (native in statuses) {
-            val status = resolveConsentInfoUpdateStatus(
-                error = networkError,
-                canRequestAds = true,
-                nativeStatus = native,
-            )
-            assertFalse(
-                status is ConsentStatus.Failed,
-                "canRequestAds=true with nativeStatus=$native must not resolve to Failed",
-            )
-        }
+        val failedFalse = assertIs<ConsentStatus.Failed>(statusWithFalse)
+        assertEquals(networkError, failedFalse.error)
     }
 
     @Test

--- a/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/ConsentOperationCoordinatorTest.kt
+++ b/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/ConsentOperationCoordinatorTest.kt
@@ -135,6 +135,161 @@ class ConsentOperationCoordinatorTest {
     }
 
     @Test
+    fun `a second form caller queued behind a non-form operation declines`() = runTest {
+        val coordinator = ConsentOperationCoordinator()
+        val order = mutableListOf<String>()
+        val nonFormEntered = CompletableDeferred<Unit>()
+        val releaseNonForm = CompletableDeferred<Unit>()
+
+        // A launch-time consent info update holds the mutex. It presents nothing, so it never
+        // claims the form slot -- which is what used to let two form callers queue behind it.
+        val nonForm = launch {
+            coordinator.serializedExclusiveOfNativeConsentOperations(onBusy = {}) {
+                order += "non-form-in"
+                nonFormEntered.complete(Unit)
+                releaseNonForm.await()
+            }
+        }
+        nonFormEntered.await()
+
+        // The user double-taps "Privacy options" while that update is still in flight. Neither tap
+        // can see a form on screen, because the first one has not presented anything yet.
+        var firstPresented = false
+        val firstTap = launch {
+            firstPresented = coordinator.exclusiveOfForms(presentsForm = true, onFormPresenting = { false }) {
+                val generation = coordinator.beginOperation()
+                coordinator.markFormPresented(generation)
+                order += "first-presented"
+                // UMP reports the dismissal, which is the only thing that frees the native pin.
+                coordinator.releaseFormPresentation(generation)
+                true
+            }
+        }
+        var secondPresented = false
+        val secondTap = launch {
+            secondPresented = coordinator.exclusiveOfForms(
+                presentsForm = true,
+                onFormPresenting = {
+                    order += "second-declined"
+                    false
+                },
+            ) {
+                order += "second-presented"
+                true
+            }
+        }
+        advanceUntilIdle()
+
+        releaseNonForm.complete(Unit)
+        nonForm.join()
+        firstTap.join()
+        secondTap.join()
+
+        assertTrue(firstPresented, "the first tap must present once the queue drains")
+        assertFalse(
+            secondPresented,
+            "the second tap must decline rather than present into a preload slot UMP just consumed",
+        )
+        assertEquals(
+            listOf("non-form-in", "second-declined", "first-presented"),
+            order,
+            "the second tap must decline while queued, not run after the first form dismisses",
+        )
+    }
+
+    @Test
+    fun `cancellation while queued for the mutex releases the form slot`() = runTest {
+        val coordinator = ConsentOperationCoordinator()
+        val nonFormEntered = CompletableDeferred<Unit>()
+        val releaseNonForm = CompletableDeferred<Unit>()
+
+        val nonForm = launch {
+            coordinator.serializedExclusiveOfNativeConsentOperations(onBusy = {}) {
+                nonFormEntered.complete(Unit)
+                releaseNonForm.await()
+            }
+        }
+        nonFormEntered.await()
+
+        // Claims the slot on entry and then waits for the mutex. The claim now spans that wait,
+        // so its unwinding is the window this fix opened and the one worth pinning.
+        var ran = false
+        val queued = launch {
+            coordinator.exclusiveOfForms(presentsForm = true, onFormPresenting = { false }) {
+                ran = true
+                true
+            }
+        }
+        advanceUntilIdle()
+        queued.cancelAndJoin()
+
+        releaseNonForm.complete(Unit)
+        nonForm.join()
+
+        assertFalse(ran, "the cancelled caller never reached the block")
+        assertTrue(
+            coordinator.exclusiveOfForms(presentsForm = true, onFormPresenting = { false }) { true },
+            "a caller cancelled while queued must not strand the form slot",
+        )
+    }
+
+    @Test
+    fun `a non-form operation does not clear a queued form caller's claim`() = runTest {
+        val coordinator = ConsentOperationCoordinator()
+        val nonFormEntered = CompletableDeferred<Unit>()
+        val releaseNonForm = CompletableDeferred<Unit>()
+        val formEntered = CompletableDeferred<Unit>()
+        val releaseForm = CompletableDeferred<Unit>()
+
+        // presentsForm = false, so this one holds the mutex WITHOUT claiming the slot -- and its
+        // finally must therefore not clear a claim it never made. The claim now outlives the
+        // mutex, so an unguarded release here would free the slot under the caller below.
+        val nonForm = launch {
+            coordinator.exclusiveOfForms(presentsForm = false, onFormPresenting = { false }) {
+                nonFormEntered.complete(Unit)
+                releaseNonForm.await()
+                true
+            }
+        }
+        nonFormEntered.await()
+
+        val form = launch {
+            coordinator.exclusiveOfForms(presentsForm = true, onFormPresenting = { false }) {
+                formEntered.complete(Unit)
+                // Deliberately short of the native boundary: no markFormPresented, so only the
+                // slot -- not the handoff pin -- can decline the probe below.
+                releaseForm.await()
+                true
+            }
+        }
+        advanceUntilIdle()
+
+        releaseNonForm.complete(Unit)
+        nonForm.join()
+        formEntered.await()
+
+        var probeDeclined = false
+        var probeRan = false
+        val probe = launch {
+            probeDeclined = !coordinator.exclusiveOfForms(presentsForm = true, onFormPresenting = { false }) {
+                probeRan = true
+                true
+            }
+        }
+        advanceUntilIdle()
+
+        assertTrue(
+            probeDeclined,
+            "a non-form operation completing must not free the slot a queued form caller claimed",
+        )
+        assertFalse(probeRan, "the probe must not run while a form operation owns the slot")
+
+        releaseForm.complete(Unit)
+        form.join()
+        probe.join()
+    }
+
+    @Test
     fun `exclusiveOfForms restores the form flag after normal completion`() = runTest {
         val coordinator = ConsentOperationCoordinator()
         assertTrue(coordinator.exclusiveOfForms(presentsForm = true, onFormPresenting = { false }) { true })

--- a/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/ConsentOperationCoordinatorTest.kt
+++ b/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/ConsentOperationCoordinatorTest.kt
@@ -387,6 +387,68 @@ class ConsentOperationCoordinatorTest {
     }
 
     @Test
+    fun `exclusiveOfForms ignores a live info update pin`() = runTest {
+        val coordinator = ConsentOperationCoordinator()
+        coordinator.markInfoUpdateStarted(coordinator.beginOperation())
+
+        // Pins the DECISION recorded on exclusiveOfForms, not an accident of the implementation:
+        // gatherConsent is the launch path and must not be starved for the length of the info
+        // update backstop by an operation nobody is waiting on. Adding the pin check here would
+        // trade an overlap UMP does not define for a reproducible launch failure.
+        assertTrue(
+            coordinator.exclusiveOfForms(presentsForm = true, onFormPresenting = { false }) { true },
+            "a form operation must not be declined by an abandoned native info update",
+        )
+    }
+
+    @Test
+    fun `taking over a live info update pin warns and keeps the newer pin`() = runTest {
+        val coordinator = ConsentOperationCoordinator()
+        val warnings = mutableListOf<String>()
+        // AdLogger's properties are process-wide, so this must be restored even on failure.
+        val originalSink = AdLogger.sink
+        AdLogger.sink = AdLogSink { level, _, message, _ ->
+            if (level == AdLogLevel.Warn) warnings += message
+        }
+        try {
+            val abandoned = coordinator.beginOperation()
+            coordinator.markInfoUpdateStarted(abandoned)
+            assertTrue(warnings.isEmpty(), "the first info update has nothing to take over")
+
+            // gatherConsent does not come through serializedExclusiveOfNativeConsentOperations,
+            // so it reaches markInfoUpdateStarted with the abandoned pin still live.
+            val current = coordinator.beginOperation()
+            coordinator.markInfoUpdateStarted(current)
+
+            assertEquals(1, warnings.size, "taking over a live info update pin must be logged")
+            assertTrue(
+                warnings.single().contains("has not reported back"),
+                "the warning must name the overlap, not the backstop expiry: ${warnings.single()}",
+            )
+
+            // The abandoned call's late callback must not free the pin the newer operation owns.
+            coordinator.releaseInfoUpdate(abandoned)
+            var ran = false
+            assertTrue(
+                coordinator.serializedExclusiveOfNativeConsentOperations(onBusy = { true }) {
+                    ran = true
+                    false
+                },
+                "a superseded info update's late callback must not open the gate",
+            )
+            assertFalse(ran, "the declined path must not run the block")
+
+            coordinator.releaseInfoUpdate(current)
+            assertFalse(
+                coordinator.serializedExclusiveOfNativeConsentOperations(onBusy = { true }) { false },
+                "the owning generation's callback must open the gate again",
+            )
+        } finally {
+            AdLogger.sink = originalSink
+        }
+    }
+
+    @Test
     fun `a stranded form pin expires at the backstop instead of declining forever`() = runTest {
         val timeSource = TestTimeSource()
         val coordinator = ConsentOperationCoordinator(timeSource)

--- a/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/ConsentOperationCoordinatorTest.kt
+++ b/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/ConsentOperationCoordinatorTest.kt
@@ -48,7 +48,7 @@ class ConsentOperationCoordinatorTest {
         val releaseFirst = CompletableDeferred<Unit>()
 
         val first = launch {
-            coordinator.serialized {
+            coordinator.serializedExclusiveOfNativeConsentOperations(onBusy = {}) {
                 order += "first-in"
                 firstEntered.complete(Unit)
                 releaseFirst.await()
@@ -56,7 +56,7 @@ class ConsentOperationCoordinatorTest {
             }
         }
         firstEntered.await()
-        val second = launch { coordinator.serialized { order += "second-in" } }
+        val second = launch { coordinator.serializedExclusiveOfNativeConsentOperations(onBusy = {}) { order += "second-in" } }
         advanceUntilIdle()
 
         assertEquals(listOf("first-in"), order, "the second block must not overlap the first")
@@ -109,7 +109,7 @@ class ConsentOperationCoordinatorTest {
         val releaseNonForm = CompletableDeferred<Unit>()
 
         val nonForm = launch {
-            coordinator.serialized {
+            coordinator.serializedExclusiveOfNativeConsentOperations(onBusy = {}) {
                 order += "non-form-in"
                 nonFormEntered.complete(Unit)
                 releaseNonForm.await()

--- a/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/ConsentStateHolderTest.kt
+++ b/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/ConsentStateHolderTest.kt
@@ -21,7 +21,6 @@ class ConsentStateHolderTest {
         val generation = holder.beginOperation()
 
         val result = holder.reconcileAndPublish(
-            generation = generation,
             privacyRequirement = PrivacyOptionsRequirementStatus.Required,
             canRequestAds = true,
             status = ConsentStatus.Required,
@@ -34,28 +33,24 @@ class ConsentStateHolderTest {
     }
 
     @Test
-    fun `reconcileAndPublish updates privacy state for superseded generation while leaving status untouched`() {
+    fun `reconcileAndPublish unconditionally updates all three flows even for superseded generation`() {
         val holder = ConsentStateHolder()
-        val stale = holder.beginOperation()
         val current = holder.beginOperation()
 
         holder.publishOperationStatus(current, ConsentStatus.Obtained)
 
-        // Reconciliation is NOT generation-gated: it reads the UMP singleton, so it is current
-        // no matter which operation's callback observed it. The STATUS is gated, so the stale
-        // callback must reconcile privacy state without republishing its own status.
         val result = holder.reconcileAndPublish(
-            generation = stale,
             privacyRequirement = PrivacyOptionsRequirementStatus.NotRequired,
             canRequestAds = true,
             status = ConsentStatus.Required,
         )
 
-        assertEquals(ConsentStatus.Obtained, result, "result should be current status value")
-        assertEquals(ConsentStatus.Obtained, holder.status.value, "superseded status must not overwrite current status")
+        assertEquals(ConsentStatus.Required, result, "result should be passed status value")
+        assertEquals(ConsentStatus.Required, holder.status.value, "superseded status MUST overwrite current status now")
         assertEquals(PrivacyOptionsRequirementStatus.NotRequired, holder.privacyOptionsRequirementStatus.value)
         assertTrue(holder.canRequestAds.value)
     }
+
 
     @Test
     fun `a late callback on the same still-current generation replaces a timeout status`() {
@@ -68,7 +63,6 @@ class ConsentStateHolderTest {
 
         // ...and later the callback for the SAME still-current generation completes with Obtained.
         val result = holder.reconcileAndPublish(
-            generation = generation,
             privacyRequirement = PrivacyOptionsRequirementStatus.NotRequired,
             canRequestAds = true,
             status = ConsentStatus.Obtained,
@@ -83,22 +77,18 @@ class ConsentStateHolderTest {
     @Test
     fun `a revocation observed by reconcileAndPublish sets canRequestAds false regardless of generation`() {
         val holder = ConsentStateHolder()
-        val initial = holder.beginOperation()
         holder.reconcileAndPublish(
-            generation = initial,
             privacyRequirement = PrivacyOptionsRequirementStatus.NotRequired,
             canRequestAds = true,
             status = ConsentStatus.Obtained,
         )
         assertTrue(holder.canRequestAds.value)
 
-        val stale = holder.beginOperation()
         val current = holder.beginOperation()
         holder.publishOperationStatus(current, ConsentStatus.Obtained)
 
         // Stale callback observes revocation
         holder.reconcileAndPublish(
-            generation = stale,
             privacyRequirement = PrivacyOptionsRequirementStatus.Required,
             canRequestAds = false,
             status = ConsentStatus.Required,
@@ -106,7 +96,7 @@ class ConsentStateHolderTest {
 
         assertFalse(holder.canRequestAds.value, "revocation must close ad request gate immediately")
         assertEquals(PrivacyOptionsRequirementStatus.Required, holder.privacyOptionsRequirementStatus.value)
-        assertEquals(ConsentStatus.Obtained, holder.status.value, "superseded status must not overwrite current status")
+        assertEquals(ConsentStatus.Required, holder.status.value, "superseded status must now overwrite current status")
     }
 
     @Test
@@ -114,7 +104,6 @@ class ConsentStateHolderTest {
         val holder = ConsentStateHolder()
         val outstanding = holder.beginOperation()
         holder.reconcileAndPublish(
-            generation = outstanding,
             privacyRequirement = PrivacyOptionsRequirementStatus.Required,
             canRequestAds = true,
             status = ConsentStatus.Obtained,
@@ -139,7 +128,7 @@ class ConsentStateHolderTest {
         val releaseFirst = CompletableDeferred<Unit>()
 
         val first = launch {
-            holder.serialized {
+            holder.serializedExclusiveOfNativeConsentOperations(onBusy = {}) {
                 order += "first-in"
                 firstEntered.complete(Unit)
                 releaseFirst.await()
@@ -147,7 +136,7 @@ class ConsentStateHolderTest {
             }
         }
         firstEntered.await()
-        val second = launch { holder.serialized { order += "second-in" } }
+        val second = launch { holder.serializedExclusiveOfNativeConsentOperations(onBusy = {}) { order += "second-in" } }
         advanceUntilIdle()
 
         assertEquals(listOf("first-in"), order, "the second block must not overlap the first")
@@ -192,7 +181,7 @@ class ConsentStateHolderTest {
         val releaseNonForm = CompletableDeferred<Unit>()
 
         val nonForm = launch {
-            holder.serialized {
+            holder.serializedExclusiveOfNativeConsentOperations(onBusy = {}) {
                 order += "non-form-in"
                 nonFormEntered.complete(Unit)
                 releaseNonForm.await()
@@ -304,15 +293,9 @@ class ConsentStateHolderTest {
         )
     }
 
-    /**
-     * Status ordering is independent of the form slot and is unchanged: an older generation still
-     * reconciles authoritative privacy truth unconditionally, but cannot publish its status over a
-     * newer operation's.
-     */
     @Test
-    fun `a superseded form callback reconciles privacy truth without publishing its status`() {
+    fun `a superseded form callback reconciles privacy truth and publishes its status`() {
         val holder = ConsentStateHolder()
-        val inFlightFormGen = holder.beginOperation()
         val newerOperationGen = holder.beginOperation()
 
         // Newer operation finishes first and sets status
@@ -320,21 +303,15 @@ class ConsentStateHolderTest {
 
         // In-flight form eventually calls back on its older generation
         holder.reconcileAndPublish(
-            generation = inFlightFormGen,
             privacyRequirement = PrivacyOptionsRequirementStatus.NotRequired,
             canRequestAds = true,
             status = ConsentStatus.Obtained,
         )
 
-        // Privacy state updated
+        // All three values move together
         assertTrue(holder.canRequestAds.value)
         assertEquals(PrivacyOptionsRequirementStatus.NotRequired, holder.privacyOptionsRequirementStatus.value)
-        // But status is NOT overwritten by the older form callback
-        assertEquals(
-            ConsentStatus.NotRequired,
-            holder.status.value,
-            "superseded form callback must not overwrite newer operation's status",
-        )
+        assertEquals(ConsentStatus.Obtained, holder.status.value, "superseded form callback MUST overwrite newer operation's status")
     }
 
     @Test
@@ -377,7 +354,7 @@ class ConsentStateHolderTest {
         val releaseNonForm = CompletableDeferred<Unit>()
 
         val nonForm = launch {
-            holder.serialized {
+            holder.serializedExclusiveOfNativeConsentOperations(onBusy = {}) {
                 order += "non-form-in"
                 nonFormEntered.complete(Unit)
                 releaseNonForm.await()
@@ -412,7 +389,6 @@ class ConsentStateHolderTest {
         val holder = ConsentStateHolder()
         val outstanding = holder.beginOperation()
         holder.reconcileAndPublish(
-            generation = outstanding,
             privacyRequirement = PrivacyOptionsRequirementStatus.Required,
             canRequestAds = true,
             status = ConsentStatus.Obtained,
@@ -434,13 +410,12 @@ class ConsentStateHolderTest {
         holder.publishOperationStatus(outstanding, ConsentStatus.Obtained)
         assertEquals(ConsentStatus.Unknown, holder.status.value)
 
-        // An outstanding generation reconcileAndPublish cannot overwrite Unknown status
+        // An outstanding generation reconcileAndPublish overwrites Unknown status
         holder.reconcileAndPublish(
-            generation = outstanding,
             privacyRequirement = PrivacyOptionsRequirementStatus.NotRequired,
             canRequestAds = true,
             status = ConsentStatus.Obtained,
         )
-        assertEquals(ConsentStatus.Unknown, holder.status.value)
+        assertEquals(ConsentStatus.Obtained, holder.status.value)
     }
 }

--- a/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/GoogleAdManagerBaseFakes.kt
+++ b/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/GoogleAdManagerBaseFakes.kt
@@ -20,7 +20,10 @@ internal class FakeGoogleAdManager(
     override val consent: ConsentController = FakeConsentController(),
     /** True models iOS (`GADApplicationIdentifier`); false models Android. */
     private val requiresDeclaredAppId: Boolean = false,
-    private val failBeforeHandoff: () -> Throwable? = { null },
+    // Suspending so a test can park here — between the native call starting and markHandoff —
+    // and cancel a caller at exactly that point. That window is where the leader/follower and
+    // detached-publication defects live, and it cannot be scripted with a plain lambda.
+    private val failBeforeHandoff: suspend () -> Throwable? = { null },
     private val nativeInitialize: suspend (AdConfig, AdInitializationConfigIdentity) -> Unit = { _, _ -> },
 ) : GoogleAdManagerBase() {
 

--- a/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/NativeInitializationOwnershipTest.kt
+++ b/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/NativeInitializationOwnershipTest.kt
@@ -7,11 +7,32 @@ import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.yield
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class NativeInitializationOwnershipTest {
+
+    @Test
+    fun `iOS native initialization timeout is strictly greater than GMA internal bound`() {
+        val iosTimeout = InitializationTimeouts.nativeInitializeIos
+        val androidTimeout = InitializationTimeouts.nativeInitialize
+        
+        assertTrue(
+            iosTimeout > 30.seconds,
+            "iOS timeout must be > 30s to win the race against GMA's internal watchdog"
+        )
+        assertTrue(
+            iosTimeout > androidTimeout,
+            "iOS timeout must be greater than the default/Android timeout"
+        )
+    }
 
     private fun config(appId: String) = AdConfig(
         androidAppId = appId,
@@ -161,5 +182,198 @@ class NativeInitializationOwnershipTest {
             consent.gatherConsentCalls,
             "a configuration the SDK already knows it will refuse must not put a consent form on screen",
         )
+    }
+
+    @Test
+    fun `a detached native success publishes its terminal status even if the leader was cancelled`() = runSlotTest {
+        val nativeCompletion = CompletableDeferred<Unit>()
+        val manager = FakeGoogleAdManager(
+            nativeInitialize = { _, _ -> nativeCompletion.await() }
+        )
+
+        val job = launch {
+            manager.initialize(config("ca-app-pub-A"), ConsentMode.SkipConsent)
+        }
+
+        while (manager.handoffMarks.isEmpty()) { yield() }
+
+        job.cancelAndJoin()
+        nativeCompletion.complete(Unit)
+        yield()
+
+        assertEquals(AdManagerStatus.Ready, manager.status.value)
+    }
+
+    @Test
+    fun `a detached native failure publishes its terminal status even if the leader was cancelled`() = runSlotTest {
+        val nativeCompletion = CompletableDeferred<Unit>()
+        val exception = RuntimeException("Native SDK crash")
+        val manager = FakeGoogleAdManager(
+            nativeInitialize = { _, _ ->
+                nativeCompletion.await()
+                throw exception
+            }
+        )
+
+        val job = launch {
+            manager.initialize(config("ca-app-pub-A"), ConsentMode.SkipConsent)
+        }
+
+        while (manager.handoffMarks.isEmpty()) { yield() }
+        job.cancelAndJoin()
+        nativeCompletion.complete(Unit)
+        yield()
+
+        val status = manager.status.value
+        assertIs<AdManagerStatus.Failed>(status)
+        assertEquals(exception.message, status.error.message)
+
+        val laterStatus = manager.initialize(config("ca-app-pub-A"), ConsentMode.SkipConsent)
+        assertEquals(status, laterStatus)
+    }
+
+    @Test
+    fun `a detached native success unblocks ad requests after caller cancellation`() = runSlotTest {
+        val nativeCompletion = CompletableDeferred<Unit>()
+        val manager = FakeGoogleAdManager(
+            nativeInitialize = { _, _ -> nativeCompletion.await() }
+        )
+
+        val job = launch {
+            manager.initialize(config("ca-app-pub-A"), ConsentMode.SkipConsent)
+        }
+
+        while (manager.handoffMarks.isEmpty()) { yield() }
+        job.cancelAndJoin()
+        nativeCompletion.complete(Unit)
+        yield()
+
+        // Assert on manager.status.value only since adRequestBlockedError() is protected 
+        // and ad loading surface is not reachable from commonTest.
+        assertEquals(AdManagerStatus.Ready, manager.status.value)
+    }
+
+    @Test
+    fun `a detached native success runs the After hook exactly once`() = runSlotTest {
+        val nativeCompletion = CompletableDeferred<Unit>()
+        var afterCount = 0
+        val hook = object : AdInitializationHook {
+            override suspend fun onPhase(phase: AdInitializationPhase, config: AdConfig) {
+                if (phase == AdInitializationPhase.AfterMobileAdsInitialize) afterCount++
+            }
+        }
+        val manager = FakeGoogleAdManager(
+            nativeInitialize = { _, _ -> nativeCompletion.await() }
+        )
+        val testConfig = AdConfig(
+            androidAppId = "ca-app-pub-A",
+            iosAppId = "ca-app-pub-A",
+            initializationHooks = listOf(hook),
+        )
+
+        val job = launch {
+            manager.initialize(testConfig, ConsentMode.SkipConsent)
+        }
+
+        while (manager.handoffMarks.isEmpty()) { yield() }
+        job.cancelAndJoin()
+        nativeCompletion.complete(Unit)
+        yield()
+
+        assertEquals(1, afterCount, "the After hook must run exactly once across the cancelled caller and the detached completion")
+    }
+
+    @Test
+    fun `a cancelled leader before handoff passes leadership to an equivalent follower`() = runSlotTest {
+        val leaderPause = CompletableDeferred<Unit>()
+        val manager = FakeGoogleAdManager(
+            failBeforeHandoff = {
+                leaderPause.await()
+                null
+            }
+        )
+        val sharedConfig = config("ca-app-pub-A")
+
+        val leaderJob = async { manager.initialize(sharedConfig, ConsentMode.SkipConsent) }
+        yield() // Leader reaches failBeforeHandoff
+
+        val followerJob = async { manager.initialize(sharedConfig, ConsentMode.SkipConsent) }
+        yield() // Follower attaches
+
+        leaderJob.cancelAndJoin()
+        leaderPause.complete(Unit)
+
+        val result = followerJob.await()
+        assertEquals(AdManagerStatus.Ready, result)
+        assertEquals(AdManagerStatus.Ready, manager.status.value)
+    }
+
+    @Test
+    fun `a cancelled leader after handoff leaves an equivalent follower waiting for native result`() = runSlotTest {
+        val nativeCompletion = CompletableDeferred<Unit>()
+        val manager = FakeGoogleAdManager(
+            nativeInitialize = { _, _ -> nativeCompletion.await() }
+        )
+        val sharedConfig = config("ca-app-pub-A")
+
+        val leaderJob = async { manager.initialize(sharedConfig, ConsentMode.SkipConsent) }
+        while (manager.handoffMarks.isEmpty()) { yield() }
+
+        val followerJob = async { manager.initialize(sharedConfig, ConsentMode.SkipConsent) }
+        yield() // Follower attaches
+
+        leaderJob.cancelAndJoin()
+        nativeCompletion.complete(Unit)
+
+        val result = followerJob.await()
+        assertEquals(AdManagerStatus.Ready, result)
+        assertEquals(AdManagerStatus.Ready, manager.status.value)
+    }
+
+    @Test
+    fun `cancelling a follower leaves the leader running to completion`() = runSlotTest {
+        val nativeCompletion = CompletableDeferred<Unit>()
+        val manager = FakeGoogleAdManager(
+            nativeInitialize = { _, _ -> nativeCompletion.await() }
+        )
+        val sharedConfig = config("ca-app-pub-A")
+
+        val leaderJob = async { manager.initialize(sharedConfig, ConsentMode.SkipConsent) }
+        while (manager.handoffMarks.isEmpty()) { yield() }
+
+        val followerJob = async { manager.initialize(sharedConfig, ConsentMode.SkipConsent) }
+        yield() // Follower attaches
+
+        followerJob.cancelAndJoin()
+        nativeCompletion.complete(Unit)
+
+        val result = leaderJob.await()
+        assertEquals(AdManagerStatus.Ready, result)
+        assertEquals(AdManagerStatus.Ready, manager.status.value)
+    }
+
+    @Test
+    fun `a cancelled leader before handoff allows a distinct follower to make its own attempt`() = runSlotTest {
+        val leaderPause = CompletableDeferred<Unit>()
+        val manager = FakeGoogleAdManager(
+            failBeforeHandoff = {
+                leaderPause.await()
+                null
+            }
+        )
+
+        val leaderJob = async { manager.initialize(config("ca-app-pub-A"), ConsentMode.SkipConsent) }
+        yield() // Leader reaches failBeforeHandoff
+
+        val distinctFollowerJob = async { manager.initialize(config("ca-app-pub-B"), ConsentMode.SkipConsent) }
+        yield() // Follower waits for the attempt
+
+        leaderJob.cancelAndJoin()
+        leaderPause.complete(Unit)
+
+        val result = distinctFollowerJob.await()
+        assertEquals(AdManagerStatus.Ready, result)
+        assertEquals(AdManagerStatus.Ready, manager.status.value)
+        assertEquals(listOf("ca-app-pub-B"), manager.handoffMarks.map { it.platformAppId })
     }
 }

--- a/admob-cmp-core/src/iosMain/kotlin/dev/avinya/ads/IosConsentController.kt
+++ b/admob-cmp-core/src/iosMain/kotlin/dev/avinya/ads/IosConsentController.kt
@@ -16,6 +16,7 @@ import UserMessagingPlatform.UMPPrivacyOptionsRequirementStatus
 import UserMessagingPlatform.UMPPrivacyOptionsRequirementStatusNotRequired
 import UserMessagingPlatform.UMPPrivacyOptionsRequirementStatusRequired
 import UserMessagingPlatform.UMPRequestParameters
+import dev.avinya.ads.internal.ConsentInfoUpdateOutcome
 import dev.avinya.ads.internal.ConsentStateHolder
 import dev.avinya.ads.internal.InitializationTimeouts
 import dev.avinya.ads.internal.NativeCallbackTimeoutException
@@ -58,13 +59,20 @@ internal class IosConsentController(
 
     override suspend fun requestConsentInfoUpdate(config: AdConfig): ConsentStatus =
         withContext(Dispatchers.Main.immediate) {
-            state.serialized {
+            state.serializedExclusiveOfNativeConsentOperations(
+                onBusy = {
+                    ConsentStatus.Failed(
+                        AdError.message("requestConsentInfoUpdate() ignored: another native consent operation is already in progress.")
+                    )
+                }
+            ) {
                 val owned = prepareConsentConfig(config)
-                performConsentInfoUpdate(
+                val outcome = performConsentInfoUpdate(
                     owned,
                     UMPConsentInformation.sharedInstance,
                     state.beginOperation(),
                 )
+                outcome.status
             }
         }
 
@@ -87,21 +95,8 @@ internal class IosConsentController(
         config: AdConfig,
         consentInformation: UMPConsentInformation,
         generation: Long,
-    ): ConsentStatus {
-        // MUST stay bounded: this is a non-interactive network round trip, and UMP can accept the
-        // call and never call back, which hangs consent admission -- and therefore ad serving --
-        // indefinitely.
-        //
-        // On timeout the status becomes Failed, but [canRequestAds] is deliberately NOT reset: it
-        // keeps whatever the last COMPLETED refresh established. On a first run that is false, so a
-        // cold start still admits nothing on an unknown consent state. On a later run it may be a
-        // previously granted true, and a dropped network round trip is not evidence that consent was
-        // withdrawn -- revoking admission on a blip would stop ad serving until the next successful
-        // refresh, for no gain in consent correctness. Consent itself has not changed; only our
-        // ability to re-confirm it has, and UMP has already persisted the user's actual choice.
-        //
-        // The consent FORM and privacy options form stay unbounded on purpose; a person is reading
-        // those.
+    ): ConsentInfoUpdateOutcome {
+        state.markInfoUpdateStarted(generation)
         try {
             awaitNativeCallback(
                 operation = "UMP requestConsentInfoUpdate",
@@ -114,13 +109,6 @@ internal class IosConsentController(
                     // unnecessary, prove it and record the reason, do not delete it because the body looks empty.
                     continuation.invokeOnCancellation { }
                     consentInformation.requestConsentInfoUpdateWithParameters(buildParams(config)) { error ->
-                        // Reconciliation is unconditional, matching the form paths below and
-                        // AndroidConsentController: this callback READS the UMP singleton, so a
-                        // callback that arrives after the waiter timed out still reports current
-                        // truth -- and it can carry a revocation. Only the STATUS is ordered, by
-                        // generation, which is what keeps a late success from overwriting a newer
-                        // operation's result. That ordering, not dropping the callback, is what
-                        // protects the terminal Failed(timeout) status.
                         val mapped = error?.let {
                             AdError(
                                 code = (it.code ?: 0).toString(),
@@ -128,13 +116,12 @@ internal class IosConsentController(
                             )
                         }
                         reconcileThenResumeIfActive(continuation, Unit) {
+                            state.releaseInfoUpdate(generation)
                             state.reconcileAndPublish(
-                                generation,
                                 privacyRequirement = privacyRequirementOf(consentInformation),
                                 canRequestAds = consentInformation.canRequestAds,
                                 status = resolveConsentInfoUpdateStatus(
                                     error = mapped,
-                                    canRequestAds = consentInformation.canRequestAds,
                                     nativeStatus = consentInformationStatus(consentInformation),
                                 ),
                             )
@@ -144,11 +131,10 @@ internal class IosConsentController(
             }
         } catch (timeout: NativeCallbackTimeoutException) {
             AdLogger.e("iOS UMP consent info update timed out.", timeout)
-            // canRequestAds is deliberately NOT reset here. See consentInfoUpdateTimeoutStatus's
-            // KDoc. The late callback above will still reconcile it if UMP ever answers.
-            state.publishOperationStatus(generation, consentInfoUpdateTimeoutStatus(timeout.message))
+            val status = state.publishOperationStatus(generation, consentInfoUpdateTimeoutStatus(timeout.message))
+            return ConsentInfoUpdateOutcome.TimedOut(status)
         }
-        return state.status.value
+        return ConsentInfoUpdateOutcome.Completed(state.status.value)
     }
 
     override suspend fun gatherConsent(config: AdConfig): ConsentStatus =
@@ -170,7 +156,7 @@ internal class IosConsentController(
                 // private performConsentInfoUpdate step directly rather than routing through the public
                 // requestConsentInfoUpdate to avoid Mutex re-entrancy deadlocks on the operations slot.
                 val update = performConsentInfoUpdate(owned, consentInformation, generation)
-                if (update is ConsentStatus.Failed && !consentInformation.canRequestAds) return@exclusiveOfForms update
+                if (update is ConsentInfoUpdateOutcome.TimedOut) return@exclusiveOfForms update.status
                 // Waits rather than failing on the first null. topViewController() deliberately
                 // reports null while the top controller is mid-presentation or mid-dismissal, which
                 // is routine at launch — the host's Compose UIViewController is often still being
@@ -192,17 +178,21 @@ internal class IosConsentController(
                 // line UMP owns the form, and cancelling this coroutine no longer means the screen
                 // is free. Released in the callback below, not by this coroutine's fate.
                 state.markFormPresented(generation)
-                suspendCancellableCoroutine<Unit> { continuation ->
+                val formStatus = suspendCancellableCoroutine<ConsentStatus?> { continuation ->
                     continuation.invokeOnCancellation { }
-                    UMPConsentForm.loadAndPresentIfRequiredFromViewController(rootVC) {
+                    UMPConsentForm.loadAndPresentIfRequiredFromViewController(rootVC) { error ->
+                        val errorStatus = if (error != null) {
+                            AdLogger.w("UMP consent form load/show failed: code=${error.code} message=${error.localizedDescription}")
+                            ConsentStatus.Failed(AdError(code = error.code.toString(), message = error.localizedDescription))
+                        } else null
+
                         // Reconciliation must not be conditional on the caller still being around —
                         // see reconcileThenResumeIfActive's KDoc. The form was shown and the user's
                         // decision (if any) is already persisted by UMP regardless of whether
                         // gatherConsent()'s caller is still listening.
-                        reconcileThenResumeIfActive(continuation, Unit) {
+                        reconcileThenResumeIfActive(continuation, errorStatus) {
                             state.releaseFormPresentation(generation)
                             state.reconcileAndPublish(
-                                generation,
                                 privacyRequirement = privacyRequirementOf(consentInformation),
                                 canRequestAds = consentInformation.canRequestAds,
                                 status = consentInformationStatus(consentInformation),
@@ -210,7 +200,7 @@ internal class IosConsentController(
                         }
                     }
                 }
-                state.status.value
+                formStatus ?: state.status.value
             }
         }
 
@@ -242,7 +232,6 @@ internal class IosConsentController(
                         reconcileThenResumeIfActive(continuation, error == null) {
                             state.releaseFormPresentation(generation)
                             state.reconcileAndPublish(
-                                generation,
                                 privacyRequirement = privacyRequirementOf(consentInformation),
                                 canRequestAds = consentInformation.canRequestAds,
                                 status = consentInformationStatus(consentInformation),
@@ -263,12 +252,11 @@ internal class IosConsentController(
         }
 
     override suspend fun resetConsentForDebug(): Boolean = withContext(Dispatchers.Main.immediate) {
-        state.exclusiveOfForms(
-            presentsForm = false,
-            onFormPresenting = {
+        state.serializedExclusiveOfNativeConsentOperations(
+            onBusy = {
                 AdLogger.w(
-                    "resetConsentForDebug() ignored: a consent form is already presenting. " +
-                        "Wait for it to dismiss before resetting consent."
+                    "resetConsentForDebug() ignored: a native consent operation is already in progress. " +
+                        "Wait for it to finish before resetting consent."
                 )
                 false
             },

--- a/admob-cmp-core/src/iosMain/kotlin/dev/avinya/ads/IosConsentController.kt
+++ b/admob-cmp-core/src/iosMain/kotlin/dev/avinya/ads/IosConsentController.kt
@@ -143,7 +143,7 @@ internal class IosConsentController(
                 presentsForm = true,
                 onFormPresenting = {
                     ConsentStatus.Failed(
-                        AdError.message("gatherConsent() ignored: a consent form is already presenting.")
+                        AdError.message("gatherConsent() ignored: another consent form operation is already in progress.")
                     )
                 },
             ) {
@@ -210,8 +210,8 @@ internal class IosConsentController(
                 presentsForm = true,
                 onFormPresenting = {
                     AdLogger.w(
-                        "showPrivacyOptions() ignored: another consent form is already " +
-                            "presenting. Wait for it to dismiss before presenting privacy options."
+                        "showPrivacyOptions() ignored: another consent form operation is " +
+                            "already in progress. Wait for it to finish before presenting privacy options."
                     )
                     false
                 },

--- a/admob-cmp-core/src/iosMain/kotlin/dev/avinya/ads/IosGoogleAdManager.kt
+++ b/admob-cmp-core/src/iosMain/kotlin/dev/avinya/ads/IosGoogleAdManager.kt
@@ -125,7 +125,7 @@ internal class IosGoogleAdManager : GoogleAdManagerBase() {
         // reported as applied. See GoogleAdManagerBase.handedOffConfigIdentity.
         awaitNativeCallback(
             operation = "GADMobileAds.start",
-            timeout = InitializationTimeouts.nativeInitialize
+            timeout = InitializationTimeouts.nativeInitializeIos
         ) {
             suspendCancellableCoroutine<Unit> { continuation ->
                 GADMobileAds.sharedInstance.startWithCompletionHandler { status ->

--- a/admob-cmp-gradle-plugin/src/main/kotlin/dev/avinya/ads/gradle/DoctorIosTask.kt
+++ b/admob-cmp-gradle-plugin/src/main/kotlin/dev/avinya/ads/gradle/DoctorIosTask.kt
@@ -85,13 +85,8 @@ public abstract class DoctorIosTask : DefaultTask() {
         } else {
             val content = plist.readText()
             // The declared VALUE is read, not just the key: a key present with an empty string is
-            // the same configuration gap as an absent one, and matching on the key alone also
-            // matches a mention in a comment.
-            val declaredAppId = GAD_APPLICATION_IDENTIFIER
-                .find(content)
-                ?.groupValues
-                ?.get(1)
-                ?.trim()
+            // the same configuration gap as an absent one.
+            val declaredAppId = declaredAppIdInPlist(content)
             when {
                 declaredAppId == null ->
                     logger.lifecycle("$bad Info.plist is missing GADApplicationIdentifier — GMA crashes at startup without it")
@@ -106,7 +101,9 @@ public abstract class DoctorIosTask : DefaultTask() {
                     }
                 }
             }
-            if (content.contains("SKAdNetworkItems")) {
+            // Stripped for the same reason the app-ID read is: a commented-out block is not
+            // configuration, and reporting it as present sends an integrator looking elsewhere.
+            if (stripXmlComments(content).contains("SKAdNetworkItems")) {
                 logger.lifecycle("$ok Info.plist declares SKAdNetworkItems")
             } else {
                 logger.lifecycle("$skip Info.plist has no SKAdNetworkItems — attribution will suffer; copy the list from the AdMob iOS docs")
@@ -115,11 +112,32 @@ public abstract class DoctorIosTask : DefaultTask() {
 
         logger.lifecycle("doctorIos is diagnostic only; it never fails the build.")
     }
-
-    private companion object {
-        val GAD_APPLICATION_IDENTIFIER = Regex(
-            "<key>\\s*GADApplicationIdentifier\\s*</key>\\s*<string>(.*?)</string>",
-            RegexOption.DOT_MATCHES_ALL,
-        )
-    }
 }
+
+private val GAD_APPLICATION_IDENTIFIER = Regex(
+    "<key>\\s*GADApplicationIdentifier\\s*</key>\\s*<string>(.*?)</string>",
+    RegexOption.DOT_MATCHES_ALL,
+)
+
+private val XML_COMMENT = Regex("<!--.*?-->", RegexOption.DOT_MATCHES_ALL)
+
+/**
+ * Drops XML comments so a commented-out declaration is never read as configuration.
+ *
+ * Matching the key AND its value is not sufficient on its own: a fully commented-out
+ * `<key>`/`<string>` pair still matches that shape, which is how `doctorIos` reported an
+ * `Info.plist` with no active `GADApplicationIdentifier` as correctly configured.
+ */
+private fun stripXmlComments(content: String): String = XML_COMMENT.replace(content, "")
+
+/**
+ * The active `GADApplicationIdentifier` value, or null when none is declared outside a comment.
+ *
+ * Returns the empty string when the key is declared with an empty value — a distinct finding
+ * from an absent key, since GMA crashes on both but the fix differs.
+ */
+internal fun declaredAppIdInPlist(content: String): String? = GAD_APPLICATION_IDENTIFIER
+    .find(stripXmlComments(content))
+    ?.groupValues
+    ?.get(1)
+    ?.trim()

--- a/admob-cmp-gradle-plugin/src/test/kotlin/dev/avinya/ads/gradle/DoctorIosPlistTest.kt
+++ b/admob-cmp-gradle-plugin/src/test/kotlin/dev/avinya/ads/gradle/DoctorIosPlistTest.kt
@@ -1,0 +1,99 @@
+package dev.avinya.ads.gradle
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class DoctorIosPlistTest {
+    @Test
+    fun `returns active declaration`() {
+        val plist = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+            <plist version="1.0">
+            <dict>
+                <key>GADApplicationIdentifier</key>
+                <string>ca-app-pub-3940256099942544~1458002511</string>
+            </dict>
+            </plist>
+        """.trimIndent()
+        assertEquals("ca-app-pub-3940256099942544~1458002511", declaredAppIdInPlist(plist))
+    }
+
+    @Test
+    fun `returns null for no declaration`() {
+        val plist = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+            <plist version="1.0">
+            <dict>
+                <key>CFBundleIdentifier</key>
+                <string>com.example.app</string>
+            </dict>
+            </plist>
+        """.trimIndent()
+        assertNull(declaredAppIdInPlist(plist))
+    }
+
+    @Test
+    fun `returns empty string for declared but empty value`() {
+        val plist = """
+            <dict>
+                <key>GADApplicationIdentifier</key>
+                <string></string>
+            </dict>
+        """.trimIndent()
+        assertEquals("", declaredAppIdInPlist(plist))
+    }
+
+    @Test
+    fun `returns null for fully commented-out key-value block`() {
+        val plist = """
+            <dict>
+                <!-- 
+                <key>GADApplicationIdentifier</key>
+                <string>ca-app-pub-1234~5678</string>
+                -->
+            </dict>
+        """.trimIndent()
+        assertNull(declaredAppIdInPlist(plist))
+    }
+
+    @Test
+    fun `returns real declaration when a commented block is also present`() {
+        val plist = """
+            <dict>
+                <!-- 
+                <key>GADApplicationIdentifier</key>
+                <string>ca-app-pub-1234~5678</string>
+                -->
+                <key>GADApplicationIdentifier</key>
+                <string>ca-app-pub-9999~0000</string>
+            </dict>
+        """.trimIndent()
+        assertEquals("ca-app-pub-9999~0000", declaredAppIdInPlist(plist))
+    }
+
+    @Test
+    fun `returns xcode variable value`() {
+        val plist = """
+            <dict>
+                <key>GADApplicationIdentifier</key>
+                <string>${'$'}(GAD_APP_ID)</string>
+            </dict>
+        """.trimIndent()
+        assertEquals("${'$'}(GAD_APP_ID)", declaredAppIdInPlist(plist))
+    }
+
+    @Test
+    fun `returns null for key mentioned only in prose text`() {
+        val plist = """
+            <dict>
+                <!-- Remember to add GADApplicationIdentifier before release! -->
+                <key>CFBundleIdentifier</key>
+                <string>com.example.app</string>
+            </dict>
+        """.trimIndent()
+        assertNull(declaredAppIdInPlist(plist))
+    }
+}

--- a/docs-site/src/content/docs/reference/changelog.mdx
+++ b/docs-site/src/content/docs/reference/changelog.mdx
@@ -35,6 +35,8 @@ Release details and release assets for all versions are published on the
 
 Initialization previously stranded the manager in a non-`Ready` state when the caller that started it was cancelled after the native handoff, blocking every ad request while GMA was initialized. Initialization now reaches `Ready` when the caller that started it was cancelled after the native handoff. Concurrent equivalent `initialize()` callers no longer cancel each other.
 
+Two consent form callers that queued behind a launch-time consent info update could previously both proceed, so the second presented the moment the first form was dismissed — into a preload slot UMP had just consumed, which both platforms report as a form error rather than a second form. A form operation now claims the form slot when it is called rather than when it reaches the front of the queue, so the second caller declines.
+
 The iOS initialization watchdog previously raced GMA's own completion bound. It no longer does so. iOS consent-form errors previously lacked parity with Android. They are now logged with parity to Android. `doctorIos` previously reported a commented-out `GADApplicationIdentifier` as configured. It no longer does so.
 
 ### Behaviour changes

--- a/docs-site/src/content/docs/reference/changelog.mdx
+++ b/docs-site/src/content/docs/reference/changelog.mdx
@@ -29,6 +29,34 @@ release is **2.2.0**.
 Release details and release assets for all versions are published on the
 [GitHub releases page](https://github.com/Meet-Miyani/admob-compose-multiplatform/releases).
 
+## Unreleased
+
+### Fixes
+
+Initialization previously stranded the manager in a non-`Ready` state when the caller that started it was cancelled after the native handoff, blocking every ad request while GMA was initialized. Initialization now reaches `Ready` when the caller that started it was cancelled after the native handoff. Concurrent equivalent `initialize()` callers no longer cancel each other.
+
+The iOS initialization watchdog previously raced GMA's own completion bound. It no longer does so. iOS consent-form errors previously lacked parity with Android. They are now logged with parity to Android. `doctorIos` previously reported a commented-out `GADApplicationIdentifier` as configured. It no longer does so.
+
+### Behaviour changes
+
+A late UMP consent callback might previously not override a newer operation's status. `ConsentStatus` now always reflects current UMP truth, so a late callback can overwrite a newer operation's status — that operation's failure remains its own return value.
+
+<Aside type="caution" title="Behaviour change">
+`ConsentStatus` now always reflects current UMP truth, so a late callback can overwrite a newer operation's status — that operation's failure remains its own return value. Admission (`canRequestAds`) is unchanged, and `gatherConsent` no longer presents a form after a *timed-out* refresh while still presenting one after a completed-with-error refresh.
+</Aside>
+
+A failed consent refresh previously returned the mapped native status. A failed consent refresh now returns `Failed` instead of the mapped native status even when prior-session admission still permits ads.
+
+<Aside type="caution" title="Behaviour change">
+A failed consent refresh now returns `Failed` instead of the mapped native status even when prior-session admission still permits ads. Admission (`canRequestAds`) is unchanged, and `gatherConsent` no longer presents a form after a *timed-out* refresh while still presenting one after a completed-with-error refresh.
+</Aside>
+
+An abandoned native consent operation might previously not explicitly decline subsequent update requests. `requestConsentInfoUpdate` can now return `Failed` when it declines because an abandoned native consent operation is still live.
+
+<Aside type="caution" title="Behaviour change">
+`requestConsentInfoUpdate` can now return `Failed` when it declines because an abandoned native consent operation is still live. Admission (`canRequestAds`) is unchanged, and `gatherConsent` no longer presents a form after a *timed-out* refresh while still presenting one after a completed-with-error refresh.
+</Aside>
+
 ## What changed in 2.2.0?
 
 A reliability release covering exception, timeout, and cancellation behaviour across consent,

--- a/docs-site/src/content/docs/reference/compatibility.mdx
+++ b/docs-site/src/content/docs/reference/compatibility.mdx
@@ -71,6 +71,10 @@ The library provides Kotlin bindings generated against specific Google Mobile Ad
 
 The bound iOS headers require that the resolved SPM major version matches the major version used during cinterop generation (`13.x` for GMA and `3.x` for UMP). An older or newer major version may fail at link time due to missing or modified Objective-C symbol definitions.
 
+## SDK Initialization and `AdManagerStatus.Ready`
+
+The SDK publishes `AdManagerStatus.Ready` after the platform's initialization callback reports, which on Android means mediation adapters have finished initializing, so every configured network can participate in the first request. A slow adapter delays `Ready` up to `InitializationTimeouts.nativeInitialize`.
+
 ## Consuming the library on iOS
 
 The iOS library targets Kotlin Multiplatform projects compiled into an iOS umbrella framework. Pure Swift iOS applications cannot import `admob-cmp` directly without a Kotlin Multiplatform wrapper module, because Kotlin/Native cinterop generates Kotlin-callable APIs rather than native Swift APIs.

--- a/docs-site/src/content/docs/start/android-setup.mdx
+++ b/docs-site/src/content/docs/start/android-setup.mdx
@@ -29,7 +29,7 @@ Google Mobile Ads requires an Application Identifier declared in your Android ap
 - **Metadata Location**: Place `<meta-data>` inside the `<application>` tag of the runnable Android application module (`androidApp`), not inside a shared Kotlin library module.
 - **Identifier Format**: Application IDs use a tilde separator (`ca-app-pub-XXXXXXXXXXXXXXXX~XXXXXXXXXX`). Providing an Ad Unit ID (which uses a slash separator) will cause initialisation failure or runtime crashes.
 - **Consent Identity**: UMP reads `com.google.android.gms.ads.APPLICATION_ID` from the manifest, while GMA Next-Gen initializes from `AdConfig.androidAppId`. Missing or mismatched metadata can make consent and ads resolve different applications and must be fixed.
-- **App ID Preflight**: During `initialize()`, the SDK checks `AdConfig.androidAppId` against the manifest value. `FailWhenUnusable` (the default) warns and continues on Android, `Strict` rejects before UMP or GMA is touched, and `WarnOnly` always warns and continues.
+- **App ID Preflight**: During `initialize()`, the SDK checks `AdConfig.androidAppId` against the manifest value. `FailWhenUnusable` (the default) warns and continues on Android, `Strict` rejects before UMP or GMA is touched, and `WarnOnly` always warns and continues. We recommend adding `AdAppIdVerification.policy = AppIdVerificationPolicy.Strict` at app startup, before the first `initialize()`, for new integrations. It turns app-ID mismatches into a deterministic `APP_ID_INVALID` failure instead of a warning, and becomes the default in 3.0.0.
 
 ## Managing the AD_ID permission
 

--- a/docs-site/src/content/docs/start/installation.mdx
+++ b/docs-site/src/content/docs/start/installation.mdx
@@ -127,6 +127,17 @@ Execute the following verification commands to confirm correct dependency resolu
 
 `doctorIos` verifies framework download caches, Xcode project references, and required `Info.plist` key declarations. Successful execution of test tasks confirms that native bindings link correctly across all targets.
 
+## Strict App ID Verification
+
+For new integrations, we recommend configuring the process-wide App ID verification policy at app startup, before your first `initialize()` call. It turns app-ID mismatches into a deterministic `APP_ID_INVALID` failure instead of a warning, and becomes the default in 3.0.0.
+
+```kotlin
+import dev.avinya.ads.AdAppIdVerification
+import dev.avinya.ads.AppIdVerificationPolicy
+
+AdAppIdVerification.policy = AppIdVerificationPolicy.Strict
+```
+
 ## Where to next?
 
 <CardGrid>

--- a/docs-site/src/content/docs/start/ios-setup.mdx
+++ b/docs-site/src/content/docs/start/ios-setup.mdx
@@ -56,7 +56,7 @@ Configure your iOS application target's `Info.plist` with required metadata keys
 </array>
 ```
 
-- `GADApplicationIdentifier`: Application identifier with a tilde separator (`ca-app-pub-XXXXXXXXXXXXXXXX~XXXXXXXXXX`). Omitting this key, or leaving its value empty, crashes native GMA on launch. AdMob CMP validates it during `initialize()` preflight under `AdAppIdVerification.policy` (`FailWhenUnusable` default, `Strict`, `WarnOnly`).
+- `GADApplicationIdentifier`: Application identifier with a tilde separator (`ca-app-pub-XXXXXXXXXXXXXXXX~XXXXXXXXXX`). Omitting this key, or leaving its value empty, crashes native GMA on launch. AdMob CMP validates it during `initialize()` preflight under `AdAppIdVerification.policy` (`FailWhenUnusable` default, `Strict`, `WarnOnly`). We recommend adding `AdAppIdVerification.policy = AppIdVerificationPolicy.Strict` at app startup, before the first `initialize()`, for new integrations. It turns app-ID mismatches into a deterministic `APP_ID_INVALID` failure instead of a warning, and becomes the default in 3.0.0.
 - `SKAdNetworkItems`: Array of ad network identifiers enabling privacy-preserving ad attribution.
 
 ## App Tracking Transparency (ATT) setup

--- a/docs-site/src/content/docs/start/quickstart.mdx
+++ b/docs-site/src/content/docs/start/quickstart.mdx
@@ -70,12 +70,18 @@ Use a `LaunchedEffect` to initialize it with test configuration, and then displa
 ```kotlin
 import androidx.compose.runtime.CompositionLocalProvider
 import dev.avinya.ads.LocalAdManager
+import dev.avinya.ads.AdAppIdVerification
+import dev.avinya.ads.AppIdVerificationPolicy
 
 @Composable
 fun App() {
     val adManager = rememberAdManager()
 
     LaunchedEffect(adManager) {
+        // Recommended setting for new integrations. Note it must be set at app startup, before the first initialize().
+        // It turns app-ID mismatches into a deterministic APP_ID_INVALID failure instead of a warning, and it becomes the default in 3.0.0.
+        AdAppIdVerification.policy = AppIdVerificationPolicy.Strict
+
         adManager.gatherConsentAndInitialize(
             AdConfig(
                 androidAppId = TestAdIds.ANDROID_APP_ID,

--- a/docs-site/test/discoverability.test.ts
+++ b/docs-site/test/discoverability.test.ts
@@ -120,3 +120,13 @@ describe('search intent copy', () => {
     expect(roadmap).not.toMatch(/ship(?:s|ped)? as `?2\.0\.0`?|when 2\.0\.0 ships/i);
   });
 });
+
+describe('integration recommendations', () => {
+  it('recommends Strict AppIdVerificationPolicy in all setup guides', () => {
+    const expectedLine = 'AdAppIdVerification.policy = AppIdVerificationPolicy.Strict';
+    expect(readRepoFile('docs-site/src/content/docs/start/quickstart.mdx')).toContain(expectedLine);
+    expect(readRepoFile('docs-site/src/content/docs/start/installation.mdx')).toContain(expectedLine);
+    expect(readRepoFile('docs-site/src/content/docs/start/android-setup.mdx')).toContain(expectedLine);
+    expect(readRepoFile('docs-site/src/content/docs/start/ios-setup.mdx')).toContain(expectedLine);
+  });
+});

--- a/docs/release/device-certification.md
+++ b/docs/release/device-certification.md
@@ -36,6 +36,7 @@ Run every row on both platforms.
 | 10 | Reward is emitted exactly once per rewarded presentation | | |
 | 11 | AdMob native ad validator reports no implementation issues | | |
 | 12 | iOS only: ordering is UMP → ATT → first ad request | n/a | |
+| 13 | Double-tap the privacy options entry point during the launch-time consent refresh → one form, and the second tap declines without a spurious failure | | |
 
 ## Devices
 


### PR DESCRIPTION
## What does this change?

Five commits closing the findings from a post-2.2.0 staff review of initialization and consent. Three landed earlier on this branch; two are new and close the findings from a follow-up review of those three.

**Initialization (`77349542`)** — five defects, kept together because they are the small, high-confidence ones and stay cherry-pickable into a 2.2.1 hotfix. Detached native success never published `Ready`; the failure counterpart was unreachable for the same scenario; an active follower inherited the leader's cancellation; the iOS watchdog shared GMA's own ~30s bound; `doctorIos` read commented-out plist declarations as configuration.

**Consent (`9a8a5d82`)** — native UMP operations are now serialized by pins that outlive their coroutines, rather than by a mutex that only ordered waiters. `ConsentStatus`, `canRequestAds` and the privacy-options requirement now move together. A failed refresh returns `Failed` rather than the mapped native status. iOS surfaces form errors with Android parity.

**Docs (`16295481`)** — the behaviour changes above, plus `AppIdVerificationPolicy.Strict` recommended for new integrations (default stays `FailWhenUnusable`; the flip is promised for 3.0.0).

**The form slot (`afd2ab09`, new)** — `exclusiveOfForms` claimed the slot only once it held `operationMutex`, so the claim never covered the wait for it. While a non-form operation held the mutex — the launch-time consent info update — two form callers could both pass the pre-lock check and queue, and the second presented the moment the first form was dismissed. That second presentation is not a second form: both platforms preload exactly one privacy options form and consume it on presentation, so the user dismisses the form they asked for and is handed a `FormError` for the tap that opened it. iOS only started surfacing that error in `9a8a5d82`. The claim now happens on entry; the release in the `finally` is guarded by `presentsForm`, without which the claim of a queued form caller would be cleared by a non-form operation completing inside the lock.

**The info-update gate (`bf810a9e`, new)** — `gatherConsent` can start a native `requestConsentInfoUpdate` while an abandoned one is still outstanding, where `requestConsentInfoUpdate` declines. The asymmetry stays and is now written down: `gatherConsent` is the launch path, and declining it because a pin nobody is waiting on is still live would fail the app's whole consent flow for as long as the pin backstop — a reproducible launch failure traded against an overlap UMP does not define on either platform. `markInfoUpdateStarted` now warns when it takes over a live pin, at the one choke point both platforms call.

`VERSION_NAME` is deliberately not bumped. The release bump is its own PR.

## Checklist

- [x] Added or updated a test that fails before this change and passes after it
- [x] Ran `./gradlew :admob-cmp-core:testAndroidHostTest` and `:admob-cmp-core:iosSimulatorArm64Test`
- [x] If this touches the public API of `admob-cmp-core` or `admob-cmp-compose`: ran `updateKotlinAbi` and committed the regenerated `api/*.klib.api` dump — n/a, public ABI unchanged; `checkKotlinAbi` and the 2.2.0 → HEAD additivity check both pass
- [x] Updated docs in `docs-site/src/content/docs/` in this PR, if user-facing behavior changed
- [x] Updated [the changelog](https://ads.avinya.dev/reference/changelog/), if behavior a consumer can observe changed
- [x] Ran `./scripts/release-readiness.sh` locally and got `READINESS: PASS` (or explained why it couldn't be run)

`READINESS: PASS` on `bf810a9e`, full run, all nine sections, nothing skipped: version lockstep, Gradle plugin build + supply-chain policy, static analysis and coverage, Android + ABI + publication metadata, Central task graph, iOS + klib ABI, published-consumer round trip, Xcode consumer, docs (AUDIT OK — 30 pages).

## Notes for the reviewer

**Each new test was checked against its own absence, not just for passing.** `a second form caller queued behind a non-form operation declines` fails on the pre-fix coordinator. `a non-form operation does not clear a queued form caller's claim` fails with the `presentsForm` guard removed. `exclusiveOfForms ignores a live info update pin` fails if the two gates are made symmetric — it guards the decision, so a future symmetry change trips a test carrying the rationale rather than shipping the launch failure. `cancellation while queued for the mutex releases the form slot` passes either way by design; it pins the new window the fix opens rather than the original defect.

**Native-SDK behaviour this rests on**, from the vendored UMP headers and Google's reference docs: `UMPConsentForm` is documented as "a single use consent form object"; both platforms preload one privacy options form and call back with an error on the next run loop when none is preloaded (`UMPFormErrorCodeAlreadyUsed` / `Unavailable`, Android `FormError` when "the form is still being preloaded"); neither platform documents concurrent `requestConsentInfoUpdate` calls or exposes an error code for one. Google's own `GoogleMobileAdsConsentManager` sample has no guard against any of this.

**Not covered by any local check — needs device certification before the version bump.** Every consent row in `docs/release/device-certification.md`, plus the new row 13: double-tap the privacy options entry point during the launch-time consent refresh and confirm one form and a clean decline. The overlapping-info-update behaviour in `bf810a9e` is explicitly undefined by UMP and cannot be proven locally either.

**Still open, deliberately out of scope:** the 2.1.0 → 2.2.0 delta (~8.5k lines, including the `IosGoogleAdManager` restructure) has not been reviewed as a whole. It is already published and immutable, so findings there become 2.2.1/2.3.0 fixes rather than a gate on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
