### PR TITLE
fix(consent): correct initialization watchdog and consent status ordering

### DIFF
--- a/admob-cmp-core/api/admob-cmp-core.klib.api
+++ b/admob-cmp-core/api/admob-cmp-core.klib.api
@@ -1696,6 +1696,8 @@ final object dev.avinya.ads/AdAppIdVerification { // dev.avinya.ads/AdAppIdVerif
 final object dev.avinya.ads/AdErrorCode { // dev.avinya.ads/AdErrorCode|null[0]
     final const val APP_ID_INVALID // dev.avinya.ads/AdErrorCode.APP_ID_INVALID|{}APP_ID_INVALID[0]
         final fun <get-APP_ID_INVALID>(): kotlin/String // dev.avinya.ads/AdErrorCode.APP_ID_INVALID.<get-APP_ID_INVALID>|<get-APP_ID_INVALID>(){}[0]
+    final const val CONSENT_OPERATION_IN_PROGRESS // dev.avinya.ads/AdErrorCode.CONSENT_OPERATION_IN_PROGRESS|{}CONSENT_OPERATION_IN_PROGRESS[0]
+        final fun <get-CONSENT_OPERATION_IN_PROGRESS>(): kotlin/String // dev.avinya.ads/AdErrorCode.CONSENT_OPERATION_IN_PROGRESS.<get-CONSENT_OPERATION_IN_PROGRESS>|<get-CONSENT_OPERATION_IN_PROGRESS>(){}[0]
     final const val CONSENT_REQUIRED // dev.avinya.ads/AdErrorCode.CONSENT_REQUIRED|{}CONSENT_REQUIRED[0]
         final fun <get-CONSENT_REQUIRED>(): kotlin/String // dev.avinya.ads/AdErrorCode.CONSENT_REQUIRED.<get-CONSENT_REQUIRED>|<get-CONSENT_REQUIRED>(){}[0]
     final const val INITIALIZATION_CONFLICT // dev.avinya.ads/AdErrorCode.INITIALIZATION_CONFLICT|{}INITIALIZATION_CONFLICT[0]

--- a/admob-cmp-core/src/androidMain/kotlin/dev/avinya/ads/AndroidConsentController.kt
+++ b/admob-cmp-core/src/androidMain/kotlin/dev/avinya/ads/AndroidConsentController.kt
@@ -2,6 +2,7 @@ package dev.avinya.ads
 
 import android.app.Activity
 import android.content.Context
+import dev.avinya.ads.internal.ANDROID_UMP_ERROR_DOMAIN
 import dev.avinya.ads.internal.ConsentInfoUpdateOutcome
 import dev.avinya.ads.internal.ConsentStateHolder
 import dev.avinya.ads.internal.InitializationTimeouts
@@ -53,7 +54,10 @@ internal class AndroidConsentController(
             state.serializedExclusiveOfNativeConsentOperations(
                 onBusy = {
                     ConsentStatus.Failed(
-                        AdError.message("requestConsentInfoUpdate() ignored: another native consent operation is already in progress.")
+                        AdError(
+                            code = AdErrorCode.CONSENT_OPERATION_IN_PROGRESS,
+                            message = "requestConsentInfoUpdate() ignored: another native consent operation is already in progress.",
+                        )
                     )
                 }
             ) {
@@ -129,6 +133,7 @@ internal class AndroidConsentController(
                                 // timed-out caller does not end the native operation.
                                 state.releaseInfoUpdate(generation)
                                 state.reconcileAndPublish(
+                                    generation = generation,
                                     privacyRequirement = privacyRequirementOf(consentInformation),
                                     canRequestAds = consentInformation.canRequestAds(),
                                     status = resolveConsentInfoUpdateStatus(
@@ -142,10 +147,12 @@ internal class AndroidConsentController(
                             val mapped = AdError(
                                 code = formError.errorCode.toString(),
                                 message = formError.message,
+                                domain = ANDROID_UMP_ERROR_DOMAIN,
                             )
                             reconcileThenResumeIfActive(continuation, Unit) {
                                 state.releaseInfoUpdate(generation)
                                 state.reconcileAndPublish(
+                                    generation = generation,
                                     privacyRequirement = privacyRequirementOf(consentInformation),
                                     canRequestAds = consentInformation.canRequestAds(),
                                     status = resolveConsentInfoUpdateStatus(
@@ -160,6 +167,11 @@ internal class AndroidConsentController(
             }
         } catch (timeout: NativeCallbackTimeoutException) {
             AdLogger.e("Android UMP consent info update timed out.", timeout)
+            // Released HERE, not left to the backstop. Past this line the wrapper has declared the
+            // operation dead and is publishing a terminal status for it, so holding the pin would
+            // only refuse the retry UMP's own guidance asks for. The late callback below still
+            // reconciles privacy truth if UMP ever answers; it just no longer gates anyone.
+            state.releaseInfoUpdate(generation)
             val status = state.publishOperationStatus(generation, consentInfoUpdateTimeoutStatus(timeout.message))
             return ConsentInfoUpdateOutcome.TimedOut(status)
         }
@@ -172,7 +184,10 @@ internal class AndroidConsentController(
                 presentsForm = true,
                 onFormPresenting = {
                     ConsentStatus.Failed(
-                        AdError.message("gatherConsent() ignored: another consent form operation is already in progress.")
+                        AdError(
+                            code = AdErrorCode.CONSENT_OPERATION_IN_PROGRESS,
+                            message = "gatherConsent() ignored: another consent form operation is already in progress.",
+                        )
                     )
                 },
             ) {
@@ -193,7 +208,13 @@ internal class AndroidConsentController(
                     UserMessagingPlatform.loadAndShowConsentFormIfRequired(activity) { formError ->
                         val errorStatus = if (formError != null) {
                             AdLogger.w("UMP consent form load/show failed: code=${formError.errorCode} message=${formError.message}")
-                            ConsentStatus.Failed(AdError(code = formError.errorCode.toString(), message = formError.message))
+                            ConsentStatus.Failed(
+                                AdError(
+                                    code = formError.errorCode.toString(),
+                                    message = formError.message,
+                                    domain = ANDROID_UMP_ERROR_DOMAIN,
+                                )
+                            )
                         } else null
 
                         // Reconciliation must not be conditional on the caller still being around —
@@ -203,9 +224,14 @@ internal class AndroidConsentController(
                         reconcileThenResumeIfActive(continuation, errorStatus) {
                             state.releaseFormPresentation(generation)
                             state.reconcileAndPublish(
+                                generation = generation,
                                 privacyRequirement = privacyRequirementOf(consentInformation),
                                 canRequestAds = consentInformation.canRequestAds(),
-                                status = consentInformationStatus(consentInformation),
+                                // The published status and the returned one are the SAME value.
+                                // Returning Failed while publishing the native status would let one
+                                // consumer await an error and another collect success for the very
+                                // same form. Admission is reconciled above either way.
+                                status = errorStatus ?: consentInformationStatus(consentInformation),
                             )
                         }
                     }
@@ -244,6 +270,7 @@ internal class AndroidConsentController(
                         reconcileThenResumeIfActive(continuation, formError == null) {
                             state.releaseFormPresentation(generation)
                             state.reconcileAndPublish(
+                                generation = generation,
                                 privacyRequirement = privacyRequirementOf(consentInformation),
                                 canRequestAds = consentInformation.canRequestAds(),
                                 status = consentInformationStatus(consentInformation),
@@ -272,6 +299,10 @@ internal class AndroidConsentController(
                 )
                 false
             },
+            // Restores the guard reset had under exclusiveOfForms(presentsForm = false): a form
+            // caller claims the slot BEFORE waiting for the mutex, so the mutex alone cannot stop a
+            // reset from wiping UMP's stored consent out from under one that is about to present.
+            declineWhileFormSlotHeld = true,
         ) {
             // Acquired inside the main hop, not before it -- this reads Activity lifecycle state,
             // which is main-thread-owned (invariant 5), matching every other entry point here.

--- a/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/AdError.kt
+++ b/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/AdError.kt
@@ -68,6 +68,21 @@ public object AdErrorCode {
      * initialize() once", this one means "fix the app bundle and rebuild".
      */
     public const val APP_ID_INVALID: String = "app_id_invalid"
+
+    /**
+     * A consent entry point declined because another native UMP operation is still outstanding.
+     *
+     * **Retryable, and usually within seconds.** This is not a consent failure: it means a form is
+     * on screen, or an earlier native call's caller was cancelled while UMP may still be working.
+     * Nothing about the user's consent has changed, and [canRequestAds][ConsentController.canRequestAds]
+     * still carries whatever the last completed refresh established -- which, per UMP's own
+     * guidance, is what to check when a consent operation reports an error.
+     *
+     * Distinguishing this from an ordinary [ConsentStatus.Failed] matters: without it a consumer
+     * cannot tell a transient, self-clearing decline from consent being genuinely broken, and will
+     * show a person an error for a condition that resolves on its own.
+     */
+    public const val CONSENT_OPERATION_IN_PROGRESS: String = "consent_operation_in_progress"
 }
 
 

--- a/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/AdState.kt
+++ b/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/AdState.kt
@@ -16,12 +16,12 @@ public sealed interface AdManagerStatus {
     /**
      * SDK is fully initialized and ready to serve ads.
      *
-     * Published after the platform's initialization callback reports, which on both platforms
-     * means mediation adapters have finished initializing — so every configured network can
-     * participate in the first request. GMA invokes that callback once the adapters finish *or*
-     * after its own 30-second bound, whichever comes first; the wrapper waits up to 40 seconds so
-     * it cannot mistake a slow-but-successful setup for a failure. A slow adapter therefore delays
-     * [Ready] by at most ~30 seconds in practice.
+     * Published after completion of the wrapper's initialization path, allowing requests subject to
+     * the existing admission gates. Google's callback can arrive after initialization completes or
+     * after its internal timeout. Individual mediation adapters can fail or time out independently;
+     * there is no guarantee that every configured mediation adapter has successfully initialized or
+     * will participate in the first request. The wrapper waits up to 40 seconds as a margin beyond
+     * Google's documented 30-second bound.
      */
     public data object Ready : AdManagerStatus
     /** SDK is disabled with a [reason] message. */

--- a/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/AdState.kt
+++ b/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/AdState.kt
@@ -14,10 +14,14 @@ public sealed interface AdManagerStatus {
     /** SDK is in the process of initializing. */
     public data object Initializing : AdManagerStatus
     /**
-     * SDK publishes [Ready] after the platform's initialization callback reports.
-     * On Android, this means mediation adapters have finished initializing, so every
-     * configured network can participate in the first request. A slow adapter delays
-     * [Ready] up to `InitializationTimeouts.nativeInitialize`.
+     * SDK is fully initialized and ready to serve ads.
+     *
+     * Published after the platform's initialization callback reports, which on both platforms
+     * means mediation adapters have finished initializing — so every configured network can
+     * participate in the first request. GMA invokes that callback once the adapters finish *or*
+     * after its own 30-second bound, whichever comes first; the wrapper waits up to 40 seconds so
+     * it cannot mistake a slow-but-successful setup for a failure. A slow adapter therefore delays
+     * [Ready] by at most ~30 seconds in practice.
      */
     public data object Ready : AdManagerStatus
     /** SDK is disabled with a [reason] message. */

--- a/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/ConsentInfoUpdatePolicy.kt
+++ b/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/ConsentInfoUpdatePolicy.kt
@@ -5,6 +5,19 @@ import dev.avinya.ads.AdError
 import dev.avinya.ads.ConsentStatus
 
 /**
+ * [AdError.domain] for errors raised by Android's UMP SDK.
+ *
+ * Load-bearing, not decoration. Android surfaces `com.google.android.ump.FormError.ErrorCode`
+ * (INTERNAL_ERROR=1, INTERNET_ERROR=2, INVALID_OPERATION=3, TIME_OUT=4) while iOS surfaces
+ * `UMPRequestErrorCode` (Internal=1, InvalidAppID=2, Network=3, Misconfiguration=4). The two
+ * enumerations occupy the SAME numeric range with DIFFERENT meanings -- "2" is a network error on
+ * Android and an invalid app ID on iOS -- so a bare [AdError.code] is ambiguous across platforms.
+ * The domain is what disambiguates it. iOS passes the `NSError`'s own domain, which already
+ * distinguishes `UMPRequestErrorDomain` from `UMPFormErrorDomain`.
+ */
+internal const val ANDROID_UMP_ERROR_DOMAIN: String = "com.google.android.ump"
+
+/**
  * The outcome of a native UMP `requestConsentInfoUpdate` operation.
  */
 internal sealed class ConsentInfoUpdateOutcome {

--- a/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/ConsentOperationCoordinator.kt
+++ b/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/ConsentOperationCoordinator.kt
@@ -107,13 +107,16 @@ internal class ConsentOperationCoordinator(
      * exactly that case -- today that is `gatherConsent`, deliberately, for the reason recorded on
      * [exclusiveOfForms]. The overlap is not defined by UMP either way, so it is worth saying out
      * loud in the log rather than leaving a consumer to infer it from two interleaved round trips.
+     *
+     * A pin found live here belongs to a CANCELLED caller. The bounded-wait path releases its own
+     * pin on timeout, so a timed-out operation never reaches this warning.
      */
     fun markInfoUpdateStarted(generation: Long) {
         if (liveInfoUpdateOrNull() != null) {
             AdLogger.w(
                 "Starting a UMP consent info update while an earlier one has not reported back. " +
-                    "The earlier call was abandoned by its caller (timed out or cancelled) and UMP " +
-                    "may still be working on it. Overlapping info updates are not defined by UMP; " +
+                    "The earlier call was abandoned when its caller was cancelled and UMP may " +
+                    "still be working on it. Overlapping info updates are not defined by UMP; " +
                     "the wrapper's own state stays coherent because the abandoned call's callback " +
                     "can no longer publish over this one."
             )
@@ -139,24 +142,40 @@ internal class ConsentOperationCoordinator(
     /**
      * Serialized execution that declines via [onBusy] if a native consent operation (form or info
      * update) is already in progress and has outlived its coroutine.
+     *
+     * [declineWhileFormSlotHeld] additionally declines while a form operation merely HOLDS the
+     * slot -- claimed on entry, possibly still queued for [operationMutex] and not yet on screen.
+     * Only `resetConsentForDebug` sets it, and it is the guard that moved when reset stopped going
+     * through [exclusiveOfForms]: wiping UMP's stored consent out from under a form caller that is
+     * about to present is not something [operationMutex] can prevent, because the claim is made
+     * BEFORE the wait and a reset can legitimately win the lock first.
+     *
+     * Every other caller leaves it false. An info update MUST queue behind a form rather than
+     * fail -- a launch-time refresh that returns "unavailable" instead of getting its form is a
+     * spurious error in front of a person. See [exclusiveOfForms].
      */
     suspend fun <T> serializedExclusiveOfNativeConsentOperations(
         onBusy: () -> T,
+        declineWhileFormSlotHeld: Boolean = false,
         block: suspend () -> T,
     ): T {
         // Pre-lock, decline ONLY on a native form handoff -- a form can be on screen with no
         // mutex holder, so waiting for the lock would be waiting for nothing. Deliberately NOT
-        // formIsLive(): slotHoldsForm means a form operation has claimed the slot but has not
-        // presented anything yet -- it may hold the mutex, or may still be queued for it -- and
-        // either way an info update must queue behind it exactly as it always has rather than fail.
+        // formIsLive() unless the caller opted in: slotHoldsForm means a form operation has claimed
+        // the slot but has not presented anything yet -- it may hold the mutex, or may still be
+        // queued for it -- and either way an info update must queue behind it rather than fail.
         if (liveHandoffOrNull() != null) return onBusy()
+        if (declineWhileFormSlotHeld && slotHoldsForm) return onBusy()
 
         return serialized {
-            // Post-lock, re-check BOTH pins. A pin still live once the mutex has been acquired
-            // can only belong to an operation whose waiter is gone (timed out or cancelled) while
-            // UMP is still working -- the abandoned case, and the only one that declines. Two live
-            // concurrent callers never reach here together, so they still queue and both run.
+            // Post-lock, re-check the pins. A pin still live once the mutex has been acquired can
+            // only belong to an operation whose caller was cancelled while UMP is still working --
+            // the abandoned case, and the only one that declines. Two live concurrent callers never
+            // reach here together, so they still queue and both run.
             if (liveHandoffOrNull() != null || liveInfoUpdateOrNull() != null) return@serialized onBusy()
+            // Re-checked under the lock for the same reason the pins are: a form caller can claim
+            // the slot while this one is queued.
+            if (declineWhileFormSlotHeld && slotHoldsForm) return@serialized onBusy()
             block()
         }
     }

--- a/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/ConsentStateHolder.kt
+++ b/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/ConsentStateHolder.kt
@@ -91,9 +91,9 @@ internal class ConsentStateHolder(timeSource: TimeSource = TimeSource.Monotonic)
      * `Failed(error)`. Publishing that unconditionally lets a superseded operation's stale error
      * land on top of a newer operation's success -- e.g. a refresh that times out at
      * `consentInfoUpdate`, a retry that succeeds, and then the first call's late error callback
-     * arriving last and republishing `Failed` while [canRequestAds] says `true`. The two public
-     * flows would then contradict each other. The generation gate is what prevents that, and it
-     * is not interchangeable with the unconditional reconcile above.
+     * arriving last and overwriting the success with `Failed`. An older operation's failure
+     * must not overwrite a newer operation's success. The generation gate is what prevents
+     * that, and it is not interchangeable with the unconditional reconcile above.
      */
     fun reconcileAndPublish(
         generation: Long,

--- a/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/ConsentStateHolder.kt
+++ b/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/ConsentStateHolder.kt
@@ -49,8 +49,13 @@ internal class ConsentStateHolder(timeSource: TimeSource = TimeSource.Monotonic)
 
     suspend fun <T> serializedExclusiveOfNativeConsentOperations(
         onBusy: () -> T,
+        declineWhileFormSlotHeld: Boolean = false,
         block: suspend () -> T,
-    ): T = coordinator.serializedExclusiveOfNativeConsentOperations(onBusy, block)
+    ): T = coordinator.serializedExclusiveOfNativeConsentOperations(
+        onBusy = onBusy,
+        declineWhileFormSlotHeld = declineWhileFormSlotHeld,
+        block = block,
+    )
 
     suspend fun <T> exclusiveOfForms(
         presentsForm: Boolean,
@@ -71,23 +76,37 @@ internal class ConsentStateHolder(timeSource: TimeSource = TimeSource.Monotonic)
     fun releaseInfoUpdate(generation: Long): Unit = coordinator.releaseInfoUpdate(generation)
 
     /**
-     * Reconciles authoritative privacy truth and publishes [status] unconditionally.
-     * Returns the [status] passed in.
+     * Reconciles authoritative privacy truth UNCONDITIONALLY, then publishes [status] only if
+     * [generation] is still the current operation. Returns the value [status] now holds.
      *
-     * A callback that reports a privacy state must ALWAYS publish the status it carries,
-     * even if it arrived late (superseded by a newer operation). If a late callback carries
-     * a revocation, dropping it leaves the gate open on stale truth; dropping the status
-     * while accepting the truth leaves the flows out of sync.
+     * The two halves are gated differently, on purpose.
+     *
+     * **Truth is never dropped.** [privacyRequirement] and [canRequestAds] are read from the UMP
+     * singleton by the callback itself, so they are current however late the callback is -- and a
+     * late callback can carry a revocation. Dropping it would leave the admission gate open on
+     * stale truth, so these publish whether or not this operation was superseded.
+     *
+     * **Status is ordered.** [status] is NOT truth in that sense: it describes the outcome of ONE
+     * operation, and `resolveConsentInfoUpdateStatus` collapses any native error into
+     * `Failed(error)`. Publishing that unconditionally lets a superseded operation's stale error
+     * land on top of a newer operation's success -- e.g. a refresh that times out at
+     * `consentInfoUpdate`, a retry that succeeds, and then the first call's late error callback
+     * arriving last and republishing `Failed` while [canRequestAds] says `true`. The two public
+     * flows would then contradict each other. The generation gate is what prevents that, and it
+     * is not interchangeable with the unconditional reconcile above.
      */
     fun reconcileAndPublish(
+        generation: Long,
         privacyRequirement: PrivacyOptionsRequirementStatus,
         canRequestAds: Boolean,
         status: ConsentStatus,
     ): ConsentStatus {
         _privacyOptionsRequirementStatus.value = privacyRequirement
         _canRequestAds.value = canRequestAds
-        _status.value = status
-        return status
+        if (coordinator.isCurrentOperation(generation)) {
+            _status.value = status
+        }
+        return _status.value
     }
 
     /**

--- a/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/NativeCallbackTimeouts.kt
+++ b/admob-cmp-core/src/commonMain/kotlin/dev/avinya/ads/internal/NativeCallbackTimeouts.kt
@@ -20,16 +20,20 @@ import kotlinx.coroutines.withTimeoutOrNull
  * the wrapper keeps BELIEVING a form is on screen, never the form itself.
  */
 internal object InitializationTimeouts {
-    /** Native `MobileAds.initialize` / `GADMobileAds.start`. */
-    val nativeInitialize: Duration = 30.seconds
-
     /**
-     * GMA iOS documents that `startWithCompletionHandler` fires after setup completes *or* after
-     * its own ~30-second internal bound, so an outer watchdog set to the same nominal value can
-     * win the race and report a false failure for a slow mediation setup — exactly the case the
-     * native fallback exists to resolve.
+     * Native `MobileAds.initialize` / `GADMobileAds.start`.
+     *
+     * Deliberately GREATER than the 30 seconds GMA itself waits. Both platforms document the same
+     * internal bound — the completion fires once the SDK and its mediation adapters finish
+     * initializing, *or* after a 30-second timeout (GMA Next-Gen Android `MobileAds.initialize`,
+     * GMA iOS `startWithCompletionHandler`). An outer watchdog set to that same nominal value
+     * races GMA's own fallback and can report a false failure for a slow — but ultimately
+     * successful — mediation setup, which is precisely the case that fallback exists to resolve.
+     *
+     * One value, not one per platform: the bound being defended against is identical on both, so a
+     * platform-specific constant would only let the two drift apart again.
      */
-    val nativeInitializeIos: Duration = 40.seconds
+    val nativeInitialize: Duration = 40.seconds
 
     /** UMP `requestConsentInfoUpdate` — a network round trip with no user interaction. */
     val consentInfoUpdate: Duration = 20.seconds
@@ -77,7 +81,14 @@ internal object InitializationTimeouts {
     val formPresentationPin: Duration = 5.minutes
 
     /**
-     * How long the native info update stays pinned.
+     * Backstop for a native info update whose caller was CANCELLED.
+     *
+     * The bounded-wait path releases its own pin when [consentInfoUpdate] expires: at that point
+     * the wrapper has already declared the operation dead and published a terminal status, so
+     * continuing to refuse later operations on its behalf would block the very retry UMP's own
+     * guidance asks for ("request an update to consent information on every app launch").
+     * Cancellation has no such moment — the coroutine simply unwinds — so this pin is what stops a
+     * cancelled caller from stranding the slot, and it must outlive [consentInfoUpdate] to do it.
      */
     val infoUpdatePin: Duration = 30.seconds
 }

--- a/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/ConsentStateHolderTest.kt
+++ b/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/ConsentStateHolderTest.kt
@@ -378,8 +378,8 @@ class ConsentStateHolderTest {
         var resetRan = false
 
         // Holds the mutex WITHOUT claiming the form slot, so the form caller below claims the slot
-        // on entry and then queues. That is the window the mutex cannot cover on its own: nothing
-        // is on screen, no handoff pin exists, and reset can legitimately win the lock first.
+        // on entry and then queues. Because reset is called after the form claims the slot,
+        // it fails the pre-lock check and declines immediately.
         val nonForm = launch {
             holder.serializedExclusiveOfNativeConsentOperations(onBusy = {}) {
                 nonFormEntered.complete(Unit)
@@ -408,6 +408,59 @@ class ConsentStateHolderTest {
         releaseNonForm.complete(Unit)
         nonForm.join()
         form.join()
+    }
+
+    @Test
+    fun `reset declines when a form claims the slot after reset queues`() = runTest {
+        val holder = ConsentStateHolder()
+        val nonFormEntered = CompletableDeferred<Unit>()
+        val releaseNonForm = CompletableDeferred<Unit>()
+        var resetRan = false
+        var resetBusyCount = 0
+
+        val nonForm = launch {
+            holder.serializedExclusiveOfNativeConsentOperations(onBusy = {}) {
+                nonFormEntered.complete(Unit)
+                releaseNonForm.await()
+                true
+            }
+        }
+        nonFormEntered.await()
+
+        val reset = launch {
+            val result = holder.serializedExclusiveOfNativeConsentOperations(
+                onBusy = { resetBusyCount++; false },
+                declineWhileFormSlotHeld = true,
+            ) {
+                resetRan = true
+                holder.reset()
+                true
+            }
+            assertFalse(result, "reset must return false when declined")
+        }
+
+        advanceUntilIdle()
+        assertFalse(resetRan, "reset block must not have run yet")
+        assertEquals(0, resetBusyCount, "reset must not have run its busy callback yet")
+
+        val formEntered = CompletableDeferred<Unit>()
+        val form = launch {
+            holder.exclusiveOfForms(presentsForm = true, onFormPresenting = { false }) {
+                formEntered.complete(Unit)
+                true
+            }
+        }
+
+        advanceUntilIdle()
+
+        releaseNonForm.complete(Unit)
+
+        reset.join()
+        assertFalse(resetRan, "reset block must never execute")
+        assertEquals(1, resetBusyCount, "reset busy callback must run exactly once")
+
+        form.join()
+        assertTrue(formEntered.isCompleted, "queued form must enter and complete successfully")
     }
 
     @Test

--- a/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/ConsentStateHolderTest.kt
+++ b/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/ConsentStateHolderTest.kt
@@ -21,6 +21,7 @@ class ConsentStateHolderTest {
         val generation = holder.beginOperation()
 
         val result = holder.reconcileAndPublish(
+            generation = generation,
             privacyRequirement = PrivacyOptionsRequirementStatus.Required,
             canRequestAds = true,
             status = ConsentStatus.Required,
@@ -33,20 +34,28 @@ class ConsentStateHolderTest {
     }
 
     @Test
-    fun `reconcileAndPublish unconditionally updates all three flows even for superseded generation`() {
+    fun `reconcileAndPublish reconciles truth for a superseded generation but does not publish its status`() {
         val holder = ConsentStateHolder()
+        val superseded = holder.beginOperation()
         val current = holder.beginOperation()
 
         holder.publishOperationStatus(current, ConsentStatus.Obtained)
 
         val result = holder.reconcileAndPublish(
+            generation = superseded,
             privacyRequirement = PrivacyOptionsRequirementStatus.NotRequired,
             canRequestAds = true,
             status = ConsentStatus.Required,
         )
 
-        assertEquals(ConsentStatus.Required, result, "result should be passed status value")
-        assertEquals(ConsentStatus.Required, holder.status.value, "superseded status MUST overwrite current status now")
+        assertEquals(ConsentStatus.Obtained, result, "the result is what status actually holds, not the dropped value")
+        assertEquals(
+            ConsentStatus.Obtained,
+            holder.status.value,
+            "a superseded operation's status must never overwrite the current operation's",
+        )
+        // Truth is NOT gated: the callback reads it from the UMP singleton, so it is current
+        // however late the callback is, and it can carry a revocation.
         assertEquals(PrivacyOptionsRequirementStatus.NotRequired, holder.privacyOptionsRequirementStatus.value)
         assertTrue(holder.canRequestAds.value)
     }
@@ -63,6 +72,7 @@ class ConsentStateHolderTest {
 
         // ...and later the callback for the SAME still-current generation completes with Obtained.
         val result = holder.reconcileAndPublish(
+            generation = generation,
             privacyRequirement = PrivacyOptionsRequirementStatus.NotRequired,
             canRequestAds = true,
             status = ConsentStatus.Obtained,
@@ -77,7 +87,9 @@ class ConsentStateHolderTest {
     @Test
     fun `a revocation observed by reconcileAndPublish sets canRequestAds false regardless of generation`() {
         val holder = ConsentStateHolder()
+        val first = holder.beginOperation()
         holder.reconcileAndPublish(
+            generation = first,
             privacyRequirement = PrivacyOptionsRequirementStatus.NotRequired,
             canRequestAds = true,
             status = ConsentStatus.Obtained,
@@ -87,8 +99,9 @@ class ConsentStateHolderTest {
         val current = holder.beginOperation()
         holder.publishOperationStatus(current, ConsentStatus.Obtained)
 
-        // Stale callback observes revocation
+        // Stale callback from `first` observes a revocation on the UMP singleton.
         holder.reconcileAndPublish(
+            generation = first,
             privacyRequirement = PrivacyOptionsRequirementStatus.Required,
             canRequestAds = false,
             status = ConsentStatus.Required,
@@ -96,7 +109,11 @@ class ConsentStateHolderTest {
 
         assertFalse(holder.canRequestAds.value, "revocation must close ad request gate immediately")
         assertEquals(PrivacyOptionsRequirementStatus.Required, holder.privacyOptionsRequirementStatus.value)
-        assertEquals(ConsentStatus.Required, holder.status.value, "superseded status must now overwrite current status")
+        assertEquals(
+            ConsentStatus.Obtained,
+            holder.status.value,
+            "truth is ungated, but a superseded operation's STATUS must not overwrite the current one's",
+        )
     }
 
     @Test
@@ -104,6 +121,7 @@ class ConsentStateHolderTest {
         val holder = ConsentStateHolder()
         val outstanding = holder.beginOperation()
         holder.reconcileAndPublish(
+            generation = outstanding,
             privacyRequirement = PrivacyOptionsRequirementStatus.Required,
             canRequestAds = true,
             status = ConsentStatus.Obtained,
@@ -294,8 +312,9 @@ class ConsentStateHolderTest {
     }
 
     @Test
-    fun `a superseded form callback reconciles privacy truth and publishes its status`() {
+    fun `a superseded form callback reconciles privacy truth without publishing its status`() {
         val holder = ConsentStateHolder()
+        val formGeneration = holder.beginOperation()
         val newerOperationGen = holder.beginOperation()
 
         // Newer operation finishes first and sets status
@@ -303,15 +322,20 @@ class ConsentStateHolderTest {
 
         // In-flight form eventually calls back on its older generation
         holder.reconcileAndPublish(
+            generation = formGeneration,
             privacyRequirement = PrivacyOptionsRequirementStatus.NotRequired,
             canRequestAds = true,
             status = ConsentStatus.Obtained,
         )
 
-        // All three values move together
+        // Truth moves; the superseded status does not.
         assertTrue(holder.canRequestAds.value)
         assertEquals(PrivacyOptionsRequirementStatus.NotRequired, holder.privacyOptionsRequirementStatus.value)
-        assertEquals(ConsentStatus.Obtained, holder.status.value, "superseded form callback MUST overwrite newer operation's status")
+        assertEquals(
+            ConsentStatus.NotRequired,
+            holder.status.value,
+            "a superseded form callback must not overwrite the newer operation's status",
+        )
     }
 
     @Test
@@ -330,9 +354,9 @@ class ConsentStateHolderTest {
         }
         formEntered.await()
 
-        val resetResult = holder.exclusiveOfForms(
-            presentsForm = false,
-            onFormPresenting = { false },
+        val resetResult = holder.serializedExclusiveOfNativeConsentOperations(
+            onBusy = { false },
+            declineWhileFormSlotHeld = true,
         ) {
             resetRan = true
             holder.reset()
@@ -343,6 +367,46 @@ class ConsentStateHolderTest {
         assertFalse(resetRan, "reset block must not execute when declined")
 
         releaseForm.complete(Unit)
+        form.join()
+    }
+
+    @Test
+    fun `reset declines to a queued form caller that only holds the slot`() = runTest {
+        val holder = ConsentStateHolder()
+        val nonFormEntered = CompletableDeferred<Unit>()
+        val releaseNonForm = CompletableDeferred<Unit>()
+        var resetRan = false
+
+        // Holds the mutex WITHOUT claiming the form slot, so the form caller below claims the slot
+        // on entry and then queues. That is the window the mutex cannot cover on its own: nothing
+        // is on screen, no handoff pin exists, and reset can legitimately win the lock first.
+        val nonForm = launch {
+            holder.serializedExclusiveOfNativeConsentOperations(onBusy = {}) {
+                nonFormEntered.complete(Unit)
+                releaseNonForm.await()
+            }
+        }
+        nonFormEntered.await()
+
+        val form = launch {
+            holder.exclusiveOfForms(presentsForm = true, onFormPresenting = { false }) { true }
+        }
+        advanceUntilIdle()
+
+        val resetResult = holder.serializedExclusiveOfNativeConsentOperations(
+            onBusy = { false },
+            declineWhileFormSlotHeld = true,
+        ) {
+            resetRan = true
+            holder.reset()
+            true
+        }
+
+        assertFalse(resetResult, "reset must decline to a form caller that has claimed the slot")
+        assertFalse(resetRan, "reset must not wipe UMP consent under a form that is about to present")
+
+        releaseNonForm.complete(Unit)
+        nonForm.join()
         form.join()
     }
 
@@ -364,9 +428,9 @@ class ConsentStateHolderTest {
         nonFormEntered.await()
 
         val reset = launch {
-            val ran = holder.exclusiveOfForms(
-                presentsForm = false,
-                onFormPresenting = { false },
+            val ran = holder.serializedExclusiveOfNativeConsentOperations(
+                onBusy = { false },
+                declineWhileFormSlotHeld = true,
             ) {
                 order += "reset-ran"
                 holder.reset()
@@ -385,18 +449,19 @@ class ConsentStateHolderTest {
     }
 
     @Test
-    fun `reset inside exclusiveOfForms still invalidates an outstanding generation`() = runTest {
+    fun `reset still invalidates an outstanding generation`() = runTest {
         val holder = ConsentStateHolder()
         val outstanding = holder.beginOperation()
         holder.reconcileAndPublish(
+            generation = outstanding,
             privacyRequirement = PrivacyOptionsRequirementStatus.Required,
             canRequestAds = true,
             status = ConsentStatus.Obtained,
         )
 
-        holder.exclusiveOfForms(
-            presentsForm = false,
-            onFormPresenting = { false },
+        holder.serializedExclusiveOfNativeConsentOperations(
+            onBusy = { false },
+            declineWhileFormSlotHeld = true,
         ) {
             holder.reset()
             true
@@ -410,12 +475,16 @@ class ConsentStateHolderTest {
         holder.publishOperationStatus(outstanding, ConsentStatus.Obtained)
         assertEquals(ConsentStatus.Unknown, holder.status.value)
 
-        // An outstanding generation reconcileAndPublish overwrites Unknown status
+        // reset() claims a fresh generation, so the outstanding one is superseded: its late
+        // callback still reconciles truth, but it cannot republish a pre-reset status.
         holder.reconcileAndPublish(
+            generation = outstanding,
             privacyRequirement = PrivacyOptionsRequirementStatus.NotRequired,
             canRequestAds = true,
             status = ConsentStatus.Obtained,
         )
-        assertEquals(ConsentStatus.Obtained, holder.status.value)
+        assertEquals(ConsentStatus.Unknown, holder.status.value, "a pre-reset generation cannot republish")
+        assertEquals(PrivacyOptionsRequirementStatus.NotRequired, holder.privacyOptionsRequirementStatus.value)
+        assertTrue(holder.canRequestAds.value, "truth reconciliation survives the reset")
     }
 }

--- a/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/NativeInitializationOwnershipTest.kt
+++ b/admob-cmp-core/src/commonTest/kotlin/dev/avinya/ads/NativeInitializationOwnershipTest.kt
@@ -20,19 +20,24 @@ import kotlinx.coroutines.yield
 class NativeInitializationOwnershipTest {
 
     @Test
-    fun `iOS native initialization timeout is strictly greater than GMA internal bound`() {
-        val iosTimeout = InitializationTimeouts.nativeInitializeIos
-        val androidTimeout = InitializationTimeouts.nativeInitialize
-        
+    fun `the native initialization watchdog outlasts GMA's own internal bound`() {
+        // Both platforms document the SAME bound, not just iOS: the completion fires once the SDK
+        // and its mediation adapters finish initializing, "or after a 30-second timeout" (GMA
+        // Next-Gen Android MobileAds.initialize, GMA iOS startWithCompletionHandler). A wrapper
+        // watchdog set to that same nominal value races GMA's own fallback and turns a slow -- but
+        // ultimately successful -- mediation setup into a false initialization failure.
+        //
+        // Asserted against the documented bound rather than against the other platform's constant:
+        // a relative assertion was what let Android keep racing while iOS was fixed.
         assertTrue(
-            iosTimeout > 30.seconds,
-            "iOS timeout must be > 30s to win the race against GMA's internal watchdog"
-        )
-        assertTrue(
-            iosTimeout > androidTimeout,
-            "iOS timeout must be greater than the default/Android timeout"
+            InitializationTimeouts.nativeInitialize > gmaInternalCompletionBound,
+            "the wrapper watchdog must outlast GMA's own $gmaInternalCompletionBound bound on " +
+                "every platform, or a slow mediation setup races it into a false failure",
         )
     }
+
+    /** What GMA itself waits before invoking its completion regardless of adapter state. */
+    private val gmaInternalCompletionBound = 30.seconds
 
     private fun config(appId: String) = AdConfig(
         androidAppId = appId,

--- a/admob-cmp-core/src/iosMain/kotlin/dev/avinya/ads/IosConsentController.kt
+++ b/admob-cmp-core/src/iosMain/kotlin/dev/avinya/ads/IosConsentController.kt
@@ -62,7 +62,10 @@ internal class IosConsentController(
             state.serializedExclusiveOfNativeConsentOperations(
                 onBusy = {
                     ConsentStatus.Failed(
-                        AdError.message("requestConsentInfoUpdate() ignored: another native consent operation is already in progress.")
+                        AdError(
+                            code = AdErrorCode.CONSENT_OPERATION_IN_PROGRESS,
+                            message = "requestConsentInfoUpdate() ignored: another native consent operation is already in progress.",
+                        )
                     )
                 }
             ) {
@@ -113,11 +116,16 @@ internal class IosConsentController(
                             AdError(
                                 code = (it.code ?: 0).toString(),
                                 message = it.localizedDescription ?: "Consent info update failed.",
+                                // UMPRequestErrorCode occupies the same 1..4 range as Android's
+                                // FormError.ErrorCode with different meanings, so the domain is
+                                // what tells a consumer which enumeration this code belongs to.
+                                domain = it.domain,
                             )
                         }
                         reconcileThenResumeIfActive(continuation, Unit) {
                             state.releaseInfoUpdate(generation)
                             state.reconcileAndPublish(
+                                generation = generation,
                                 privacyRequirement = privacyRequirementOf(consentInformation),
                                 canRequestAds = consentInformation.canRequestAds,
                                 status = resolveConsentInfoUpdateStatus(
@@ -131,6 +139,11 @@ internal class IosConsentController(
             }
         } catch (timeout: NativeCallbackTimeoutException) {
             AdLogger.e("iOS UMP consent info update timed out.", timeout)
+            // Released HERE, not left to the backstop. Past this line the wrapper has declared the
+            // operation dead and is publishing a terminal status for it, so holding the pin would
+            // only refuse the retry UMP's own guidance asks for. The late callback below still
+            // reconciles privacy truth if UMP ever answers; it just no longer gates anyone.
+            state.releaseInfoUpdate(generation)
             val status = state.publishOperationStatus(generation, consentInfoUpdateTimeoutStatus(timeout.message))
             return ConsentInfoUpdateOutcome.TimedOut(status)
         }
@@ -143,7 +156,10 @@ internal class IosConsentController(
                 presentsForm = true,
                 onFormPresenting = {
                     ConsentStatus.Failed(
-                        AdError.message("gatherConsent() ignored: another consent form operation is already in progress.")
+                        AdError(
+                            code = AdErrorCode.CONSENT_OPERATION_IN_PROGRESS,
+                            message = "gatherConsent() ignored: another consent form operation is already in progress.",
+                        )
                     )
                 },
             ) {
@@ -183,7 +199,13 @@ internal class IosConsentController(
                     UMPConsentForm.loadAndPresentIfRequiredFromViewController(rootVC) { error ->
                         val errorStatus = if (error != null) {
                             AdLogger.w("UMP consent form load/show failed: code=${error.code} message=${error.localizedDescription}")
-                            ConsentStatus.Failed(AdError(code = error.code.toString(), message = error.localizedDescription))
+                            ConsentStatus.Failed(
+                                AdError(
+                                    code = error.code.toString(),
+                                    message = error.localizedDescription,
+                                    domain = error.domain,
+                                )
+                            )
                         } else null
 
                         // Reconciliation must not be conditional on the caller still being around —
@@ -193,9 +215,14 @@ internal class IosConsentController(
                         reconcileThenResumeIfActive(continuation, errorStatus) {
                             state.releaseFormPresentation(generation)
                             state.reconcileAndPublish(
+                                generation = generation,
                                 privacyRequirement = privacyRequirementOf(consentInformation),
                                 canRequestAds = consentInformation.canRequestAds,
-                                status = consentInformationStatus(consentInformation),
+                                // The published status and the returned one are the SAME value.
+                                // Returning Failed while publishing the native status would let one
+                                // consumer await an error and another collect success for the very
+                                // same form. Admission is reconciled above either way.
+                                status = errorStatus ?: consentInformationStatus(consentInformation),
                             )
                         }
                     }
@@ -232,6 +259,7 @@ internal class IosConsentController(
                         reconcileThenResumeIfActive(continuation, error == null) {
                             state.releaseFormPresentation(generation)
                             state.reconcileAndPublish(
+                                generation = generation,
                                 privacyRequirement = privacyRequirementOf(consentInformation),
                                 canRequestAds = consentInformation.canRequestAds,
                                 status = consentInformationStatus(consentInformation),
@@ -260,6 +288,10 @@ internal class IosConsentController(
                 )
                 false
             },
+            // Restores the guard reset had under exclusiveOfForms(presentsForm = false): a form
+            // caller claims the slot BEFORE waiting for the mutex, so the mutex alone cannot stop a
+            // reset from wiping UMP's stored consent out from under one that is about to present.
+            declineWhileFormSlotHeld = true,
         ) {
             state.reset()
             UMPConsentInformation.sharedInstance.reset()

--- a/admob-cmp-core/src/iosMain/kotlin/dev/avinya/ads/IosGoogleAdManager.kt
+++ b/admob-cmp-core/src/iosMain/kotlin/dev/avinya/ads/IosGoogleAdManager.kt
@@ -125,7 +125,7 @@ internal class IosGoogleAdManager : GoogleAdManagerBase() {
         // reported as applied. See GoogleAdManagerBase.handedOffConfigIdentity.
         awaitNativeCallback(
             operation = "GADMobileAds.start",
-            timeout = InitializationTimeouts.nativeInitializeIos
+            timeout = InitializationTimeouts.nativeInitialize
         ) {
             suspendCancellableCoroutine<Unit> { continuation ->
                 GADMobileAds.sharedInstance.startWithCompletionHandler { status ->

--- a/docs-site/src/content/docs/privacy/consent.mdx
+++ b/docs-site/src/content/docs/privacy/consent.mdx
@@ -55,6 +55,39 @@ network failure on the consent-info update endpoint, which is a
 transient condition and can be retried. A persistent `Failed`
 state usually points to a misconfigured AdMob app ID or missing App ID settings.
 
+Two things are worth checking before you show a person an error.
+
+**`canRequestAds` is the value that matters.** A failed refresh does not revoke
+consent: UMP keeps whatever the last completed refresh established, so
+`consent.canRequestAds` may still be `true` and ads may still serve while
+`status` reads `Failed`. This is [what Google's own guidance recommends
+checking](https://developers.google.com/admob/android/privacy) when a consent
+operation reports an error.
+
+**Check `error.code` for `AdErrorCode.CONSENT_OPERATION_IN_PROGRESS`.** That code
+means the call declined because another native UMP operation was still
+outstanding — a form on screen, or an earlier call whose caller was cancelled. It
+is retryable within seconds and is not a consent failure, so it should not surface
+to a person as one.
+
+```kotlin
+when (val status = adManager.consent.status.value) {
+    is ConsentStatus.Failed ->
+        if (status.error.code == AdErrorCode.CONSENT_OPERATION_IN_PROGRESS) {
+            // Transient. Retry shortly; nothing to tell the user.
+        } else if (adManager.consent.canRequestAds.value) {
+            // Refresh failed, but a previous session's choice still permits ads.
+        } else {
+            // A real consent problem worth surfacing.
+        }
+    else -> Unit
+}
+```
+
+`error.domain` distinguishes the platform the numeric `code` came from. Android's
+`FormError.ErrorCode` and iOS's `UMPRequestErrorCode` both use `1..4` with
+different meanings, so never branch on a bare numeric consent code without it.
+
 ## Which ConsentMode should I use?
 
 ```kotlin

--- a/docs-site/src/content/docs/privacy/consent.mdx
+++ b/docs-site/src/content/docs/privacy/consent.mdx
@@ -48,45 +48,74 @@ adManager.gatherConsentAndInitialize(
 | `NotRequired` | Regulation does not require consent for this user. |
 | `Failed(error)` | The consent-info update failed; the error is attached. |
 
-A practical note on `Failed(error)`: the error is a regular
+A practical note on consent state: there are three distinct concepts at play.
+1. The **return value** of a suspending call describes the outcome of that specific attempted operation.
+2. `consent.status` is the **shared published state**. A rejected busy call leaves this unchanged.
+3. `consent.canRequestAds` determines **consent admission**. Actual ad loading also requires manager readiness.
+
+When an operation returns `Failed(error)`, the error is a regular
 `AdError` carrying standard fields — `code`,
 `message`, `domain`, `responseInfo`. The most common cause is a
-network failure on the consent-info update endpoint, which is a
-transient condition and can be retried. A persistent `Failed`
-state usually points to a misconfigured AdMob app ID or missing App ID settings.
+network failure, which is a
+transient condition. A persistent `Failed`
+state usually points to a misconfigured AdMob app ID.
 
-Two things are worth checking before you show a person an error.
-
-**`canRequestAds` is the value that matters.** A failed refresh does not revoke
+Before you show a person an error, check `canRequestAds`. A failed refresh does not revoke
 consent: UMP keeps whatever the last completed refresh established, so
 `consent.canRequestAds` may still be `true` and ads may still serve while
-`status` reads `Failed`. This is [what Google's own guidance recommends
-checking](https://developers.google.com/admob/android/privacy) when a consent
-operation reports an error.
+an operation failed. This is [what Google's own guidance recommends
+checking](https://developers.google.com/admob/android/privacy).
 
-**Check `error.code` for `AdErrorCode.CONSENT_OPERATION_IN_PROGRESS`.** That code
-means the call declined because another native UMP operation was still
-outstanding — a form on screen, or an earlier call whose caller was cancelled. It
-is retryable within seconds and is not a consent failure, so it should not surface
-to a person as one.
+If an action fails because a form is already showing or an update is in progress, wait for the existing operation to finish before retrying if the action is still needed. Do not implement an automatic retry loop: a duplicate tap should not cause another form to open after dismissal.
+
+### Handling errors in 2.2.0
 
 ```kotlin
-when (val status = adManager.consent.status.value) {
-    is ConsentStatus.Failed ->
-        if (status.error.code == AdErrorCode.CONSENT_OPERATION_IN_PROGRESS) {
-            // Transient. Retry shortly; nothing to tell the user.
+import dev.avinya.ads.AdManager
+import dev.avinya.ads.AdConfig
+import dev.avinya.ads.ConsentStatus
+
+suspend fun startConsentFlow(adManager: AdManager, config: AdConfig) {
+    val result = adManager.consent.gatherConsent(config)
+
+    if (result is ConsentStatus.Failed) {
+        if (adManager.consent.canRequestAds.value) {
+            // Refresh failed, but a previous session's choice still permits ads.
+        } else {
+            // A real consent problem worth surfacing. Note that 2.2.0 has no dedicated
+            // busy-error constant, and not every failed native refresh is guaranteed
+            // to return Failed.
+        }
+    }
+}
+```
+
+<Aside type="note" title="Unreleased — unavailable in 2.2.0">
+The following demonstrates handling the busy error introduced after 2.2.0. This code branches on the awaited operation result, never `consent.status.value`. A `CONSENT_OPERATION_IN_PROGRESS` error is returned to the declined caller as a declined concurrent request, and explicitly is not published to the status flow. The same handling applies to `requestConsentInfoUpdate(config)`. These examples are alternatives for different versions, do not call both sequentially.
+
+```kotlin
+import dev.avinya.ads.AdErrorCode
+import dev.avinya.ads.AdManager
+import dev.avinya.ads.AdConfig
+import dev.avinya.ads.ConsentStatus
+
+suspend fun startConsentFlow(adManager: AdManager, config: AdConfig) {
+    val result = adManager.consent.gatherConsent(config)
+
+    if (result is ConsentStatus.Failed) {
+        if (result.error.code == AdErrorCode.CONSENT_OPERATION_IN_PROGRESS) {
+            // Another consent operation is already running.
         } else if (adManager.consent.canRequestAds.value) {
             // Refresh failed, but a previous session's choice still permits ads.
         } else {
             // A real consent problem worth surfacing.
         }
-    else -> Unit
+    }
 }
 ```
 
-`error.domain` distinguishes the platform the numeric `code` came from. Android's
-`FormError.ErrorCode` and iOS's `UMPRequestErrorCode` both use `1..4` with
-different meanings, so never branch on a bare numeric consent code without it.
+Additionally, in unreleased versions, `error.domain` is improved on consent errors to distinguish the platform the numeric `code` came from. Android's `FormError.ErrorCode` and iOS's `UMPRequestErrorCode` both use `1..4` with different meanings, so never branch on a bare numeric consent code without it.
+</Aside>
 
 ## Which ConsentMode should I use?
 

--- a/docs-site/src/content/docs/reference/changelog.mdx
+++ b/docs-site/src/content/docs/reference/changelog.mdx
@@ -51,10 +51,10 @@ Release details and release assets for all versions are published on the
 Three changes affect what `ConsentStatus` your code sees. Admission (`canRequestAds`) is unchanged by all three — it still carries whatever the last completed refresh established, which is what [UMP's own guidance](https://developers.google.com/admob/android/privacy) says to check when a consent operation reports an error.
 
 1. **A failed consent refresh now returns `Failed`** rather than the mapped native status, even when a previous session's admission still permits ads.
-2. **`requestConsentInfoUpdate` can now return `Failed`** when it declines because another native consent operation is still outstanding. This decline carries `AdErrorCode.CONSENT_OPERATION_IN_PROGRESS` and is retryable within seconds — treat it as "try again shortly", not as a consent failure.
+2. **`requestConsentInfoUpdate` can now return `Failed`** when it declines because another native consent operation is still outstanding. This busy error is returned to the declined caller and does not overwrite shared published status. It carries `AdErrorCode.CONSENT_OPERATION_IN_PROGRESS`. Wait for the existing operation to finish before retrying if the action is still needed.
 3. **`gatherConsent` no longer presents a form after a *timed-out* refresh**, while it still presents one after a refresh that completed with an error.
 
-A late UMP callback still reconciles privacy truth unconditionally — a revocation is never dropped — but it does **not** publish a status over a newer operation's. `ConsentStatus` and `canRequestAds` can no longer contradict each other.
+A late UMP callback still reconciles privacy truth unconditionally — a revocation is never dropped — but a superseded callback cannot overwrite a newer operation's published status, while callback reconciliation still refreshes current native privacy/admission values. It remains a valid case for an operation to return or publish `Failed` while `canRequestAds` remains `true` (if a previous completed refresh permitted ads).
 </Aside>
 
 ## What changed in 2.2.0?

--- a/docs-site/src/content/docs/reference/changelog.mdx
+++ b/docs-site/src/content/docs/reference/changelog.mdx
@@ -33,30 +33,28 @@ Release details and release assets for all versions are published on the
 
 ### Fixes
 
-Initialization previously stranded the manager in a non-`Ready` state when the caller that started it was cancelled after the native handoff, blocking every ad request while GMA was initialized. Initialization now reaches `Ready` when the caller that started it was cancelled after the native handoff. Concurrent equivalent `initialize()` callers no longer cancel each other.
+**Initialization no longer strands the manager in a non-`Ready` state** when the caller that started it was cancelled after the native handoff. Previously that blocked every ad request while GMA was in fact initialized. Concurrent equivalent `initialize()` callers also no longer cancel each other.
 
-Two consent form callers that queued behind a launch-time consent info update could previously both proceed, so the second presented the moment the first form was dismissed — into a preload slot UMP had just consumed, which both platforms report as a form error rather than a second form. A form operation now claims the form slot when it is called rather than when it reaches the front of the queue, so the second caller declines.
+**The native initialization watchdog no longer races GMA's own completion bound, on either platform.** GMA invokes its completion once the SDK and its mediation adapters finish *or* after its own 30-second bound — the same on Android (`MobileAds.initialize`) and iOS (`startWithCompletionHandler`). The wrapper's watchdog was set to that same 30 seconds, so a slow but ultimately successful mediation setup could be reported as an initialization failure. It now waits 40 seconds on both platforms.
 
-The iOS initialization watchdog previously raced GMA's own completion bound. It no longer does so. iOS consent-form errors previously lacked parity with Android. They are now logged with parity to Android. `doctorIos` previously reported a commented-out `GADApplicationIdentifier` as configured. It no longer does so.
+**Two consent form callers queued behind a launch-time consent info update could both proceed**, so the second presented the moment the first was dismissed — into a preload slot UMP had just consumed, which both platforms report as a form error rather than a second form. A form operation now claims the form slot when it is called rather than when it reaches the front of the queue, so the second caller declines.
+
+**A timed-out consent info update no longer blocks the retry that follows it.** The operation's pin is released when the wrapper declares it dead, instead of lingering and making the next `requestConsentInfoUpdate` — including the one `initialize(InitializeOnlyIfAlreadyAllowed)` performs — decline without contacting UMP.
+
+**Consent errors now carry a usable `AdError.domain`.** Android's `FormError.ErrorCode` and iOS's `UMPRequestErrorCode` occupy the same `1..4` numeric range with different meanings, so `AdError.code` alone was ambiguous across platforms.
+
+`resetConsentForDebug()` again declines while a consent form operation holds the form slot. iOS consent-form errors are now logged with parity to Android. `doctorIos` no longer reports a commented-out `GADApplicationIdentifier` as configured.
 
 ### Behaviour changes
 
-A late UMP consent callback might previously not override a newer operation's status. `ConsentStatus` now always reflects current UMP truth, so a late callback can overwrite a newer operation's status — that operation's failure remains its own return value.
+<Aside type="caution" title="Behaviour changes">
+Three changes affect what `ConsentStatus` your code sees. Admission (`canRequestAds`) is unchanged by all three — it still carries whatever the last completed refresh established, which is what [UMP's own guidance](https://developers.google.com/admob/android/privacy) says to check when a consent operation reports an error.
 
-<Aside type="caution" title="Behaviour change">
-`ConsentStatus` now always reflects current UMP truth, so a late callback can overwrite a newer operation's status — that operation's failure remains its own return value. Admission (`canRequestAds`) is unchanged, and `gatherConsent` no longer presents a form after a *timed-out* refresh while still presenting one after a completed-with-error refresh.
-</Aside>
+1. **A failed consent refresh now returns `Failed`** rather than the mapped native status, even when a previous session's admission still permits ads.
+2. **`requestConsentInfoUpdate` can now return `Failed`** when it declines because another native consent operation is still outstanding. This decline carries `AdErrorCode.CONSENT_OPERATION_IN_PROGRESS` and is retryable within seconds — treat it as "try again shortly", not as a consent failure.
+3. **`gatherConsent` no longer presents a form after a *timed-out* refresh**, while it still presents one after a refresh that completed with an error.
 
-A failed consent refresh previously returned the mapped native status. A failed consent refresh now returns `Failed` instead of the mapped native status even when prior-session admission still permits ads.
-
-<Aside type="caution" title="Behaviour change">
-A failed consent refresh now returns `Failed` instead of the mapped native status even when prior-session admission still permits ads. Admission (`canRequestAds`) is unchanged, and `gatherConsent` no longer presents a form after a *timed-out* refresh while still presenting one after a completed-with-error refresh.
-</Aside>
-
-An abandoned native consent operation might previously not explicitly decline subsequent update requests. `requestConsentInfoUpdate` can now return `Failed` when it declines because an abandoned native consent operation is still live.
-
-<Aside type="caution" title="Behaviour change">
-`requestConsentInfoUpdate` can now return `Failed` when it declines because an abandoned native consent operation is still live. Admission (`canRequestAds`) is unchanged, and `gatherConsent` no longer presents a form after a *timed-out* refresh while still presenting one after a completed-with-error refresh.
+A late UMP callback still reconciles privacy truth unconditionally — a revocation is never dropped — but it does **not** publish a status over a newer operation's. `ConsentStatus` and `canRequestAds` can no longer contradict each other.
 </Aside>
 
 ## What changed in 2.2.0?

--- a/docs-site/src/content/docs/reference/compatibility.mdx
+++ b/docs-site/src/content/docs/reference/compatibility.mdx
@@ -73,7 +73,9 @@ The bound iOS headers require that the resolved SPM major version matches the ma
 
 ## SDK Initialization and `AdManagerStatus.Ready`
 
-The SDK publishes `AdManagerStatus.Ready` after the platform's initialization callback reports, which on Android means mediation adapters have finished initializing, so every configured network can participate in the first request. A slow adapter delays `Ready` up to `InitializationTimeouts.nativeInitialize`.
+The SDK publishes `AdManagerStatus.Ready` after the platform's initialization callback reports. On both Android and iOS that means mediation adapters have finished initializing, so every configured network can participate in the first ad request.
+
+Google Mobile Ads invokes that callback once the SDK and its adapters finish, **or after its own 30-second bound**, whichever comes first — on Android (`MobileAds.initialize`) and on iOS (`startWithCompletionHandler`) alike. AdMob CMP waits up to **40 seconds** on both platforms, deliberately longer than that bound, so a slow but ultimately successful mediation setup is never reported as an initialization failure. In practice a slow adapter delays `Ready` by at most about 30 seconds.
 
 ## Consuming the library on iOS
 

--- a/docs-site/src/content/docs/reference/compatibility.mdx
+++ b/docs-site/src/content/docs/reference/compatibility.mdx
@@ -73,9 +73,11 @@ The bound iOS headers require that the resolved SPM major version matches the ma
 
 ## SDK Initialization and `AdManagerStatus.Ready`
 
-The SDK publishes `AdManagerStatus.Ready` after the platform's initialization callback reports. On both Android and iOS that means mediation adapters have finished initializing, so every configured network can participate in the first ad request.
+The SDK publishes `AdManagerStatus.Ready` after completion of the wrapper's initialization path, allowing ad requests subject to the existing admission gates.
 
-Google Mobile Ads invokes that callback once the SDK and its adapters finish, **or after its own 30-second bound**, whichever comes first — on Android (`MobileAds.initialize`) and on iOS (`startWithCompletionHandler`) alike. AdMob CMP waits up to **40 seconds** on both platforms, deliberately longer than that bound, so a slow but ultimately successful mediation setup is never reported as an initialization failure. In practice a slow adapter delays `Ready` by at most about 30 seconds.
+Google Mobile Ads invokes its initialization callback once the SDK and its adapters finish, or after its own internal timeout — on Android (`MobileAds.initialize`) and on iOS (`startWithCompletionHandler`) alike. Individual mediation adapters can fail or time out independently; `Ready` does not guarantee that every configured adapter has successfully initialized or will participate in the first ad request.
+
+To prevent hanging indefinitely if a native response never arrives, the wrapper enforces its own initialization watchdog. In **2.2.0**, this was a **30-second** bound. In **unreleased versions**, this is a **40-second** margin beyond Google's documented 30-second limit. Note that this timeout applies only to the native initialization phase, not the entire application startup sequence (which also includes consent gathering and pre-initialization hooks).
 
 ## Consuming the library on iOS
 

--- a/docs-site/src/content/docs/start/quickstart.mdx
+++ b/docs-site/src/content/docs/start/quickstart.mdx
@@ -69,8 +69,12 @@ Use a `LaunchedEffect` to initialize it with test configuration, and then displa
 
 `AdAppIdVerification.policy` is process-wide, so set it once at your app's entry point — not from a composable. Recommended for new integrations: it turns app-ID mismatches into a deterministic `APP_ID_INVALID` failure instead of a warning, and it becomes the default in 3.0.0.
 
+### Android application module
+
 ```kotlin
-// Android: Application.onCreate(). iOS: your app's entry point, before the first Compose frame.
+package com.example
+
+import android.app.Application
 import dev.avinya.ads.AdAppIdVerification
 import dev.avinya.ads.AppIdVerificationPolicy
 
@@ -81,6 +85,59 @@ class MyApplication : Application() {
     }
 }
 ```
+
+If your application already has a custom `Application` class, add the policy assignment to your existing `onCreate()` instead of creating a new class.
+
+Register the application in your `AndroidManifest.xml` using `android:name="com.example.MyApplication"`:
+
+```xml
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application android:name="com.example.MyApplication">
+        <!-- Preserve your existing AdMob metadata -->
+        <meta-data
+            android:name="com.google.android.gms.ads.APPLICATION_ID"
+            android:value="ca-app-pub-3940256099942544~3347511713" />
+    </application>
+</manifest>
+```
+
+### iOS application module
+
+Use a Kotlin startup bridge called from the existing SwiftUI application entry point. This avoids requiring consumers to export SDK types directly to Swift.
+
+```kotlin
+// iosMain
+import dev.avinya.ads.AdAppIdVerification
+import dev.avinya.ads.AppIdVerificationPolicy
+
+fun configureAdsAtStartup(): Unit {
+    AdAppIdVerification.policy = AppIdVerificationPolicy.Strict
+}
+```
+
+Then invoke the bridge at application startup in your SwiftUI `@main` application, before constructing the Compose root or starting SDK initialization:
+
+```swift
+import SwiftUI
+import Shared
+
+@main
+struct iosApp: App {
+    init() {
+        AdStartupKt.configureAdsAtStartup()
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}
+```
+
+`Shared` is the example umbrella-framework name and must match your consumer's framework name.
+
+### Shared Compose example
 
 Then initialize from your composable entry point:
 

--- a/docs-site/src/content/docs/start/quickstart.mdx
+++ b/docs-site/src/content/docs/start/quickstart.mdx
@@ -67,21 +67,32 @@ Now let's render an ad! In your top-level `@Composable` entry point, you'll grab
 
 Use a `LaunchedEffect` to initialize it with test configuration, and then display a `BannerAdView`.
 
+`AdAppIdVerification.policy` is process-wide, so set it once at your app's entry point — not from a composable. Recommended for new integrations: it turns app-ID mismatches into a deterministic `APP_ID_INVALID` failure instead of a warning, and it becomes the default in 3.0.0.
+
+```kotlin
+// Android: Application.onCreate(). iOS: your app's entry point, before the first Compose frame.
+import dev.avinya.ads.AdAppIdVerification
+import dev.avinya.ads.AppIdVerificationPolicy
+
+class MyApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        AdAppIdVerification.policy = AppIdVerificationPolicy.Strict
+    }
+}
+```
+
+Then initialize from your composable entry point:
+
 ```kotlin
 import androidx.compose.runtime.CompositionLocalProvider
 import dev.avinya.ads.LocalAdManager
-import dev.avinya.ads.AdAppIdVerification
-import dev.avinya.ads.AppIdVerificationPolicy
 
 @Composable
 fun App() {
     val adManager = rememberAdManager()
 
     LaunchedEffect(adManager) {
-        // Recommended setting for new integrations. Note it must be set at app startup, before the first initialize().
-        // It turns app-ID mismatches into a deterministic APP_ID_INVALID failure instead of a warning, and it becomes the default in 3.0.0.
-        AdAppIdVerification.policy = AppIdVerificationPolicy.Strict
-
         adManager.gatherConsentAndInitialize(
             AdConfig(
                 androidAppId = TestAdIds.ANDROID_APP_ID,

--- a/docs/release/device-certification.md
+++ b/docs/release/device-certification.md
@@ -37,6 +37,8 @@ Run every row on both platforms.
 | 11 | AdMob native ad validator reports no implementation issues | | |
 | 12 | iOS only: ordering is UMP → ATT → first ad request | n/a | |
 | 13 | Double-tap the privacy options entry point during the launch-time consent refresh → one form, and the second tap declines without a spurious failure | | |
+| 14 | Slow mediation adapter (throttled network, real mediation configured) → `Ready` is reached, not a spurious initialization failure, on both platforms | | |
+| 15 | Airplane mode during the launch-time consent refresh, then restore and retry `initialize()` immediately → the retry contacts UMP rather than declining, and `ConsentStatus` never contradicts `canRequestAds` | | |
 
 ## Devices
 


### PR DESCRIPTION
## Summary

Consent-operation status ordering and watchdog fixes for the wrapper's
UMP/GMA integration, plus a docs-consistency follow-up found in an
independent max-effort code review of this branch.

### Core fix (158c8186)
- Fixed the native-initialization watchdog racing GMA's own internal
  30s completion bound on both platforms (was iOS-only; now a single
  40s `nativeInitialize` for both).
- `ConsentStateHolder.reconcileAndPublish` now gates the *status*
  write on the operation's generation while still reconciling privacy
  truth (`canRequestAds`, `privacyOptionsRequirementStatus`)
  unconditionally, so a superseded callback's stale error can no
  longer overwrite a newer operation's status.
- A timed-out `requestConsentInfoUpdate` now releases its info-update
  pin immediately instead of leaving it live for `infoUpdatePin`,
  unblocking the retry UMP's own guidance recommends.
- `resetConsentForDebug` again declines while a consent form operation
  merely holds the form slot (claimed on entry, before the mutex
  wait), restoring a guard that moved off `exclusiveOfForms`.
- Added `AdErrorCode.CONSENT_OPERATION_IN_PROGRESS` and populated
  `AdError.domain` on consent errors, since Android's
  `FormError.ErrorCode` and iOS's `UMPRequestErrorCode` occupy the
  same `1..4` numeric range with different meanings.

### Review follow-up (this commit)
A max-effort review of the branch surfaced two documentation bugs and
one test-coverage gap in the above; all three are fixed here:

- **consent.mdx**: the busy-error handling example branched on
  `consent.status.value`, but `CONSENT_OPERATION_IN_PROGRESS` is only
  ever returned to the declined caller and is never published to the
  status flow — the branch was unreachable. Fixed to branch on the
  awaited operation's return value, and gated behind an "Unreleased —
  unavailable in 2.2.0" note since the constant doesn't exist in the
  2.2.0 tag the quickstart installs.
- **changelog.mdx**: removed an inaccurate "`ConsentStatus` and
  `canRequestAds` can no longer contradict each other" claim that
  contradicted the very next bullet up — a failed refresh returning
  `Failed` while `canRequestAds == true` remains an expected, valid
  case.
- **quickstart.mdx**: fixed a missing `Application` import, added the
  `AndroidManifest` registration the snippet's class needs to actually
  run, and added the iOS startup-bridge example that was previously
  only a comment.
- **AdState.kt / compatibility.mdx**: `Ready` no longer claims every
  configured mediation adapter has finished initializing — adapters
  can fail or time out independently of the wrapper's watchdog.
- **ConsentStateHolderTest.kt**: added the missing ordering for the
  post-lock `declineWhileFormSlotHeld` guard (reset queues for the
  mutex *before* a form claims the slot), which the existing test
  didn't exercise.

## Verification

- `./gradlew :admob-cmp-core:testAndroidHostTest` for
  `ConsentStateHolderTest` + `NativeInitializationOwnershipTest`:
  34/34 passed.
- Full local `./scripts/release-readiness.sh` (no `--skip-docs`):
  **READINESS: PASS**, all 9 sections green (version lockstep, plugin
  build, static analysis, Android + ABI, Central task graph, iOS +
  klib ABI, published-consumer round trip, Xcode consumer build, and
  Dokka + Astro + docs verify).

🤖 Generated with [Claude Code](https://claude.com/claude-code)