### PR TITLE
chore(release): 2.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Coming from a hand-rolled `expect class AdManager`? See the [migration guide](ht
 
 ```kotlin
 // commonMain
-implementation("dev.avinya.ads:admob-cmp:2.2.0")
+implementation("dev.avinya.ads:admob-cmp:2.3.0")
 ```
 
 > [!IMPORTANT]
@@ -33,7 +33,7 @@ implementation("dev.avinya.ads:admob-cmp:2.2.0")
 >
 > ```kotlin
 > plugins {
->     id("dev.avinya.ads.admob-cmp") version "2.2.0"
+>     id("dev.avinya.ads.admob-cmp") version "2.3.0"
 > }
 > ```
 
@@ -159,6 +159,7 @@ NativeAdView(session = session, slotKey = "after-article-3", placement = nativeP
 
 | admob-cmp | Kotlin | Compose Multiplatform | Android `minSdk` | iOS deployment target |
 |---|---|---|---|---|
+| 2.3.0 | 2.3.20 | 1.11.1 | 26 | 15.0 |
 | 2.2.0 | 2.3.20 | 1.11.1 | 26 | 15.0 |
 | 2.1.0 | 2.3.20 | 1.11.1 | 26 | 15.0 |
 | 2.0.1 | 2.3.20 | 1.11.1 | 26 | 15.0 |
@@ -168,7 +169,7 @@ NativeAdView(session = session, slotKey = "after-article-3", placement = nativeP
 | 1.0.2 | 2.3.20 | 1.11.1 | 26 | 15.0 |
 | 1.0.0 | 2.3.20 | 1.11.1 | 26 | 15.0 |
 
-Underlying Google SDKs bound by 2.2.0:
+Underlying Google SDKs bound by 2.3.0:
 
 | SDK | Version |
 |---|---|

--- a/admob-cmp-gradle-plugin/gradle.properties
+++ b/admob-cmp-gradle-plugin/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=dev.avinya.ads
-VERSION_NAME=2.2.0
+VERSION_NAME=2.3.0
 POM_ARTIFACT_ID=admob-cmp-gradle-plugin
 POM_NAME=AdMob CMP Gradle Plugin
 POM_DESCRIPTION=AdMob CMP Gradle plugin for Kotlin Multiplatform projects. Links Google Mobile Ads and UMP into Kotlin/Native iOS test executables, resolving GAD undefined-symbol linker errors. Not affiliated with or endorsed by Google. AdMob and Google Mobile Ads are trademarks of Google LLC.

--- a/docs-site/src/content/docs/index.mdx
+++ b/docs-site/src/content/docs/index.mdx
@@ -42,7 +42,7 @@ The SDK provides a single-coordinate facade (`dev.avinya.ads:admob-cmp`) for And
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            implementation("dev.avinya.ads:admob-cmp:2.2.0")
+            implementation("dev.avinya.ads:admob-cmp:2.3.0")
         }
     }
 }

--- a/docs-site/src/content/docs/privacy/consent.mdx
+++ b/docs-site/src/content/docs/privacy/consent.mdx
@@ -90,8 +90,8 @@ suspend fun startConsentFlow(adManager: AdManager, config: AdConfig) {
 }
 ```
 
-<Aside type="note" title="Unreleased — unavailable in 2.2.0">
-The following demonstrates handling the busy error introduced after 2.2.0. This code branches on the awaited operation result, never `consent.status.value`. A `CONSENT_OPERATION_IN_PROGRESS` error is returned to the declined caller as a declined concurrent request, and explicitly is not published to the status flow. The same handling applies to `requestConsentInfoUpdate(config)`. These examples are alternatives for different versions, do not call both sequentially.
+<Aside type="note" title="New in 2.3.0 — unavailable in 2.2.0">
+The following demonstrates handling the busy error introduced in 2.3.0. This code branches on the awaited operation result, never `consent.status.value`. A `CONSENT_OPERATION_IN_PROGRESS` error is returned to the declined caller as a declined concurrent request, and explicitly is not published to the status flow. The same handling applies to `requestConsentInfoUpdate(config)`. These examples are alternatives for different versions, do not call both sequentially.
 
 ```kotlin
 import dev.avinya.ads.AdErrorCode
@@ -114,7 +114,7 @@ suspend fun startConsentFlow(adManager: AdManager, config: AdConfig) {
 }
 ```
 
-Additionally, in unreleased versions, `error.domain` is improved on consent errors to distinguish the platform the numeric `code` came from. Android's `FormError.ErrorCode` and iOS's `UMPRequestErrorCode` both use `1..4` with different meanings, so never branch on a bare numeric consent code without it.
+Additionally, in 2.3.0, `error.domain` is improved on consent errors to distinguish the platform the numeric `code` came from. Android's `FormError.ErrorCode` and iOS's `UMPRequestErrorCode` both use `1..4` with different meanings, so never branch on a bare numeric consent code without it.
 </Aside>
 
 ## Which ConsentMode should I use?

--- a/docs-site/src/content/docs/reference/changelog.mdx
+++ b/docs-site/src/content/docs/reference/changelog.mdx
@@ -12,11 +12,12 @@ import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
 All published artifacts live under `dev.avinya.ads` on Maven Central:
 `admob-cmp`, `admob-cmp-core`, `admob-cmp-compose`, and the
 `dev.avinya.ads.admob-cmp.gradle.plugin` marker. The current
-release is **2.2.0**.
+release is **2.3.0**.
 
 | Version | Status | Highlights |
 |---|---|---|
-| 2.2.0 | Current | Non-retryable `initialize()` conflicts, serialized consent operations, bounded startup timeouts, constructor-time configuration validation, configurable `AdLogger` and app ID verification policy |
+| 2.3.0 | Current | Initialization no longer strands a cancelled caller outside `Ready`, 40-second init watchdog, form-slot claimed on entry, released pin after a timed-out info update, platform-qualified consent `AdError.domain`, new `CONSENT_OPERATION_IN_PROGRESS` code |
+| 2.2.0 | Superseded | Non-retryable `initialize()` conflicts, serialized consent operations, bounded startup timeouts, constructor-time configuration validation, configurable `AdLogger` and app ID verification policy |
 | 2.1.0 | Superseded | Native-ad renderer parity across Android, iOS, and preview; themeable templates |
 | 2.0.1 | Superseded | Native-ad custom fonts, renderer parity, synchronous leases, and grid sessions |
 | 2.0.0 | Superseded | Release 2.0.0 |
@@ -29,7 +30,7 @@ release is **2.2.0**.
 Release details and release assets for all versions are published on the
 [GitHub releases page](https://github.com/Meet-Miyani/admob-compose-multiplatform/releases).
 
-## Unreleased
+## 2.3.0
 
 ### Fixes
 

--- a/docs-site/src/content/docs/reference/compatibility.mdx
+++ b/docs-site/src/content/docs/reference/compatibility.mdx
@@ -14,6 +14,7 @@ Every row in the matrix reflects the exact toolchain and platform SDK bindings p
 
 | `admob-cmp` | Kotlin | Compose Multiplatform | Android `minSdk` | iOS deployment target |
 |---|---|---|---|---|
+| 2.3.0 | 2.3.20 | 1.11.1 | 26 | 15.0 |
 | 2.2.0 | 2.3.20 | 1.11.1 | 26 | 15.0 |
 | 2.1.0 | 2.3.20 | 1.11.1 | 26 | 15.0 |
 | 2.0.1 | 2.3.20 | 1.11.1 | 26 | 15.0 |
@@ -77,7 +78,7 @@ The SDK publishes `AdManagerStatus.Ready` after completion of the wrapper's init
 
 Google Mobile Ads invokes its initialization callback once the SDK and its adapters finish, or after its own internal timeout — on Android (`MobileAds.initialize`) and on iOS (`startWithCompletionHandler`) alike. Individual mediation adapters can fail or time out independently; `Ready` does not guarantee that every configured adapter has successfully initialized or will participate in the first ad request.
 
-To prevent hanging indefinitely if a native response never arrives, the wrapper enforces its own initialization watchdog. In **2.2.0**, this was a **30-second** bound. In **unreleased versions**, this is a **40-second** margin beyond Google's documented 30-second limit. Note that this timeout applies only to the native initialization phase, not the entire application startup sequence (which also includes consent gathering and pre-initialization hooks).
+To prevent hanging indefinitely if a native response never arrives, the wrapper enforces its own initialization watchdog. In **2.2.0** and earlier, this was a **30-second** bound. In **2.3.0**, this is a **40-second** margin beyond Google's documented 30-second limit. Note that this timeout applies only to the native initialization phase, not the entire application startup sequence (which also includes consent gathering and pre-initialization hooks).
 
 ## Consuming the library on iOS
 

--- a/docs-site/src/content/docs/reference/troubleshooting.mdx
+++ b/docs-site/src/content/docs/reference/troubleshooting.mdx
@@ -25,7 +25,7 @@ Applying the `dev.avinya.ads.admob-cmp` Gradle plugin resolves this issue automa
 ```kotlin
 // shared/build.gradle.kts
 plugins {
-    id("dev.avinya.ads.admob-cmp") version "2.2.0"
+    id("dev.avinya.ads.admob-cmp") version "2.3.0"
 }
 ```
 

--- a/docs-site/src/content/docs/start/android-setup.mdx
+++ b/docs-site/src/content/docs/start/android-setup.mdx
@@ -56,7 +56,7 @@ Removing `AD_ID` disables access to the device advertising identifier on Android
 
 ## Android build requirements
 
-AdMob CMP 2.2.0 is built and tested against the following toolchain specifications:
+AdMob CMP 2.3.0 is built and tested against the following toolchain specifications:
 
 | Setting | Tested Version / Specification |
 |---|---|

--- a/docs-site/src/content/docs/start/installation.mdx
+++ b/docs-site/src/content/docs/start/installation.mdx
@@ -38,7 +38,7 @@ Most Compose Multiplatform applications should depend on the umbrella coordinate
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            implementation("dev.avinya.ads:admob-cmp:2.2.0")
+            implementation("dev.avinya.ads:admob-cmp:2.3.0")
         }
     }
 }
@@ -50,8 +50,8 @@ The umbrella artifact includes both `admob-cmp-core` and `admob-cmp-compose`.
 
 For projects that do not use Compose Multiplatform or require decoupled architectures, the underlying modules can be imported individually:
 
-- `dev.avinya.ads:admob-cmp-core:2.2.0`: Contains core controllers (`AdManager`, `BannerAdController`, `InterstitialAdController`), lifecycle state machines, ad caching, retry policies, and platform adapters. Has no Compose Multiplatform dependencies.
-- `dev.avinya.ads:admob-cmp-compose:2.2.0`: Contains Compose Multiplatform composables (`rememberAdManager()`, `BannerAdView`, `NativeAdView`). Depends on `admob-cmp-core`.
+- `dev.avinya.ads:admob-cmp-core:2.3.0`: Contains core controllers (`AdManager`, `BannerAdController`, `InterstitialAdController`), lifecycle state machines, ad caching, retry policies, and platform adapters. Has no Compose Multiplatform dependencies.
+- `dev.avinya.ads:admob-cmp-compose:2.3.0`: Contains Compose Multiplatform composables (`rememberAdManager()`, `BannerAdView`, `NativeAdView`). Depends on `admob-cmp-core`.
 
 ## Version catalog configuration
 
@@ -60,7 +60,7 @@ For multi-module Gradle projects, manage library dependencies and plugin definit
 ```toml
 # gradle/libs.versions.toml
 [versions]
-admob-cmp = "2.2.0"
+admob-cmp = "2.3.0"
 
 [libraries]
 admob-cmp = { module = "dev.avinya.ads:admob-cmp", version.ref = "admob-cmp" }
@@ -95,7 +95,7 @@ To resolve Kotlin/Native test linking, apply the `dev.avinya.ads.admob-cmp` Grad
 ```kotlin
 // shared/build.gradle.kts
 plugins {
-    id("dev.avinya.ads.admob-cmp") version "2.2.0"
+    id("dev.avinya.ads.admob-cmp") version "2.3.0"
 }
 ```
 

--- a/docs-site/src/content/docs/start/ios-setup.mdx
+++ b/docs-site/src/content/docs/start/ios-setup.mdx
@@ -20,10 +20,10 @@ AdMob CMP distributes Objective-C cinterop bindings in its Kotlin Multiplatform 
 1. In Xcode, open your iOS project and select **File → Add Package Dependencies...**
 2. Enter the Google Mobile Ads SPM repository URL:
    `https://github.com/googleads/swift-package-manager-google-mobile-ads.git`
-   Select the **GoogleMobileAds** product and specify version rule **Up to Next Major** with **13.x** (AdMob CMP 2.2.0 binds GMA iOS 13.7.0).
+   Select the **GoogleMobileAds** product and specify version rule **Up to Next Major** with **13.x** (AdMob CMP 2.3.0 binds GMA iOS 13.7.0).
 3. Enter the User Messaging Platform SPM repository URL:
    `https://github.com/googleads/swift-package-manager-google-user-messaging-platform.git`
-   Select the **GoogleUserMessagingPlatform** product and specify version rule **Up to Next Major** with **3.x** (AdMob CMP 2.2.0 binds UMP iOS 3.1.0).
+   Select the **GoogleUserMessagingPlatform** product and specify version rule **Up to Next Major** with **3.x** (AdMob CMP 2.3.0 binds UMP iOS 3.1.0).
 
 </Steps>
 
@@ -109,7 +109,7 @@ Executing Kotlin/Native test tasks (such as `./gradlew :shared:iosSimulatorArm64
 ```kotlin
 // shared/build.gradle.kts
 plugins {
-    id("dev.avinya.ads.admob-cmp") version "2.2.0"
+    id("dev.avinya.ads.admob-cmp") version "2.3.0"
 }
 ```
 

--- a/docs-site/src/content/docs/start/quickstart.mdx
+++ b/docs-site/src/content/docs/start/quickstart.mdx
@@ -19,7 +19,7 @@ First, add the core AdMob CMP library to your shared Kotlin module.
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            implementation("dev.avinya.ads:admob-cmp:2.2.0")
+            implementation("dev.avinya.ads:admob-cmp:2.3.0")
         }
     }
 }
@@ -32,7 +32,7 @@ If your project runs Kotlin/Native unit tests (`:shared:iosSimulatorArm64Test`),
 ```kotlin
 // shared/build.gradle.kts
 plugins {
-    id("dev.avinya.ads.admob-cmp") version "2.2.0"
+    id("dev.avinya.ads.admob-cmp") version "2.3.0"
 }
 ```
 

--- a/docs-site/src/content/docs/start/what-is-admob-cmp.mdx
+++ b/docs-site/src/content/docs/start/what-is-admob-cmp.mdx
@@ -12,7 +12,7 @@ import PlatformMatrix from '../../../components/diagrams/PlatformMatrix.astro';
 
 AdMob CMP is an open-source Kotlin Multiplatform (KMP) SDK for Google AdMob in Compose Multiplatform applications. It provides one shared Kotlin API for Google Mobile Ads (GMA), User Messaging Platform (UMP) consent state, ad loading, presentation, and revenue events on Android and iOS.
 
-Instead of maintaining separate Android and iOS ad abstractions, add `dev.avinya.ads:admob-cmp:2.2.0` and call the same controllers from `commonMain`. Native application IDs, store disclosures, consent configuration, and iOS package setup remain the application's responsibility.
+Instead of maintaining separate Android and iOS ad abstractions, add `dev.avinya.ads:admob-cmp:2.3.0` and call the same controllers from `commonMain`. Native application IDs, store disclosures, consent configuration, and iOS package setup remain the application's responsibility.
 
 ## Why use AdMob CMP?
 

--- a/docs-site/src/data/landing.ts
+++ b/docs-site/src/data/landing.ts
@@ -120,8 +120,8 @@ export interface LandingMeta {
 }
 
 export const landingMeta: LandingMeta = {
-  mavenCoordinate: 'dev.avinya.ads:admob-cmp:2.2.0',
-  gradlePlugin: 'dev.avinya.ads.admob-cmp:2.2.0',
+  mavenCoordinate: 'dev.avinya.ads:admob-cmp:2.3.0',
+  gradlePlugin: 'dev.avinya.ads.admob-cmp:2.3.0',
   kotlinVersion: '2.3.20',
   composeMultiplatformVersion: '1.11.1',
   androidMinSdk: 26,

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ umpIosHeadersSha256=02b6b1925be8a6cfc294478c1a6bb1dd4de70cd9e4f31cbbfb789ab4de7b
 
 # Publishing metadata shared by all published artifacts.
 GROUP=dev.avinya.ads
-VERSION_NAME=2.2.0
+VERSION_NAME=2.3.0
 POM_NAME=AdMob CMP
 POM_DESCRIPTION=Open-source Kotlin Multiplatform and Compose Multiplatform SDK for Google AdMob on Android and iOS, published as dev.avinya.ads:admob-cmp. Not affiliated with or endorsed by Google. AdMob and Google Mobile Ads are trademarks of Google LLC.
 POM_URL=https://github.com/Meet-Miyani/admob-compose-multiplatform


### PR DESCRIPTION
Cuts **2.3.0**, releasing the consent and initialization fixes that merged in #42. Those fixes landed on `master` without a version bump, so they are currently sitting unreleased; this is the bump that ships them.

## Why 2.3.0 and not 2.2.1

The merged work adds a public constant — `AdErrorCode.CONSENT_OPERATION_IN_PROGRESS`, already reflected in `admob-cmp-core/api/admob-cmp-core.klib.api`. Additive public API is a semver **minor**, not a patch.

## Contents

Two commits, version bump last, per the release protocol in `AGENTS.md`:

- `docs(release): promote the unreleased notes to 2.3.0` — turns the `## Unreleased` changelog section into `## 2.3.0`, adds the release row to the changelog and compatibility matrices (docs + README), and moves the dependency/plugin coordinates to 2.3.0. The two "unreleased versions" prose references — the 40-second initialization watchdog and the platform-qualified consent `AdError.domain` — now name 2.3.0.
- `chore(release): bump VERSION_NAME to 2.3.0` — `gradle.properties` and `admob-cmp-gradle-plugin/gradle.properties` in lockstep.

`landingMeta.mavenCoordinate` / `landingMeta.gradlePlugin` in `docs-site/src/data/landing.ts` move too. The landing page renders the coordinate from that record and `test/landing.test.ts` asserts it matches the gradle `VERSION_NAME`; leaving it behind would have shipped a landing page advertising 2.2.0 while publishing 2.3.0.

The contrastive `2.2.0` references in `privacy/consent.mdx` are deliberately left alone — that section documents pre-2.3.0 error handling against the 2.3.0 example, so rewriting them would erase the comparison. Same for the historical matrix rows and the "2.2.0 and earlier" watchdog note.

## Verification

`./scripts/release-readiness.sh` — **`READINESS: PASS`**, full run, all nine sections, none skipped:

| Section | Result |
|---|---|
| 1. Version lockstep | PASS |
| 2. Gradle plugin build + supply-chain policy | PASS |
| 3. Static analysis and coverage | PASS |
| 4. Android + ABI + publication metadata | PASS |
| 5. Central task graph | PASS |
| 6. iOS + klib ABI | PASS (`PUBLIC API COMPATIBILITY: PASS`) |
| 7. Published-consumer round trip | PASS |
| 8. Xcode consumer | PASS |
| 9. Docs (Dokka + Astro + visual checks + verify) | PASS (252 tests) |

An earlier run failed section 9 on the `landing.ts` coordinate described above; that was fixed and the full gate re-run clean from scratch.

## On merge

The `VERSION_NAME` bump is the release trigger. `release.yml` will generate and attest provenance, then wait for approval on the protected `maven-central` environment before anything is uploaded or tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)